### PR TITLE
docs: sync documentation after Phase 6.3 spread/rest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,6 @@ tests/
 
 See `docs/superpowers/plans/2026-03-12-full-refactoring-roadmap.md` for the complete plan.
 
-**Completed:** Chunks 1-7 + Milestones 13A/13B + Milestone 14 HIGH + CLI/IR/Analyzer evolution + Phase 6.0-6.2
-**Current:** Phase 6.2 complete — try-catch → Result matching, top-level statements → fn main()
-**Status:** 165 tests passing (62 equivalence + 8 IR + 7 CLI + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped)
+**Completed:** Chunks 1-7 + Milestones 13A/13B + Milestone 14 HIGH + CLI/IR/Analyzer evolution + Phase 6.0-6.3
+**Current:** Phase 6.3 complete — array spread, rest parameter declaration, try-catch, top-level stmts
+**Status:** 168 tests passing (65 equivalence + 8 IR + 7 CLI + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped)

--- a/docs/superpowers/plans/2026-03-13-nestjs-full-transpilation-roadmap.md
+++ b/docs/superpowers/plans/2026-03-13-nestjs-full-transpilation-roadmap.md
@@ -14,7 +14,7 @@
 
 | Aspect | Status | Details |
 |--------|--------|---------|
-| Tests | 165 pass, 1 skip | 62 equivalence, 7 CLI, 8 IR, 73 integration, 9 codegen, 4 common, 1 trybuild |
+| Tests | 168 pass, 1 skip | 65 equivalence, 7 CLI, 8 IR, 73 integration, 9 codegen, 4 common, 1 trybuild |
 | CLI | 4 commands | check, build, compile, run (branded, --quiet, --json) |
 | Analyzer | 8 lint + 11 API blocks | var, any, eval, for-in, try-catch, delete, with, labeled |
 | Codegen | ~4190 lines, 20 modules | Expressions, statements, classes, stdlib |
@@ -468,7 +468,7 @@ fn log(args: Vec<String>) { }
 
 #### Tasks
 
-- [ ] **Task 6.3.1: Write failing test for array spread**
+- [x] **Task 6.3.1: Write failing test for array spread** ✓
 
   ```rust
   #[test]
@@ -482,7 +482,7 @@ fn log(args: Vec<String>) { }
   }
   ```
 
-- [ ] **Task 6.3.2: Implement array spread in literal.rs**
+- [x] **Task 6.3.2: Implement array spread in literal.rs** ✓
 
   In `convert_array_lit()`, detect `ExprOrSpread` with spread=true:
   - Single array: `arr.clone()`
@@ -538,7 +538,7 @@ fn log(args: Vec<String>) { }
   }
   ```
 
-- [ ] **Task 6.3.6: Implement rest parameters in fn_decl.rs**
+- [x] **Task 6.3.6: Implement rest parameters in fn_decl.rs** ✓ (declaration side)
 
   Detect `Pat::Rest(rest_pat)` in function parameters:
   - Last parameter with `...` → `Vec<T>` parameter

--- a/docs/superpowers/plans/MASTER_PLAN.md
+++ b/docs/superpowers/plans/MASTER_PLAN.md
@@ -11,8 +11,9 @@
 
 | Metric | Value |
 |--------|-------|
-| Tests passing | 165 (62 equivalence + 7 CLI + 8 IR + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped) |
-| Equivalence tests | 62 (proving TS↔Rust output identity) |
+| Tests passing | 168 (65 equivalence + 7 CLI + 8 IR + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped) |
+| Equivalence tests | 65 (proving TS↔Rust output identity) |
+| Array spread | `[...a, ...b]` → `a.iter().cloned().chain(b.iter().cloned()).collect()` |
 | Supported expressions | 16+ types |
 | Control flow | while, for, for-of, do-while, switch, if/else, try-catch |
 | Top-level statements | const, let, expressions, console.log — auto-wrapped in fn main() |


### PR DESCRIPTION
## Summary

Sync documentation after Phase 6.3 (array spread + rest parameters).

## Changes

| Document | Update |
|----------|--------|
| CLAUDE.md | Phase 6.0-6.3 complete, tests 165→168 |
| MASTER_PLAN.md | Tests 165→168, array spread documented |
| NestJS Roadmap | Tasks 6.3.1, 6.3.2, 6.3.6 marked [x] |

## Test plan
- [x] Documentation only
- [x] Pre-commit hook passed

Closes #48