### PR TITLE
docs: update module structure after stmt.rs refactoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,11 @@ crates/tyrus_codegen/src/
 │   ├── interface.rs      # RustGenerator visitor, interfaces → structs
 │   ├── helpers.rs        # to_snake_case, to_pascal_case, is_string_expr, is_primitive_type
 │   ├── fn_decl.rs        # Function declaration transpilation
-│   ├── stmt.rs           # Statement conversion
+│   ├── stmt/             # Statement conversion (split from 427-line monolith)
+│   │   ├── mod.rs         # Dispatcher + convert_stmt, convert_stmt_recursive
+│   │   ├── var_decl.rs    # Variable declarations (ident, object/array destructuring)
+│   │   ├── loops.rs       # while, for-of, for-in, for, do-while
+│   │   └── switch.rs      # switch → match
 │   ├── type_mapper.rs    # TS→Rust type mapping
 │   └── expr/             # Expression conversion
 │       ├── mod.rs         # Expression dispatcher

--- a/README.md
+++ b/README.md
@@ -189,7 +189,11 @@ convert/
 ├── mod.rs          — module declarations and re-exports
 ├── interface.rs    — RustGenerator struct definition + Visit impl (entry point)
 ├── helpers.rs      — shared utilities: to_snake_case, to_pascal_case, is_string_expr
-├── stmt.rs         — statement conversion (convert_stmt, convert_stmt_recursive)
+├── stmt/           — statement conversion (split into sub-modules)
+│   ├── mod.rs          — dispatcher + convert_stmt, convert_stmt_recursive
+│   ├── var_decl.rs     — variable declarations (ident, object/array destructuring)
+│   ├── loops.rs        — while, for-of, for-in, for, do-while
+│   └── switch.rs       — switch → match
 ├── fn_decl.rs      — function declaration processing (process_fn_decl)
 ├── module.rs       — module/import handling
 ├── type_mapper.rs  — TypeScript → Rust type mapping (deduplicated map_type_core)

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -183,7 +183,11 @@ convert/
 ├── mod.rs          — declarações de módulo e re-exports
 ├── interface.rs    — definição da struct RustGenerator + impl Visit (ponto de entrada)
 ├── helpers.rs      — utilitários compartilhados: to_snake_case, to_pascal_case, is_string_expr
-├── stmt.rs         — conversão de statements (convert_stmt, convert_stmt_recursive)
+├── stmt/           — conversão de statements (separado em sub-módulos)
+│   ├── mod.rs          — dispatcher + convert_stmt, convert_stmt_recursive
+│   ├── var_decl.rs     — declarações de variáveis (ident, desestruturação objeto/array)
+│   ├── loops.rs        — while, for-of, for-in, for, do-while
+│   └── switch.rs       — switch → match
 ├── fn_decl.rs      — processamento de declaração de funções (process_fn_decl)
 ├── module.rs       — manipulação de módulos/imports
 ├── type_mapper.rs  — mapeamento de tipos TypeScript → Rust (map_type_core deduplicado)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,7 +78,11 @@ convert/
 ├── mod.rs          — module declarations and re-exports
 ├── interface.rs    — RustGenerator struct definition + Visit impl (pipeline entry point)
 ├── helpers.rs      — shared utilities: to_snake_case, to_pascal_case, is_string_expr
-├── stmt.rs         — statement conversion (convert_stmt, convert_stmt_recursive)
+├── stmt/           — statement conversion (split into sub-modules)
+│   ├── mod.rs          — dispatcher + convert_stmt, convert_stmt_recursive
+│   ├── var_decl.rs     — variable declarations (ident, object/array destructuring)
+│   ├── loops.rs        — while, for-of, for-in, for, do-while
+│   └── switch.rs       — switch → match
 ├── fn_decl.rs      — function declaration processing (process_fn_decl)
 ├── module.rs       — module/import handling
 ├── type_mapper.rs  — TypeScript → Rust type mapping (deduplicated map_type_core)


### PR DESCRIPTION
## Summary

Update codegen module tree in 4 documentation files to reflect the `stmt.rs` → `stmt/` directory split from PR #31.

## Changes

| File | Update |
|------|--------|
| CLAUDE.md | `stmt.rs` → `stmt/` with 4 sub-modules |
| README.md | Same |
| README.pt-br.md | Same (Portuguese) |
| docs/ARCHITECTURE.md | Same |

## Test plan
- [x] Documentation only — no code changes

Closes #32