### PR TITLE
fix(ci): require Node.js 22+ for equivalence tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
+      - name: Setup Node.js 22 (for semantic equivalence tests)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Install nextest
         uses: taiki-e/install-action@nextest
 

--- a/crates/tyrus_test_utils/src/lib.rs
+++ b/crates/tyrus_test_utils/src/lib.rs
@@ -177,27 +177,18 @@ pub fn run_node(ts_code: &str) -> String {
             ts_file.to_str().unwrap_or_default(),
         ])
         .output()
-        .expect("Node.js not found. Install Node.js to run equivalence tests.");
+        .expect("Node.js not found. Install Node.js 22+ to run equivalence tests.");
 
     if output.status.success() {
         return String::from_utf8_lossy(&output.stdout).to_string();
     }
 
-    // Fallback: try as plain JS
-    let js_file = temp_dir.path().join("test.js");
-    fs::write(&js_file, ts_code).expect("Failed to write JS file");
-    let fallback = Command::new("node")
-        .arg(js_file.to_str().unwrap_or_default())
-        .output()
-        .expect("Failed to run Node.js");
-
-    if !fallback.status.success() {
-        let stderr = String::from_utf8_lossy(&fallback.stderr);
-        panic!(
-            "\n=== NODE EXECUTION FAILED ===\nCODE:\n{}\n\nSTDERR:\n{}",
-            ts_code, stderr
-        );
-    }
-
-    String::from_utf8_lossy(&fallback.stdout).to_string()
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    panic!(
+        "\n=== NODE EXECUTION FAILED ===\n\
+         Node.js 22+ is required for --experimental-strip-types.\n\
+         Check your Node version with: node --version\n\n\
+         CODE:\n{}\n\nSTDERR:\n{}",
+        ts_code, stderr
+    )
 }

