### PR TITLE
chore: pre-commit hooks (fmt + clippy)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,13 @@ cargo run --bin tyrus -- --quiet <command>             # Suppress banner
 
 # Snapshots
 cargo insta review                     # Review snapshot changes
+
+# Benchmarks
+cargo bench --bench transpiler         # Transpilation speed (criterion)
+cargo bench --bench runtime_comparison # Node.js vs Rust runtime comparison
+
+# Git hooks (run once after cloning)
+./scripts/setup-hooks.sh               # Install pre-commit (fmt + clippy)
 ```
 
 ## Architecture

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,20 +1,15 @@
 #!/bin/sh
 # Pre-commit hook for Tyrus
-# Install: cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
-# Or:      ln -sf ../../scripts/pre-commit .git/hooks/pre-commit
-
-set -e
+# Install: ./scripts/setup-hooks.sh
 
 echo "=== Pre-commit: cargo fmt ==="
-cargo fmt -- --check
-if [ $? -ne 0 ]; then
+if ! cargo fmt -- --check; then
     echo "ERROR: cargo fmt failed. Run 'cargo fmt' to fix."
     exit 1
 fi
 
 echo "=== Pre-commit: cargo clippy ==="
-cargo clippy --workspace --quiet 2>&1
-if [ $? -ne 0 ]; then
+if ! cargo clippy --workspace -- -D warnings; then
     echo "ERROR: cargo clippy found warnings. Fix them before committing."
     exit 1
 fi

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Pre-commit hook for Tyrus
+# Install: cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+# Or:      ln -sf ../../scripts/pre-commit .git/hooks/pre-commit
+
+set -e
+
+echo "=== Pre-commit: cargo fmt ==="
+cargo fmt -- --check
+if [ $? -ne 0 ]; then
+    echo "ERROR: cargo fmt failed. Run 'cargo fmt' to fix."
+    exit 1
+fi
+
+echo "=== Pre-commit: cargo clippy ==="
+cargo clippy --workspace --quiet 2>&1
+if [ $? -ne 0 ]; then
+    echo "ERROR: cargo clippy found warnings. Fix them before committing."
+    exit 1
+fi
+
+echo "=== Pre-commit: OK ==="

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -2,9 +2,12 @@
 # Setup git hooks for Tyrus development
 # Usage: ./scripts/setup-hooks.sh
 
+set -e
+
 HOOKS_DIR="$(git rev-parse --show-toplevel)/.git/hooks"
 SCRIPTS_DIR="$(git rev-parse --show-toplevel)/scripts"
 
 ln -sf "$SCRIPTS_DIR/pre-commit" "$HOOKS_DIR/pre-commit"
+chmod +x "$HOOKS_DIR/pre-commit"
 echo "Installed pre-commit hook"
 echo "Done. Hooks are active."

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Setup git hooks for Tyrus development
+# Usage: ./scripts/setup-hooks.sh
+
+HOOKS_DIR="$(git rev-parse --show-toplevel)/.git/hooks"
+SCRIPTS_DIR="$(git rev-parse --show-toplevel)/scripts"
+
+ln -sf "$SCRIPTS_DIR/pre-commit" "$HOOKS_DIR/pre-commit"
+echo "Installed pre-commit hook"
+echo "Done. Hooks are active."


### PR DESCRIPTION
## Summary

- Add `scripts/pre-commit` hook that runs `cargo fmt --check` and `cargo clippy` before every commit
- Add `scripts/setup-hooks.sh` for easy one-command installation (symlink-based, no external deps)
- Document benchmark commands and hook setup in `CLAUDE.md`

## Why

- Prevents broken formatting and clippy warnings from reaching CI
- Zero external dependencies (just shell scripts + cargo)
- Symlink-based: updates to `scripts/pre-commit` apply immediately

## Setup

```bash
./scripts/setup-hooks.sh
```

## Test plan
- [x] Hook installed via `./scripts/setup-hooks.sh`
- [x] Commit with hook active — fmt + clippy ran successfully
- [x] `cargo nextest run --workspace` — 158 passed, 1 skipped
- [x] `cargo clippy --workspace` — clean
- [x] `cargo fmt -- --check` — clean

Closes #26