### PR TITLE
perf(bench): implement Criterion.rs transpiler benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +252,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +272,33 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -318,6 +357,73 @@ dependencies = [
  "once_cell",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "difflib"
@@ -440,6 +546,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +577,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hstr"
@@ -630,6 +753,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +774,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -830,6 +973,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "owo-colors"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +1072,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,6 +1186,26 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1539,6 +1736,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,9 +1921,11 @@ dependencies = [
 name = "tyrus_orchestrator"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "miette",
  "swc_common",
  "swc_ecma_ast",
+ "tempfile",
  "tokio",
  "tyrus_analyzer",
  "tyrus_codegen",
@@ -1905,6 +2114,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,30 +1,43 @@
-# Scientific Benchmarks
+# Transpiler Benchmarks
 
-This directory contains rigorous performance benchmarks to validate the efficiency of TypeRust-generated code compared to Node.js execution.
+This directory documents the performance benchmarking infrastructure for the Tyrus transpiler.
 
 ## Status
 
-Benchmarking infrastructure is planned (Phase 2 of the Standardization Plan). The compiler itself is now production-stable with a full test suite (unit/snapshot/compilation tiers). Benchmarks of the _generated_ Rust code will follow.
+Implemented. Criterion.rs benchmarks measure transpiler throughput (TypeScript to Rust conversion speed). Located in `crates/tyrus_orchestrator/benches/transpiler.rs`.
 
 ## Methodology
 
-We use [Criterion.rs](https://github.com/bheisler/criterion.rs) for statistically significant benchmarking.
+We use [Criterion.rs](https://github.com/bheisler/criterion.rs) for statistically significant benchmarking with automatic warm-up, outlier detection, and HTML report generation.
 
 ### Metrics
 
-1. **Execution Time:** Wall-clock time for specific algorithms.
-2. **Throughput:** Operations per second.
-3. **Memory Usage:** Peak RSS (Resident Set Size).
+1. **Execution Time:** Wall-clock time per transpilation invocation.
+2. **Throughput:** Iterations per second for each scenario.
+3. **Statistical Confidence:** Criterion computes confidence intervals and detects regressions automatically.
 
 ## Running Benchmarks
 
 ```bash
-cargo bench
+# Run all benchmarks
+cargo bench -p tyrus_orchestrator
+
+# Run a specific benchmark by name
+cargo bench -p tyrus_orchestrator -- transpile_simple_functions
+
+# Compile without running (CI validation)
+cargo bench -p tyrus_orchestrator --no-run
 ```
 
-## Scenarios (Planned)
+HTML reports are generated in `target/criterion/` after each run.
 
-- **Fibonacci (Recursive):** Stress tests function call overhead.
-- **JSON Serialization:** Stress tests struct/DTO mapping (interfaces → `#[derive(Serialize, Deserialize)]`).
-- **Http Requests:** Stress tests `reqwest` vs `axios` (requires local echo server).
-- **Array Operations:** Stress tests iterator chains (`.map`/`.filter`/`.find`) vs JS equivalents.
+## Scenarios
+
+| Benchmark | Description | Source Pattern |
+|-----------|-------------|----------------|
+| `transpile_simple_functions` | Three typed functions (arithmetic, boolean, template literal) | Tier 1 functions |
+| `transpile_interfaces` | Three interfaces including optional fields and nested types | Tier 2 interfaces |
+| `transpile_class_with_methods` | Class with private field, constructor, methods, and self-mutation | Tier 2 classes |
+| `transpile_combined_project` | Mixed file with functions, control flow, interface, and class | Multi-construct file |
+
+Each scenario writes TypeScript source to a temporary file and benchmarks the full `build()` pipeline: parsing, code generation, and formatting.

--- a/crates/tyrus_orchestrator/Cargo.toml
+++ b/crates/tyrus_orchestrator/Cargo.toml
@@ -17,4 +17,12 @@ swc_ecma_ast = "18.0.0"
 swc_common = "17.0.1"
 miette = { version = "7.6.0", features = ["fancy"] } # Matched miette version too
 walkdir = "2.3"
-tokio = { version = "1.0", features = ["full"] } 
+tokio = { version = "1.0", features = ["full"] }
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+tempfile = "3.10"
+
+[[bench]]
+name = "transpiler"
+harness = false

--- a/crates/tyrus_orchestrator/benches/transpiler.rs
+++ b/crates/tyrus_orchestrator/benches/transpiler.rs
@@ -1,0 +1,193 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::io::Write;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use tempfile::NamedTempFile;
+use tyrus_common::fs::FilePath;
+
+/// Write TypeScript source to a temporary file and return the file handle
+/// and its corresponding `FilePath`. The temp file stays alive as long as
+/// the returned `NamedTempFile` is in scope.
+fn ts_temp_file(source: &str) -> (NamedTempFile, FilePath) {
+    let mut tmp = tempfile::Builder::new()
+        .suffix(".ts")
+        .tempfile()
+        .expect("failed to create temp file");
+    tmp.write_all(source.as_bytes())
+        .expect("failed to write ts source");
+    tmp.flush().expect("failed to flush temp file");
+    let path: FilePath = tmp.path().to_path_buf().into();
+    (tmp, path)
+}
+
+// ---------------------------------------------------------------------------
+// TypeScript source snippets
+// ---------------------------------------------------------------------------
+
+const SIMPLE_FUNCTION_TS: &str = r#"
+function square(x: number): number {
+    return x * x;
+}
+
+function isPositive(n: number): boolean {
+    return n > 0;
+}
+
+function formatUser(name: string, age: number): string {
+    return `${name} is ${age} years old`;
+}
+"#;
+
+const INTERFACE_TS: &str = r#"
+interface User {
+    name: string;
+    age: number;
+    email: string;
+    active: boolean;
+}
+
+interface Product {
+    id: number;
+    title: string;
+    price: number;
+    description?: string;
+}
+
+interface ApiResponse {
+    data: User[];
+    total: number;
+    success: boolean;
+}
+"#;
+
+const CLASS_TS: &str = r#"
+class Calculator {
+    private result: number;
+
+    constructor() {
+        this.result = 0;
+    }
+
+    add(value: number): number {
+        this.result = this.result + value;
+        return this.result;
+    }
+
+    getResult(): number {
+        return this.result;
+    }
+
+    reset(): void {
+        this.result = 0;
+    }
+}
+"#;
+
+const COMBINED_TS: &str = r#"
+function max(a: number, b: number): number {
+    if (a > b) {
+        return a;
+    } else {
+        return b;
+    }
+}
+
+function countdown(n: number): number {
+    let result: number = 0;
+    let i: number = n;
+    while (i > 0) {
+        result = result + i;
+        i = i - 1;
+    }
+    return result;
+}
+
+interface Config {
+    host: string;
+    port: number;
+    debug: boolean;
+}
+
+class Counter {
+    private count: number;
+
+    constructor() {
+        this.count = 0;
+    }
+
+    increment(): number {
+        this.count = this.count + 1;
+        return this.count;
+    }
+
+    getCount(): number {
+        return this.count;
+    }
+}
+"#;
+
+// ---------------------------------------------------------------------------
+// Benchmark functions
+// ---------------------------------------------------------------------------
+
+fn bench_simple_function(c: &mut Criterion) {
+    let (_tmp, path) = ts_temp_file(SIMPLE_FUNCTION_TS);
+
+    c.bench_function("transpile_simple_functions", |b| {
+        b.iter(|| {
+            let result = tyrus_orchestrator::build(black_box(&path));
+            assert!(result.is_ok());
+            result
+        });
+    });
+}
+
+fn bench_interface(c: &mut Criterion) {
+    let (_tmp, path) = ts_temp_file(INTERFACE_TS);
+
+    c.bench_function("transpile_interfaces", |b| {
+        b.iter(|| {
+            let result = tyrus_orchestrator::build(black_box(&path));
+            assert!(result.is_ok());
+            result
+        });
+    });
+}
+
+fn bench_class(c: &mut Criterion) {
+    let (_tmp, path) = ts_temp_file(CLASS_TS);
+
+    c.bench_function("transpile_class_with_methods", |b| {
+        b.iter(|| {
+            let result = tyrus_orchestrator::build(black_box(&path));
+            assert!(result.is_ok());
+            result
+        });
+    });
+}
+
+fn bench_combined(c: &mut Criterion) {
+    let (_tmp, path) = ts_temp_file(COMBINED_TS);
+
+    c.bench_function("transpile_combined_project", |b| {
+        b.iter(|| {
+            let result = tyrus_orchestrator::build(black_box(&path));
+            assert!(result.is_ok());
+            result
+        });
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Criterion harness
+// ---------------------------------------------------------------------------
+
+criterion_group!(
+    transpiler_benches,
+    bench_simple_function,
+    bench_interface,
+    bench_class,
+    bench_combined,
+);
+criterion_main!(transpiler_benches);


### PR DESCRIPTION
## Summary

Closes #12

- Implement Criterion.rs benchmarking infrastructure for transpiler performance
- 4 benchmark scenarios: simple function, interface, class, full project
- Update benches/README.md with implementation status

## Test plan

- [x] `cargo bench --no-run` compiles successfully
- [ ] `cargo bench` produces benchmark results
- [x] `cargo clippy --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)