--- a/docs/superpowers/plans/2026-03-13-milestone-13-bugfix-and-control-flow.md
+++ b/docs/superpowers/plans/2026-03-13-milestone-13-bugfix-and-control-flow.md
@@ -1,0 +1,530 @@
+# Milestone 13: Bug Fixes + Control Flow Expansion
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 4 known transpiler bugs and unlock 6 blocked control flow constructs, expanding the Oxidizable Standard coverage from ~70% to ~90%.
+
+**Architecture:** Changes target 3 layers: (1) `tyrus_analyzer` to unblock rejected statements, (2) `tyrus_codegen` to fix bugs and add missing transpilation, (3) `tests/` for comprehensive validation. All changes follow TDD — write failing test first, then fix.
+
+**Tech Stack:** Rust, SWC AST (`swc_ecma_ast`, `swc_ecma_visit`), `quote!` macros, `insta` snapshots, `cargo nextest`.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `crates/tyrus_analyzer/src/lints.rs` | Modify | Remove rejections for for-of, for-in, do-while, for, switch, try-catch |
+| `crates/tyrus_codegen/src/convert/stmt.rs` | Modify | Add switch, try-catch, do-while, traditional for transpilation |
+| `crates/tyrus_codegen/src/convert/expr/mod.rs` | Modify | Add unary expression dispatch |
+| `crates/tyrus_codegen/src/convert/expr/misc.rs` | Modify | Fix optional chaining `Some()` wrapper, add unary expr conversion |
+| `crates/tyrus_codegen/src/convert/expr/call.rs` | Modify | Fix `.find()` closure type mismatch |
+| `crates/tyrus_codegen/src/convert/expr/arrow.rs` | Modify | Fix `const` vs `let` immutability (if variable decl logic is here) |
+| `crates/tyrus_codegen/src/convert/interface.rs` | Modify | Fix `const` → `let` (immutable) in variable declarations |
+| `tests/fixtures/tier5/` | Create | New fixtures for control flow + bug fixes |
+| `tests/src/unit/tier5.rs` | Create | Unit tests for new features |
+| `tests/src/snapshot/tier5.rs` | Create | Snapshot tests for new features |
+| `tests/src/compilation/tier5.rs` | Create | Compilation tests for new features |
+
+---
+
+## Chunk 1: Bug Fixes (4 bugs)
+
+### Task 1: Fix `const` vs `let` immutability
+
+**Context:** Currently both `const x = 1` and `let x = 1` produce `let mut x = 1f64`. The fix: `const` → `let` (immutable), `let` → `let mut` (mutable).
+
+**Files:**
+- Test: `tests/src/unit/tier5.rs`
+- Modify: `crates/tyrus_codegen/src/convert/stmt.rs` (variable declaration logic)
+- Modify: `crates/tyrus_codegen/src/convert/interface.rs` (if VarDecl is handled in Visit impl)
+
+**Investigation needed:** Before implementing, read `stmt.rs` and `interface.rs` to find where `VarDecl` is processed and where `let mut` is emitted. The fix is changing the emission logic based on `decl.kind` (`VarDeclKind::Const` vs `VarDeclKind::Let`).
+
+- [ ] **Step 1: Write failing test**
+
+In `tests/src/unit/tier5.rs`:
+```rust
+#[test]
+fn test_const_produces_immutable_let() {
+    let rust = transpile("function f(): void { const x: number = 42; }");
+    assert!(rust.contains("let x"), "const should produce immutable 'let'");
+    assert!(!rust.contains("let mut x"), "const should NOT produce 'let mut'");
+}
+
+#[test]
+fn test_let_produces_mutable_let_mut() {
+    let rust = transpile("function f(): void { let x: number = 42; }");
+    assert!(rust.contains("let mut x"), "let should produce 'let mut'");
+}
+```
+
+- [ ] **Step 2: Run tests — expect FAIL** (const currently produces `let mut`)
+
+Run: `cargo test -p integration_tests tier5::test_const_produces_immutable_let -- --exact`
+
+- [ ] **Step 3: Find and fix the VarDecl emission logic**
+
+Read `stmt.rs` to find where `VarDeclKind` is checked. Change:
+- `VarDeclKind::Const` → emit `let` (no `mut`)
+- `VarDeclKind::Let` → emit `let mut`
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+- [ ] **Step 5: Update snapshot tests** (existing snapshots will change since `const` now produces `let`)
+
+Run: `cargo insta review`
+
+---
+
+### Task 2: Fix unary expression support (`!`, `-`, `+`)
+
+**Context:** Unary expressions (`-x`, `!flag`, `+str`) hit `compile_error!("Tyrus: unsupported expression")` in the expression dispatcher.
+
+**Files:**
+- Test: `tests/src/unit/tier5.rs`
+- Modify: `crates/tyrus_codegen/src/convert/expr/mod.rs` (add `Expr::Unary` dispatch)
+- Modify: `crates/tyrus_codegen/src/convert/expr/misc.rs` (add `convert_unary_expr` function)
+
+- [ ] **Step 1: Write failing test**
+
+```rust
+#[test]
+fn test_unary_negation() {
+    let rust = transpile("function f(x: number): number { return -x; }");
+    assert!(rust.contains("-x") || rust.contains("- x"), "should preserve unary negation");
+    assert!(!rust.contains("compile_error"), "should NOT produce compile_error");
+}
+
+#[test]
+fn test_unary_not() {
+    let rust = transpile("function f(x: boolean): boolean { return !x; }");
+    assert!(rust.contains("!x") || rust.contains("! x"), "should preserve logical NOT");
+}
+
+#[test]
+fn test_unary_plus() {
+    let rust = transpile("function f(x: number): number { return +x; }");
+    // Unary + in JS is identity for numbers, can be dropped
+    assert!(!rust.contains("compile_error"), "should NOT produce compile_error");
+}
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+- [ ] **Step 3: Add `Expr::Unary` to expression dispatcher**
+
+In `expr/mod.rs`, add a match arm:
+```rust
+Expr::Unary(unary) => convert_unary_expr(unary, generator),
+```
+
+- [ ] **Step 4: Implement `convert_unary_expr` in `expr/misc.rs`**
+
+```rust
+pub(crate) fn convert_unary_expr(
+    expr: &UnaryExpr,
+    generator: &RustGenerator,
+) -> proc_macro2::TokenStream {
+    let arg = convert_expr(&expr.arg, generator);
+    match expr.op {
+        UnaryOp::Minus => quote::quote! { -#arg },
+        UnaryOp::Plus => arg, // identity for numbers
+        UnaryOp::Bang => quote::quote! { !#arg },
+        UnaryOp::TypeOf => quote::quote! { compile_error!("Tyrus: typeof not supported") },
+        _ => quote::quote! { compile_error!("Tyrus: unsupported unary operator") },
+    }
+}
+```
+
+- [ ] **Step 5: Run tests — expect PASS**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "fix(codegen): add unary expression support (!, -, +)"
+```
+
+---
+
+### Task 3: Fix optional chaining `Some()` wrapper
+
+**Context:** Optional chaining `obj?.name` generates `and_then(|__v| __v.name.clone())` but should generate `and_then(|__v| Some(__v.name.clone()))` for non-Option fields.
+
+**Files:**
+- Test: `tests/src/compilation/tier5.rs` (the ignored test should now pass)
+- Modify: `crates/tyrus_codegen/src/convert/expr/misc.rs` (find `convert_opt_chain`)
+
+- [ ] **Step 1: Read `misc.rs` to find the optional chaining logic**
+
+- [ ] **Step 2: Un-ignore the existing test**
+
+In `tests/src/compilation/tier3.rs`, remove `#[ignore]` from `test_tier3_optional_chaining_compiles`.
+
+- [ ] **Step 3: Fix the closure to wrap return in `Some()`**
+
+In the `and_then` closure generation, change the body from:
+```rust
+quote! { |__v| #body }
+```
+to:
+```rust
+quote! { |__v| Some(#body) }
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 4: Fix `.find()` closure type mismatch
+
+**Context:** `.find()` generates `nums.iter().find(|n| n > 10f64)` but `n` is `&&f64` (double reference), causing type mismatch.
+
+**Files:**
+- Test: `tests/src/compilation/tier3.rs` (un-ignore the test)
+- Modify: `crates/tyrus_codegen/src/convert/expr/call.rs` (find `.find()` generation)
+
+- [ ] **Step 1: Read `call.rs` to find the `.find()` logic**
+
+- [ ] **Step 2: Fix the closure parameter dereferencing**
+
+The fix is to dereference in the closure: `|n| *n > 10f64` or `|&&n| n > 10f64`
+
+Preferred approach — add dereference in comparison:
+```rust
+// For .find(), generate |item| *item > value
+quote! { |#param| *#param #op #value }
+```
+
+Or use `.iter().find(|&#param| ...)` pattern.
+
+- [ ] **Step 3: Un-ignore `test_tier3_advanced_methods_compiles`**
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+---
+
+## Chunk 2: Unlock Blocked Control Flow
+
+### Task 5: Remove analyzer rejections for supported control flow
+
+**Context:** `lints.rs` explicitly rejects 6 control flow constructs that already have (or will have) codegen support. We need to selectively unblock them.
+
+**Files:**
+- Modify: `crates/tyrus_analyzer/src/lints.rs`
+- Test: `tests/src/unit/tier5.rs`
+
+- [ ] **Step 1: Read `lints.rs` to find all rejection points**
+
+Look for `visit_for_stmt`, `visit_for_of_stmt`, `visit_for_in_stmt`, `visit_do_while_stmt`, `visit_switch_stmt`, `visit_try_stmt`.
+
+- [ ] **Step 2: Remove/comment the rejection visitors for:**
+- `for_of_stmt` (codegen already exists in `stmt.rs`)
+- `for_in_stmt` (codegen already exists in `stmt.rs`)
+- `do_while_stmt` (will add codegen in Task 7)
+- `for_stmt` (will add codegen in Task 6)
+- Keep rejection for `switch` and `try-catch` until codegen is ready (Tasks 8-9)
+
+- [ ] **Step 3: Write test for for-of loop**
+
+```rust
+#[test]
+fn test_for_of_loop() {
+    let rust = transpile("function f(): void { const arr: number[] = [1,2,3]; for (const x of arr) { console.log(x); } }");
+    assert!(rust.contains("for"), "should contain for loop");
+    assert!(!rust.contains("compile_error"), "should NOT reject for-of");
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS** (codegen already exists)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(analyzer): unblock for-of, for-in, do-while, for loops"
+```
+
+---
+
+### Task 6: Add traditional `for` loop transpilation
+
+**Context:** `for (let i = 0; i < n; i++)` → Rust `for` or `while` loop equivalent.
+
+**Files:**
+- Modify: `crates/tyrus_codegen/src/convert/stmt.rs`
+- Test: `tests/src/unit/tier5.rs`
+
+- [ ] **Step 1: Write failing test**
+
+```rust
+#[test]
+fn test_traditional_for_loop() {
+    let rust = transpile("function f(n: number): number { let sum: number = 0; for (let i: number = 0; i < n; i++) { sum = sum + i; } return sum; }");
+    assert!(!rust.contains("compile_error"), "should transpile for loop");
+    // Traditional for becomes while in Rust
+    assert!(rust.contains("while") || rust.contains("for"), "should produce loop");
+}
+```
+
+- [ ] **Step 2: Implement `ForStmt` handling in `stmt.rs`**
+
+Strategy: Convert `for (init; test; update) { body }` to:
+```rust
+{
+    init;
+    while test {
+        body;
+        update;
+    }
+}
+```
+
+- [ ] **Step 3: Run tests — expect PASS**
+
+- [ ] **Step 4: Commit**
+
+---
+
+### Task 7: Add `do-while` loop transpilation
+
+**Files:**
+- Modify: `crates/tyrus_codegen/src/convert/stmt.rs`
+- Test: `tests/src/unit/tier5.rs`
+
+- [ ] **Step 1: Write failing test**
+
+```rust
+#[test]
+fn test_do_while_loop() {
+    let rust = transpile("function f(): number { let x: number = 0; do { x = x + 1; } while (x < 10); return x; }");
+    assert!(rust.contains("loop"), "do-while should use Rust 'loop'");
+    assert!(rust.contains("break"), "do-while should break on condition");
+}
+```
+
+- [ ] **Step 2: Implement `DoWhileStmt` in `stmt.rs`**
+
+Strategy: Convert `do { body } while (test)` to:
+```rust
+loop {
+    body;
+    if !test { break; }
+}
+```
+
+- [ ] **Step 3: Run tests — expect PASS**
+
+- [ ] **Step 4: Commit**
+
+---
+
+### Task 8: Add `switch` statement transpilation
+
+**Files:**
+- Modify: `crates/tyrus_codegen/src/convert/stmt.rs`
+- Modify: `crates/tyrus_analyzer/src/lints.rs` (remove rejection)
+- Test: `tests/src/unit/tier5.rs`
+
+- [ ] **Step 1: Write failing test**
+
+```rust
+#[test]
+fn test_switch_statement() {
+    let rust = transpile(r#"function f(x: string): string {
+        switch (x) {
+            case "a": return "alpha";
+            case "b": return "beta";
+            default: return "unknown";
+        }
+    }"#);
+    assert!(rust.contains("match"), "switch should become match");
+    assert!(rust.contains("alpha"), "should contain case body");
+}
+```
+
+- [ ] **Step 2: Remove switch rejection from `lints.rs`**
+
+- [ ] **Step 3: Implement `SwitchStmt` in `stmt.rs`**
+
+Strategy: Convert `switch(x) { case "a": ...; default: ... }` to:
+```rust
+match x.as_str() {  // or match x { } for non-string types
+    "a" => { ... },
+    "b" => { ... },
+    _ => { ... },
+}
+```
+
+Handle fall-through by collecting consecutive cases without break into the same arm.
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 9: Add `try-catch` transpilation
+
+**Files:**
+- Modify: `crates/tyrus_codegen/src/convert/stmt.rs`
+- Modify: `crates/tyrus_analyzer/src/lints.rs` (remove rejection)
+- Test: `tests/src/unit/tier5.rs`
+
+- [ ] **Step 1: Write failing test**
+
+```rust
+#[test]
+fn test_try_catch() {
+    let rust = transpile(r#"function f(): string {
+        try {
+            return "ok";
+        } catch (e) {
+            return "error";
+        }
+    }"#);
+    assert!(rust.contains("match") || rust.contains("if let"), "try-catch should use match/if-let");
+    assert!(!rust.contains("compile_error"), "should NOT produce compile_error");
+}
+```
+
+- [ ] **Step 2: Remove try-catch rejection from `lints.rs`**
+
+- [ ] **Step 3: Implement `TryStmt` in `stmt.rs`**
+
+Strategy: Convert `try { body } catch(e) { handler }` to:
+```rust
+match (|| -> Result<_, Box<dyn std::error::Error>> { body })() {
+    Ok(val) => val,
+    Err(e) => { handler },
+}
+```
+
+Or simpler: wrap the try body in a closure that returns Result, then match.
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+---
+
+## Chunk 3: Stdlib Expansion
+
+### Task 10: Add missing Array methods
+
+**Files:**
+- Modify: `crates/tyrus_codegen/src/stdlib/array.rs`
+- Test: `tests/src/unit/tier5.rs`
+
+Methods to add:
+- `concat()` → `.iter().chain(other.iter()).cloned().collect()`
+- `slice(start, end)` → `[start..end].to_vec()`
+- `includes(item)` → `.contains(&item)`
+- `indexOf(item)` → `.iter().position(|x| x == &item)`
+- `length` (property) → `.len()`
+
+- [ ] **Step 1: Write failing tests for each method**
+- [ ] **Step 2: Implement in `array.rs`**
+- [ ] **Step 3: Run tests — expect PASS**
+- [ ] **Step 4: Commit**
+
+---
+
+### Task 11: Add missing String methods
+
+**Files:**
+- Modify: `crates/tyrus_codegen/src/stdlib/string.rs`
+- Test: `tests/src/unit/tier5.rs`
+
+Methods to add:
+- `substring(start, end)` → `[start..end]` or `.get(start..end)`
+- `charAt(i)` → `.chars().nth(i)`
+- `startsWith(prefix)` → `.starts_with(&prefix)`
+- `endsWith(suffix)` → `.ends_with(&suffix)`
+- `repeat(n)` → `.repeat(n)`
+- `padStart(len, fill)` → `format!("{:>width$}", s, width=len)` with fill
+- `length` (property) → `.len()`
+
+- [ ] **Step 1: Write failing tests for each method**
+- [ ] **Step 2: Implement in `string.rs`**
+- [ ] **Step 3: Run tests — expect PASS**
+- [ ] **Step 4: Commit**
+
+---
+
+### Task 12: Add Object methods
+
+**Files:**
+- Modify: `crates/tyrus_codegen/src/convert/expr/call.rs` (or new `stdlib/object.rs`)
+- Test: `tests/src/unit/tier5.rs`
+
+Methods to add:
+- `Object.keys(obj)` → `obj.keys().cloned().collect::<Vec<_>>()` (for HashMap)
+- `Object.values(obj)` → `obj.values().cloned().collect::<Vec<_>>()`
+- `Object.entries(obj)` → `obj.iter().collect::<Vec<_>>()`
+
+- [ ] **Step 1: Write failing tests**
+- [ ] **Step 2: Implement**
+- [ ] **Step 3: Run tests — expect PASS**
+- [ ] **Step 4: Commit**
+
+---
+
+## Chunk 4: Integration Tests + Snapshot Updates
+
+### Task 13: Create tier5 test fixtures
+
+**Files:**
+- Create: `tests/fixtures/tier5/control_flow.ts` (for, for-of, do-while, switch)
+- Create: `tests/fixtures/tier5/error_handling.ts` (try-catch)
+- Create: `tests/fixtures/tier5/unary_ops.ts` (!, -, +)
+- Create: `tests/fixtures/tier5/immutability.ts` (const vs let)
+
+- [ ] **Step 1: Write fixture files**
+- [ ] **Step 2: Add snapshot tests in `tests/src/snapshot/tier5.rs`**
+- [ ] **Step 3: Add compilation tests in `tests/src/compilation/tier5.rs`**
+- [ ] **Step 4: Register modules in `mod.rs` files**
+- [ ] **Step 5: Run all tests — expect PASS**
+- [ ] **Step 6: Accept snapshots with `cargo insta accept`**
+- [ ] **Step 7: Final commit**
+
+```bash
+git commit -m "test(tier5): add fixtures and tests for control flow + bug fixes"
+```
+
+---
+
+## Chunk 5: Documentation + Cleanup
+
+### Task 14: Update all documentation
+
+- [ ] **Step 1: Update ROADMAP.md** — Add Milestone 13
+- [ ] **Step 2: Update GRAMMAR.md** — Add switch, try-catch, do-while, for to supported constructs
+- [ ] **Step 3: Update CLAUDE.md** — Update test count and known limitations
+- [ ] **Step 4: Update STANDARDIZATION_PLAN.md** — Mark Phase 8 (if applicable)
+- [ ] **Step 5: Update benches/README.md** — If any new benchmark scenarios
+
+### Task 15: Final verification
+
+- [ ] **Step 1: Run full test suite** — `cargo nextest run --workspace`
+- [ ] **Step 2: Run clippy** — `cargo clippy --workspace`
+- [ ] **Step 3: Run fmt check** — `cargo fmt -- --check`
+- [ ] **Step 4: Verify demo** — `cargo run --bin tyrus -- build examples/real_world_demo/src --output examples/real_world_demo/output && cd examples/real_world_demo/output && cargo check`
+
+---
+
+## Summary
+
+| Chunk | Tasks | Impact |
+|-------|-------|--------|
+| 1: Bug Fixes | 4 bugs fixed | `const` immutability, unary ops, optional chaining, find() |
+| 2: Control Flow | 5 constructs unlocked | for, for-of, for-in, do-while, switch, try-catch |
+| 3: Stdlib | 15+ methods added | Array, String, Object methods |
+| 4: Tests | 20+ new tests | Tier 5 fixtures + compilation verification |
+| 5: Docs | Update all | ROADMAP, GRAMMAR, CLAUDE.md |
+
+**Expected outcome:** TypeScript coverage jumps from ~70% to ~90% of the Oxidizable Standard.

--- a/docs/superpowers/plans/MASTER_PLAN.md
+++ b/docs/superpowers/plans/MASTER_PLAN.md
@@ -1,0 +1,204 @@
+# Tyrus Master Plan — Unified Roadmap
+
+> Central plan governing all development. Macro phases → Micro milestones → Nano tasks.
+> Every PR maps to a nano task. Every nano task has an equivalence test proving it works.
+
+**Principle:** Nothing advances without semantic equivalence proof. Every new feature must pass `assert_output_equivalent()`.
+
+---
+
+## Current State (2026-03-13)
+
+| Metric | Value |
+|--------|-------|
+| Tests passing | 109 (94 integration + 2 tier4 + 9 codegen + 4 common) |
+| Equivalence tests | 23 (proving TS↔Rust output identity) |
+| Supported expressions | 16+ types |
+| String methods | 9 (includes, replace, split, toUpperCase, toLowerCase, trim, startsWith, endsWith, toString) |
+| Array methods | 10 (map, filter, forEach, find, some, every, reduce, join, includes, push) |
+| Math functions | 8 (max, min, round, floor, ceil, abs, random, spread variants) |
+| Blocked by analyzer | 6 constructs (for, for-in, for-of, do-while, switch, try-catch) |
+| Known bugs | 2 (parenthesized expr precedence, top-level var empty output) |
+
+---
+
+## MACRO PHASES
+
+```
+Phase 1 ✅ Foundation     (Milestones 1-8)   — Core transpilation, types, NestJS
+Phase 2 ✅ Quality         (Milestones 9-12)  — Strict rules, decomposition, test suite
+Phase 3 ✅ Equivalence     (Milestone 13A)    — Prove output identity for basics
+Phase 4 🔨 Control Flow    (Milestone 13B)    — Unlock blocked constructs + bug fixes
+Phase 5 📋 Stdlib Complete (Milestone 14)     — Full JS/TS method coverage
+Phase 6 📋 Advanced TS     (Milestone 15)     — Class inheritance, enums, advanced patterns
+Phase 7 📋 Academic        (Milestone 16)     — Benchmarks, formal spec, paper
+```
+
+---
+
+## Phase 4: Control Flow Expansion (Milestone 13B)
+
+**Goal:** Unlock 6 blocked control flow constructs and fix remaining bugs. Coverage: ~70% → ~90%.
+
+### Micro 4.1: Bug Fixes
+
+| Nano | Task | Files | Equivalence Test |
+|------|------|-------|-----------------|
+| 4.1.1 | Fix optional chaining `Some()` wrapper | `expr/misc.rs` | `obj?.name` returns correct value |
+| 4.1.2 | Fix `.find()` closure type mismatch (`&&f64`) | `expr/call.rs` | `[1,2,3].find(n => n > 1)` |
+| 4.1.3 | Fix parenthesized expression precedence | `expr/mod.rs` | `(2 + 3) * 4` = 20, not 14 |
+
+### Micro 4.2: Unblock Analyzer
+
+| Nano | Task | Files | Equivalence Test |
+|------|------|-------|-----------------|
+| 4.2.1 | Remove analyzer rejection for `for-of` | `lints.rs` | `for (const x of arr) { console.log(x) }` |
+| 4.2.2 | Remove analyzer rejection for `for-in` | `lints.rs` | `for (const k in obj) { console.log(k) }` |
+| 4.2.3 | Remove analyzer rejection for `do-while` | `lints.rs` | `do { i++ } while (i < 5)` |
+| 4.2.4 | Remove analyzer rejection for `for` | `lints.rs` | `for (let i=0; i<5; i++) { console.log(i) }` |
+
+### Micro 4.3: New Control Flow Codegen
+
+| Nano | Task | Files | Equivalence Test |
+|------|------|-------|-----------------|
+| 4.3.1 | Traditional `for` loop → `while` | `stmt.rs` | `for(let i=0; i<n; i++) { sum += i }` |
+| 4.3.2 | `do-while` → `loop { ... if !cond { break } }` | `stmt.rs` | `do { x++ } while (x < 10)` |
+| 4.3.3 | `switch` → `match` | `stmt.rs`, `lints.rs` | `switch(x) { case "a": ... }` |
+| 4.3.4 | `try-catch` → `match` on Result | `stmt.rs`, `lints.rs` | `try { ok() } catch(e) { err() }` |
+
+---
+
+## Phase 5: Stdlib Complete (Milestone 14)
+
+**Goal:** Cover the most-used JS/TS methods. Each nano task adds ONE method + equivalence test.
+
+### Micro 5.1: String Methods
+
+| Nano | Method | Rust Mapping | Priority |
+|------|--------|-------------|----------|
+| 5.1.1 | `substring(start, end)` | `s[start..end].to_string()` | HIGH |
+| 5.1.2 | `charAt(i)` | `s.chars().nth(i)` | HIGH |
+| 5.1.3 | `indexOf(substr)` | `s.find(substr)` | HIGH |
+| 5.1.4 | `repeat(n)` | `s.repeat(n)` | MEDIUM |
+| 5.1.5 | `padStart(len, fill)` | `format!("{:>width$}", s)` | LOW |
+| 5.1.6 | `padEnd(len, fill)` | `format!("{:<width$}", s)` | LOW |
+| 5.1.7 | `slice(start, end)` | `s[start..end].to_string()` | MEDIUM |
+
+### Micro 5.2: Array Methods
+
+| Nano | Method | Rust Mapping | Priority |
+|------|--------|-------------|----------|
+| 5.2.1 | `indexOf(item)` | `.iter().position(\|x\| x == &item)` | HIGH |
+| 5.2.2 | `slice(start, end)` | `[start..end].to_vec()` | HIGH |
+| 5.2.3 | `concat(other)` | `.iter().chain(other.iter()).cloned().collect()` | MEDIUM |
+| 5.2.4 | `sort()` | `.sort_by(\|a,b\| a.partial_cmp(b).unwrap_or(Ordering::Equal))` | MEDIUM |
+| 5.2.5 | `reverse()` | `.reverse()` | LOW |
+| 5.2.6 | `pop()` | `.pop()` | LOW |
+| 5.2.7 | `shift()` | `.remove(0)` | LOW |
+| 5.2.8 | `flat()` / `flatMap()` | `.into_iter().flatten().collect()` | LOW |
+
+### Micro 5.3: Math Functions
+
+| Nano | Method | Rust Mapping | Priority |
+|------|--------|-------------|----------|
+| 5.3.1 | `Math.pow(base, exp)` | `base.powf(exp)` | HIGH |
+| 5.3.2 | `Math.sqrt(x)` | `x.sqrt()` | HIGH |
+| 5.3.3 | `Math.PI` | `std::f64::consts::PI` | HIGH |
+| 5.3.4 | `Math.E` | `std::f64::consts::E` | MEDIUM |
+| 5.3.5 | `Math.log(x)` | `x.ln()` | MEDIUM |
+| 5.3.6 | `Math.sin/cos/tan(x)` | `x.sin()` / `.cos()` / `.tan()` | LOW |
+| 5.3.7 | `Math.sign(x)` | `x.signum()` | LOW |
+| 5.3.8 | `Math.trunc(x)` | `x.trunc()` | LOW |
+
+### Micro 5.4: Object Methods
+
+| Nano | Method | Rust Mapping | Priority |
+|------|--------|-------------|----------|
+| 5.4.1 | `Object.keys(obj)` | `obj.keys().cloned().collect::<Vec<_>>()` | HIGH |
+| 5.4.2 | `Object.values(obj)` | `obj.values().cloned().collect::<Vec<_>>()` | HIGH |
+| 5.4.3 | `Object.entries(obj)` | `obj.iter().collect::<Vec<_>>()` | MEDIUM |
+
+### Micro 5.5: Console Methods
+
+| Nano | Method | Rust Mapping | Priority |
+|------|--------|-------------|----------|
+| 5.5.1 | `console.warn()` | `eprintln!("[WARN] {}", ...)` | LOW |
+| 5.5.2 | `console.info()` | `println!("[INFO] {}", ...)` | LOW |
+
+---
+
+## Phase 6: Advanced TypeScript (Milestone 15)
+
+**Goal:** Support advanced TS patterns that are common in real codebases.
+
+### Micro 6.1: Class Features
+
+| Nano | Feature | Description |
+|------|---------|-------------|
+| 6.1.1 | Class inheritance | `extends` → trait impl + composition |
+| 6.1.2 | Getters/Setters | `get x()` → method, `set x(v)` → method |
+| 6.1.3 | Static methods | `static` → `impl` associated functions |
+| 6.1.4 | Abstract classes | `abstract` → trait definition |
+
+### Micro 6.2: Advanced Expressions
+
+| Nano | Feature | Description |
+|------|---------|-------------|
+| 6.2.1 | Spread operator | `...arr` → `.iter().cloned()` |
+| 6.2.2 | Rest parameters | `...args: T[]` → `args: Vec<T>` |
+| 6.2.3 | Nullish assignment | `??=` → `if option.is_none() { ... }` |
+| 6.2.4 | Type narrowing | `typeof x === "string"` → match guards |
+
+### Micro 6.3: Advanced Types
+
+| Nano | Feature | Description |
+|------|---------|-------------|
+| 6.3.1 | Intersection types | `A & B` → struct composition |
+| 6.3.2 | Mapped types | `Partial<T>`, `Required<T>` → Option wrapping |
+| 6.3.3 | Index signatures | `[key: string]: T` → HashMap field |
+| 6.3.4 | Discriminated unions | `type A = {kind: "a"} \| {kind: "b"}` → enum |
+
+---
+
+## Phase 7: Academic (Milestone 16)
+
+### Micro 7.1: Benchmarks
+- Criterion.rs benchmark suite (transpilation speed)
+- Node.js vs Rust runtime comparison (execution speed, memory)
+
+### Micro 7.2: Formal Specification
+- Complete EBNF grammar for Oxidizable Standard
+- Formal type mapping specification
+
+### Micro 7.3: Paper/TCC
+- Academic paper draft in `papers/`
+- Reproducible benchmark results
+
+---
+
+## Execution Order
+
+**Immediate next:** Phase 4, Micro 4.1 (bug fixes) → then 4.2 (unblock analyzer) → then 4.3 (control flow codegen).
+
+Each nano task follows this workflow:
+1. Create issue on GitHub
+2. Branch from issue (`feat/`, `fix/`)
+3. Write equivalence test FIRST (TDD)
+4. Implement minimal fix
+5. Run full suite + clippy + fmt
+6. Commit with `<type>(<scope>): <subject>`
+7. Update GRAMMAR.md if new construct
+8. PR → merge
+
+---
+
+## Detailed Plans
+
+| Phase | Plan File |
+|-------|-----------|
+| Phase 1-2 | `docs/superpowers/plans/2026-03-12-full-refactoring-roadmap.md` (COMPLETE) |
+| Phase 3 | `docs/superpowers/plans/2026-03-13-milestone-13-semantic-equivalence.md` (COMPLETE) |
+| Phase 4 | `docs/superpowers/plans/2026-03-13-milestone-13B-control-flow.md` (TO CREATE) |
+| Phase 5 | `docs/superpowers/plans/milestone-14-stdlib-complete.md` (TO CREATE) |
+| Phase 6 | `docs/superpowers/plans/milestone-15-advanced-ts.md` (TO CREATE) |
+| Phase 7 | `docs/superpowers/plans/milestone-16-academic.md` (TO CREATE) |


### PR DESCRIPTION
## Summary
- Remove broken JS fallback in `run_node()` that caused CI failures when Node.js 20 couldn't parse TypeScript type annotations as plain JS
- Add `actions/setup-node@v4` with `node-version: 22` to CI build job
- Add unified `MASTER_PLAN.md` consolidating 3 separate plans into macro/micro/nano roadmap
- Add Phase 4 control flow plan (Milestone 13B)

## Test plan
- [x] All 109 tests pass locally
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --workspace` passes
- [ ] CI Build & Test job passes with Node.js 22