### PR TITLE
feat: array spread operator and rest parameters (Phase 6.3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,6 @@ tests/
 
 See `docs/superpowers/plans/2026-03-12-full-refactoring-roadmap.md` for the complete plan.
 
-**Completed:** Chunks 1-7 + Milestones 13A/13B + Milestone 14 HIGH + CLI/IR/Analyzer evolution + Phase 6.0-6.2
-**Current:** Phase 6.2 complete — try-catch → Result matching, top-level statements → fn main()
-**Status:** 165 tests passing (62 equivalence + 8 IR + 7 CLI + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped)
+**Completed:** Chunks 1-7 + Milestones 13A/13B + Milestone 14 HIGH + CLI/IR/Analyzer evolution + Phase 6.0-6.3
+**Current:** Phase 6.3 complete — array spread, rest parameter declaration, try-catch, top-level stmts
+**Status:** 168 tests passing (65 equivalence + 8 IR + 7 CLI + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped)

--- a/crates/tyrus_codegen/src/convert/expr/literal.rs
+++ b/crates/tyrus_codegen/src/convert/expr/literal.rs
@@ -59,13 +59,50 @@ impl RustGenerator {
     }
 
     pub(crate) fn convert_array_lit(&self, arr: &swc_ecma_ast::ArrayLit) -> TokenStream {
-        let elems: Vec<_> = arr
-            .elems
-            .iter()
-            .flatten()
-            .map(|elem| self.convert_expr_or_spread(elem))
-            .collect();
-        quote! { vec![#(#elems),*] }
+        let elems: Vec<_> = arr.elems.iter().flatten().collect::<Vec<_>>();
+
+        // Check if any element uses spread syntax
+        let has_spread = elems.iter().any(|e| e.spread.is_some());
+
+        if !has_spread {
+            let items: Vec<_> = elems.iter().map(|e| self.convert_expr(&e.expr)).collect();
+            return quote! { vec![#(#items),*] };
+        }
+
+        // Build chain of iterators for spread elements
+        let mut chains: Vec<TokenStream> = Vec::new();
+        let mut pending_items: Vec<TokenStream> = Vec::new();
+
+        for elem in &elems {
+            if elem.spread.is_some() {
+                // Flush pending non-spread items first
+                if !pending_items.is_empty() {
+                    let items = pending_items.clone();
+                    chains.push(quote! { vec![#(#items),*].into_iter() });
+                    pending_items.clear();
+                }
+                let spread_expr = self.convert_expr(&elem.expr);
+                chains.push(quote! { #spread_expr.iter().cloned() });
+            } else {
+                pending_items.push(self.convert_expr(&elem.expr));
+            }
+        }
+
+        // Flush remaining non-spread items
+        if !pending_items.is_empty() {
+            let items = pending_items;
+            chains.push(quote! { vec![#(#items),*].into_iter() });
+        }
+
+        // Chain all iterators together
+        if chains.len() == 1 {
+            let first = &chains[0];
+            quote! { #first.collect::<Vec<_>>() }
+        } else {
+            let first = &chains[0];
+            let rest = &chains[1..];
+            quote! { #first #(.chain(#rest))* .collect::<Vec<_>>() }
+        }
     }
 
     pub(crate) fn convert_tpl(&self, tpl: &swc_ecma_ast::Tpl) -> TokenStream {

--- a/crates/tyrus_codegen/src/convert/expr/literal.rs
+++ b/crates/tyrus_codegen/src/convert/expr/literal.rs
@@ -77,9 +77,8 @@ impl RustGenerator {
             if elem.spread.is_some() {
                 // Flush pending non-spread items first
                 if !pending_items.is_empty() {
-                    let items = pending_items.clone();
+                    let items = std::mem::take(&mut pending_items);
                     chains.push(quote! { vec![#(#items),*].into_iter() });
-                    pending_items.clear();
                 }
                 let spread_expr = self.convert_expr(&elem.expr);
                 chains.push(quote! { #spread_expr.iter().cloned() });

--- a/crates/tyrus_codegen/src/convert/fn_decl.rs
+++ b/crates/tyrus_codegen/src/convert/fn_decl.rs
@@ -36,7 +36,9 @@ impl RustGenerator {
                     // ...args: T[] → args: Vec<T>
                     if let Pat::Ident(ident) = &*rest_pat.arg {
                         let param_name = format_ident!("{}", ident.sym.to_string());
-                        let param_type = map_ts_type(ident.type_ann.as_ref());
+                        // RestPat carries the type annotation, not the inner ident
+                        let param_type =
+                            map_ts_type(rest_pat.type_ann.as_ref().or(ident.type_ann.as_ref()));
                         params.push(quote! { mut #param_name: #param_type });
                     }
                 }

--- a/crates/tyrus_codegen/src/convert/fn_decl.rs
+++ b/crates/tyrus_codegen/src/convert/fn_decl.rs
@@ -26,10 +26,21 @@ impl RustGenerator {
         // Extract parameters — mark all as `mut` since TS allows reassignment
         let mut params = Vec::new();
         for param in &n.function.params {
-            if let Pat::Ident(ident_pat) = &param.pat {
-                let param_name = format_ident!("{}", ident_pat.sym.to_string());
-                let param_type = map_ts_type(ident_pat.type_ann.as_ref());
-                params.push(quote! { mut #param_name: #param_type });
+            match &param.pat {
+                Pat::Ident(ident_pat) => {
+                    let param_name = format_ident!("{}", ident_pat.sym.to_string());
+                    let param_type = map_ts_type(ident_pat.type_ann.as_ref());
+                    params.push(quote! { mut #param_name: #param_type });
+                }
+                Pat::Rest(rest_pat) => {
+                    // ...args: T[] → args: Vec<T>
+                    if let Pat::Ident(ident) = &*rest_pat.arg {
+                        let param_name = format_ident!("{}", ident.sym.to_string());
+                        let param_type = map_ts_type(ident.type_ann.as_ref());
+                        params.push(quote! { mut #param_name: #param_type });
+                    }
+                }
+                _ => {}
             }
         }
 

--- a/docs/superpowers/plans/2026-03-13-nestjs-full-transpilation-roadmap.md
+++ b/docs/superpowers/plans/2026-03-13-nestjs-full-transpilation-roadmap.md
@@ -14,7 +14,7 @@
 
 | Aspect | Status | Details |
 |--------|--------|---------|
-| Tests | 165 pass, 1 skip | 62 equivalence, 7 CLI, 8 IR, 73 integration, 9 codegen, 4 common, 1 trybuild |
+| Tests | 168 pass, 1 skip | 65 equivalence, 7 CLI, 8 IR, 73 integration, 9 codegen, 4 common, 1 trybuild |
 | CLI | 4 commands | check, build, compile, run (branded, --quiet, --json) |
 | Analyzer | 8 lint + 11 API blocks | var, any, eval, for-in, try-catch, delete, with, labeled |
 | Codegen | ~4190 lines, 20 modules | Expressions, statements, classes, stdlib |
@@ -468,7 +468,7 @@ fn log(args: Vec<String>) { }
 
 #### Tasks
 
-- [ ] **Task 6.3.1: Write failing test for array spread**
+- [x] **Task 6.3.1: Write failing test for array spread** ✓
 
   ```rust
   #[test]
@@ -482,7 +482,7 @@ fn log(args: Vec<String>) { }
   }
   ```
 
-- [ ] **Task 6.3.2: Implement array spread in literal.rs**
+- [x] **Task 6.3.2: Implement array spread in literal.rs** ✓
 
   In `convert_array_lit()`, detect `ExprOrSpread` with spread=true:
   - Single array: `arr.clone()`
@@ -538,7 +538,7 @@ fn log(args: Vec<String>) { }
   }
   ```
 
-- [ ] **Task 6.3.6: Implement rest parameters in fn_decl.rs**
+- [x] **Task 6.3.6: Implement rest parameters in fn_decl.rs** ✓ (declaration side)
 
   Detect `Pat::Rest(rest_pat)` in function parameters:
   - Last parameter with `...` → `Vec<T>` parameter

--- a/docs/superpowers/plans/MASTER_PLAN.md
+++ b/docs/superpowers/plans/MASTER_PLAN.md
@@ -11,8 +11,9 @@
 
 | Metric | Value |
 |--------|-------|
-| Tests passing | 165 (62 equivalence + 7 CLI + 8 IR + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped) |
-| Equivalence tests | 62 (proving TS↔Rust output identity) |
+| Tests passing | 168 (65 equivalence + 7 CLI + 8 IR + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped) |
+| Equivalence tests | 65 (proving TS↔Rust output identity) |
+| Array spread | `[...a, ...b]` → `a.iter().cloned().chain(b.iter().cloned()).collect()` |
 | Supported expressions | 16+ types |
 | Control flow | while, for, for-of, do-while, switch, if/else, try-catch |
 | Top-level statements | const, let, expressions, console.log — auto-wrapped in fn main() |

--- a/tests/src/equivalence/mod.rs
+++ b/tests/src/equivalence/mod.rs
@@ -4,5 +4,6 @@ mod console;
 mod control_flow;
 mod error_handling;
 mod math;
+mod spread;
 mod strings;
 mod top_level;

--- a/tests/src/equivalence/spread.rs
+++ b/tests/src/equivalence/spread.rs
@@ -1,0 +1,44 @@
+use crate::helpers::assert_output_equivalent;
+
+#[test]
+fn test_equivalence_array_spread_two_arrays() {
+    assert_output_equivalent(
+        r#"
+function combine(): string {
+    const arr1: string[] = ["a", "b", "c"];
+    const arr2: string[] = ["d", "e", "f"];
+    const combined: string[] = [...arr1, ...arr2];
+    return combined.join(", ");
+}
+console.log(combine());
+"#,
+    );
+}
+
+#[test]
+fn test_equivalence_array_spread_with_elements() {
+    assert_output_equivalent(
+        r#"
+function build(): string {
+    const middle: string[] = ["b", "c"];
+    const all: string[] = ["a", ...middle, "d"];
+    return all.join(", ");
+}
+console.log(build());
+"#,
+    );
+}
+
+#[test]
+fn test_equivalence_array_spread_single() {
+    assert_output_equivalent(
+        r#"
+function copy(): string {
+    const original: string[] = ["x", "y", "z"];
+    const clone: string[] = [...original];
+    return clone.join(", ");
+}
+console.log(copy());
+"#,
+    );
+}


### PR DESCRIPTION
## Summary

Implement array spread operator and rest parameter declaration transpilation.

## Array Spread

```typescript
const combined = [...arr1, ...arr2];
// → arr1.iter().cloned().chain(arr2.iter().cloned()).collect::<Vec<_>>()

const all = [1, ...middle, 4];
// → vec![1].into_iter().chain(middle.iter().cloned()).chain(vec![4].into_iter()).collect::<Vec<_>>()
```

## Rest Parameters (declaration side)

```typescript
function sum(...nums: number[]): number { ... }
// → fn sum(mut nums: Vec<f64>) -> f64 { ... }
```

Note: Caller-side transformation (`sum(1,2,3)` → `sum(vec![1,2,3])`) is tracked for future work.

## Changes

| File | Change |
|------|--------|
| `literal.rs` | Array spread: detect `ExprOrSpread.spread`, chain iterators |
| `fn_decl.rs` | Rest params: handle `Pat::Rest` in function parameters |
| `spread.rs` | **NEW** — 3 equivalence tests |

## Test plan
- [x] `test_equivalence_array_spread_two_arrays` — `[...a, ...b]`
- [x] `test_equivalence_array_spread_with_elements` — `[1, ...mid, 4]`
- [x] `test_equivalence_array_spread_single` — `[...original]` (clone)
- [x] `cargo nextest run --workspace` — 168 passed (+3 new), 1 skipped
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] Pre-commit hook passed

Closes #46