### PR TITLE
docs: sync documentation after Phase 6.1 try-catch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,6 @@ tests/
 
 See `docs/superpowers/plans/2026-03-12-full-refactoring-roadmap.md` for the complete plan.
 
-**Completed:** Chunks 1-7 + Milestones 13A/13B + Milestone 14 HIGH + CLI/IR/Analyzer evolution + Phase 6.0 Infrastructure
-**Current:** Phase 6.0 complete — prettyplease, thiserror 2.0, trybuild, AppError HTTP variants
-**Status:** 158 tests passing (55 equivalence + 8 IR + 7 CLI + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped)
+**Completed:** Chunks 1-7 + Milestones 13A/13B + Milestone 14 HIGH + CLI/IR/Analyzer evolution + Phase 6.0 Infrastructure + Phase 6.1 try-catch
+**Current:** Phase 6.1 complete — try-catch → Result matching, throw new Error → Err(), nested try-catch
+**Status:** 162 tests passing (59 equivalence + 8 IR + 7 CLI + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped)

--- a/README.md
+++ b/README.md
@@ -158,11 +158,11 @@ tyrus --quiet check ./src/index.ts
 
 ## 🧪 Test Suite
 
-158 tests across 7 test types and 4 feature tiers:
+162 tests across 7 test types and 4 feature tiers:
 
 | Type | Count | Description |
 |------|-------|-------------|
-| **Equivalence** | 55 | Semantic proof: TS and Rust produce identical stdout |
+| **Equivalence** | 59 | Semantic proof: TS and Rust produce identical stdout |
 | **CLI** | 7 | Integration tests for all CLI commands and flags |
 | **Unit** | 27 | Fast, isolated codegen function tests |
 | **Snapshot** | 6 | Full transpilation output via `insta` |

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -152,11 +152,11 @@ tyrus --quiet check ./src/index.ts
 
 ## 🧪 Suite de Testes
 
-158 testes distribuídos em 7 tipos de teste e 4 camadas de funcionalidades:
+162 testes distribuídos em 7 tipos de teste e 4 camadas de funcionalidades:
 
 | Tipo | Quantidade | Descrição |
 |------|-----------|-----------|
-| **Equivalência** | 55 | Prova semântica: TS e Rust produzem stdout idêntico |
+| **Equivalência** | 59 | Prova semântica: TS e Rust produzem stdout idêntico |
 | **CLI** | 7 | Testes de integração para todos os comandos e flags |
 | **Unitário** | 27 | Rápido, funções isoladas de codegen |
 | **Snapshot** | 6 | Saída completa de transpilação via `insta` |

--- a/docs/superpowers/plans/2026-03-13-nestjs-full-transpilation-roadmap.md
+++ b/docs/superpowers/plans/2026-03-13-nestjs-full-transpilation-roadmap.md
@@ -14,7 +14,7 @@
 
 | Aspect | Status | Details |
 |--------|--------|---------|
-| Tests | 158 pass, 1 skip | 55 equivalence, 7 CLI, 8 IR, 73 integration, 9 codegen, 4 common, 1 trybuild |
+| Tests | 162 pass, 1 skip | 59 equivalence, 7 CLI, 8 IR, 73 integration, 9 codegen, 4 common, 1 trybuild |
 | CLI | 4 commands | check, build, compile, run (branded, --quiet, --json) |
 | Analyzer | 8 lint + 11 API blocks | var, any, eval, for-in, try-catch, delete, with, labeled |
 | Codegen | ~4190 lines, 20 modules | Expressions, statements, classes, stdlib |
@@ -160,7 +160,7 @@ match (|| -> Result<_, AppError> {
 
 #### Tasks
 
-- [ ] **Task 6.1.1: Remove try-catch from analyzer block list**
+- [x] **Task 6.1.1: Remove try-catch from analyzer block list** ✓
 
   Modify `crates/tyrus_analyzer/src/lints.rs`:
   - Remove the entire `fn visit_try_stmt(&mut self, n: &swc_ecma_ast::TryStmt)` method from the `Visit` impl for `LintVisitor` (lines 79-86)
@@ -180,7 +180,7 @@ match (|| -> Result<_, AppError> {
 
   Run: `cargo clippy --workspace`
 
-- [ ] **Task 6.1.2: Write failing equivalence test for basic try-catch**
+- [x] **Task 6.1.2: Write failing equivalence test for basic try-catch** ✓
 
   Create `tests/src/equivalence/error_handling.rs`:
 
@@ -211,7 +211,7 @@ match (|| -> Result<_, AppError> {
 
   Run: `cargo test -p integration_tests test_equivalence_try_catch_basic` — Expected: FAIL
 
-- [ ] **Task 6.1.2b: Refactor stmt.rs before adding try-catch**
+- [x] **Task 6.1.2b: Refactor stmt.rs before adding try-catch** ✓ (PR #31)
 
   `stmt.rs` is already at 427 lines (near the 400-line project limit). Before adding try-catch logic, extract existing switch/for-of/do-while conversion into a sub-module to make room.
 
@@ -221,7 +221,7 @@ match (|| -> Result<_, AppError> {
 
   Run: `cargo test --workspace` — all 157 tests must still pass.
 
-- [ ] **Task 6.1.3: Implement try-catch in stmt.rs**
+- [x] **Task 6.1.3: Implement try-catch in stmt/try_catch.rs** ✓
 
   Modify `crates/tyrus_codegen/src/convert/stmt.rs` (or `stmt/mod.rs` after refactor):
   - Add `Stmt::Try(try_stmt)` arm to `convert_stmt()`
@@ -234,7 +234,7 @@ match (|| -> Result<_, AppError> {
 
   Run: `cargo test -p integration_tests test_equivalence_try_catch_basic` — Expected: PASS
 
-- [ ] **Task 6.1.4: Write equivalence test for try-catch with throw**
+- [x] **Task 6.1.4: Write equivalence test for try-catch with throw** ✓
 
   Add to `error_handling.rs`:
 
@@ -264,7 +264,7 @@ match (|| -> Result<_, AppError> {
 
   Run: `cargo test -p integration_tests test_equivalence_try_catch` — Expected: PASS
 
-- [ ] **Task 6.1.5: Write equivalence test for nested try-catch**
+- [x] **Task 6.1.5: Write equivalence test for nested try-catch** ✓
 
   ```rust
   #[test]

--- a/docs/superpowers/plans/MASTER_PLAN.md
+++ b/docs/superpowers/plans/MASTER_PLAN.md
@@ -11,21 +11,21 @@
 
 | Metric | Value |
 |--------|-------|
-| Tests passing | 158 (55 equivalence + 7 CLI + 8 IR + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped) |
-| Equivalence tests | 55 (proving TS↔Rust output identity) |
+| Tests passing | 162 (59 equivalence + 7 CLI + 8 IR + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped) |
+| Equivalence tests | 59 (proving TS↔Rust output identity) |
 | Supported expressions | 16+ types |
-| Control flow | while, for, for-of, do-while, switch, if/else |
+| Control flow | while, for, for-of, do-while, switch, if/else, try-catch |
 | String methods | 16 (includes, replace, split, toUpperCase, toLowerCase, trim, startsWith, endsWith, toString, substring, charAt, indexOf, repeat, slice, padStart, padEnd) |
 | Array methods | 15 (map, filter, forEach, find, some, every, reduce, join, includes, push, indexOf, slice, concat, reverse, pop, sort, shift, flat, flatMap) |
 | Math functions | 15 (max, min, round, floor, ceil, abs, random, pow, sqrt, log, trunc, sign, sin, cos, tan) |
 | Math constants | 2 (PI, E) |
 | Console methods | 5 (log, error, warn, info, debug) |
-| Blocked by analyzer | 5 constructs (for-in, try-catch, delete, with, labeled) |
+| Blocked by analyzer | 4 constructs (for-in, delete, with, labeled) |
 | CLI commands | 4 (check, build, compile, run) |
-| Analyzer lint rules | 8 (var, any, eval, for-in, try-catch, delete, with, labeled) |
+| Analyzer lint rules | 7 (var, any, eval, for-in, delete, with, labeled) |
 | Unsupported APIs detected | 11 (DOM, timers, require, XMLHttpRequest, etc.) |
 | IR types defined | 4 (TyrusType, TyrusExpr, TyrusStmt, TyrusDecl) |
-| Known bugs | 1 (optional chaining on Option fields creates double-Option — needs type inference) |
+| Known bugs | 4 (optional chaining double-Option #existing, try-catch finally skipped on success #36, side-effect try early return #37, return in loop inside try #38) |
 
 ---
 


### PR DESCRIPTION
## Summary

Sync all documentation after Phase 6.1 try-catch implementation (PR #35).

## Changes

| Document | Update |
|----------|--------|
| MASTER_PLAN.md | Tests 158→162, try-catch in control flow, blocked 5→4, known bugs +3 (#36 #37 #38) |
| NestJS Roadmap | Tasks 6.1.1-6.1.5 marked [x] complete |
| CLAUDE.md | Phase 6.1 complete, test count updated |
| README.md | Test count 158→162, equivalence 55→59 |
| README.pt-br.md | Same updates in Portuguese |

## Edge case issues created
- #36: finally block skipped on success path
- #37: side-effect try body causes early return
- #38: return inside loops in try body not wrapped in Ok()

## Test plan
- [x] Documentation only — no code changes
- [x] Pre-commit hook passed

Closes #39