### PR TITLE
feat: class inheritance — extends, super(), method override (Phase 6.4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,6 @@ tests/
 
 See `docs/superpowers/plans/2026-03-12-full-refactoring-roadmap.md` for the complete plan.
 
-**Completed:** Chunks 1-7 + Milestones 13A/13B + Milestone 14 HIGH + CLI/IR/Analyzer evolution + Phase 6.0-6.3
-**Current:** Phase 6.3 complete — array spread, rest parameter declaration, try-catch, top-level stmts
-**Status:** 168 tests passing (65 equivalence + 8 IR + 7 CLI + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped)
+**Completed:** Chunks 1-7 + Milestones 13A/13B + Milestone 14 HIGH + CLI/IR/Analyzer evolution + Phase 6.0-6.4
+**Current:** Phase 6.4 complete — class inheritance (extends, super(), method override), spread, try-catch, top-level
+**Status:** 170 tests passing (67 equivalence + 8 IR + 7 CLI + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Adhering to strict "Safe Transpilation" principles:
 - **Control Flow**: `if/else`, `while`, `for`, `for-of`, `do-while`, `switch/case`, ternary, `try/catch`
 - **Top-Level Statements**: `const`, `let`, expressions auto-wrapped in `fn main()`
 - **Spread Operator**: `[...arr1, ...arr2]` → iterator chain
+- **Class Inheritance**: `extends`, `super()`, method override via field flattening
 - **Operators**: Arithmetic, comparison, logical, `**` (exponentiation), `%` (modulo)
 - **Class State**: Automatic `Arc<Mutex<T>>` wrapping for services/controllers
 - **Interfaces**: `interface` -> `#[derive(Serialize, Deserialize)] struct`
@@ -160,11 +161,11 @@ tyrus --quiet check ./src/index.ts
 
 ## 🧪 Test Suite
 
-168 tests across 7 test types and 4 feature tiers:
+170 tests across 7 test types and 4 feature tiers:
 
 | Type | Count | Description |
 |------|-------|-------------|
-| **Equivalence** | 65 | Semantic proof: TS and Rust produce identical stdout |
+| **Equivalence** | 67 | Semantic proof: TS and Rust produce identical stdout |
 | **CLI** | 7 | Integration tests for all CLI commands and flags |
 | **Unit** | 27 | Fast, isolated codegen function tests |
 | **Snapshot** | 6 | Full transpilation output via `insta` |

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -66,6 +66,7 @@ Aderindo aos princípios estritos de "Transpilação Segura":
 - **Fluxo de Controle**: `if/else`, `while`, `for`, `for-of`, `do-while`, `switch/case`, ternário, `try/catch`
 - **Top-Level Statements**: `const`, `let`, expressões auto-wrapped em `fn main()`
 - **Spread Operator**: `[...arr1, ...arr2]` → iterator chain
+- **Herança de Classe**: `extends`, `super()`, override de métodos via field flattening
 - **Operadores**: Aritméticos, comparação, lógicos, `**` (exponenciação), `%` (módulo)
 - **Estado de Classe**: Encapsulamento automático com `Arc<Mutex<T>>` para services/controllers
 - **Interfaces**: `interface` -> `#[derive(Serialize, Deserialize)] struct`
@@ -154,11 +155,11 @@ tyrus --quiet check ./src/index.ts
 
 ## 🧪 Suite de Testes
 
-168 testes distribuídos em 7 tipos de teste e 4 camadas de funcionalidades:
+170 testes distribuídos em 7 tipos de teste e 4 camadas de funcionalidades:
 
 | Tipo | Quantidade | Descrição |
 |------|-----------|-----------|
-| **Equivalência** | 65 | Prova semântica: TS e Rust produzem stdout idêntico |
+| **Equivalência** | 67 | Prova semântica: TS e Rust produzem stdout idêntico |
 | **CLI** | 7 | Testes de integração para todos os comandos e flags |
 | **Unitário** | 27 | Rápido, funções isoladas de codegen |
 | **Snapshot** | 6 | Saída completa de transpilação via `insta` |

--- a/crates/tyrus_codegen/src/convert/class/constructor.rs
+++ b/crates/tyrus_codegen/src/convert/class/constructor.rs
@@ -121,6 +121,30 @@ impl RustGenerator {
         if let Some(body) = &constructor.body {
             for stmt in &body.stmts {
                 if let Stmt::Expr(ExprStmt { expr, .. }) = stmt {
+                    // Handle super(args) — map args to parent field initializations
+                    if let Expr::Call(call) = &**expr {
+                        if let swc_ecma_ast::Callee::Super(_) = &call.callee {
+                            // Map super() arguments to parent fields by position
+                            let parent_fields: Vec<(String, String)> = class_fields
+                                .iter()
+                                .filter(|(name, _)| !initialized_fields.contains(name.as_str()))
+                                .map(|(n, _)| (n.clone(), String::new()))
+                                .collect();
+
+                            for (idx, arg) in call.args.iter().enumerate() {
+                                if idx < parent_fields.len() {
+                                    let field_name_str = &parent_fields[idx].0;
+                                    let field_name =
+                                        format_ident!("{}", to_snake_case(field_name_str));
+                                    let value = self.convert_expr(&arg.expr);
+                                    field_inits.push(quote! { #field_name: #value });
+                                    initialized_fields.insert(field_name_str.clone());
+                                }
+                            }
+                            continue;
+                        }
+                    }
+
                     if let Expr::Assign(assign) = &**expr {
                         // Check if left side is this.field
                         if let AssignTarget::Simple(simple) = &assign.left {

--- a/crates/tyrus_codegen/src/convert/class/mod.rs
+++ b/crates/tyrus_codegen/src/convert/class/mod.rs
@@ -43,17 +43,17 @@ impl RustGenerator {
         let mut methods = Vec::new();
         let mut constructor: Option<&Constructor> = None;
         let mut class_fields_meta = Vec::new();
-        let mut own_field_names: Vec<(String, String)> = Vec::new();
+        let mut own_field_names: Vec<(String, proc_macro2::TokenStream, bool)> = Vec::new();
 
         // If extending a parent, include parent fields first
         if let Some(ref parent) = parent_class_name {
             if let Some(parent_fields) = self.class_fields.get(parent) {
-                for (field_name, field_type) in parent_fields {
+                for (field_name, field_type, is_opt) in parent_fields {
                     let fname = format_ident!("{}", to_snake_case(field_name));
-                    let ftype: proc_macro2::TokenStream = field_type.parse().unwrap_or_default();
+                    let ftype = field_type.clone();
                     fields.push(quote! { pub #fname: #ftype });
-                    class_fields_meta.push((field_name.clone(), false));
-                    own_field_names.push((field_name.clone(), field_type.clone()));
+                    class_fields_meta.push((field_name.clone(), *is_opt));
+                    own_field_names.push((field_name.clone(), ftype, *is_opt));
                 }
             }
         }
@@ -69,7 +69,9 @@ impl RustGenerator {
                 {
                     fields.push(field_tokens);
                     class_fields_meta.push((name.clone(), is_opt));
-                    own_field_names.push((name.clone(), type_str.clone()));
+                    // Store raw type as TokenStream for inheritance
+                    let raw_type_tokens = map_ts_type(prop.type_ann.as_ref());
+                    own_field_names.push((name.clone(), raw_type_tokens, is_opt));
                     if is_dep {
                         dependency_fields.insert(name);
                     } else if is_service_or_controller {

--- a/crates/tyrus_codegen/src/convert/class/mod.rs
+++ b/crates/tyrus_codegen/src/convert/class/mod.rs
@@ -29,11 +29,34 @@ impl RustGenerator {
             }
         }
 
+        // Detect inheritance: class Dog extends Animal
+        let parent_class_name = n.class.super_class.as_ref().and_then(|expr| {
+            if let swc_ecma_ast::Expr::Ident(ident) = &**expr {
+                Some(ident.sym.to_string())
+            } else {
+                None
+            }
+        });
+
         // 1. Generate Struct (Properties)
         let mut fields = Vec::new();
         let mut methods = Vec::new();
         let mut constructor: Option<&Constructor> = None;
         let mut class_fields_meta = Vec::new();
+        let mut own_field_names: Vec<(String, String)> = Vec::new();
+
+        // If extending a parent, include parent fields first
+        if let Some(ref parent) = parent_class_name {
+            if let Some(parent_fields) = self.class_fields.get(parent) {
+                for (field_name, field_type) in parent_fields {
+                    let fname = format_ident!("{}", to_snake_case(field_name));
+                    let ftype: proc_macro2::TokenStream = field_type.parse().unwrap_or_default();
+                    fields.push(quote! { pub #fname: #ftype });
+                    class_fields_meta.push((field_name.clone(), false));
+                    own_field_names.push((field_name.clone(), field_type.clone()));
+                }
+            }
+        }
 
         let mut dependency_fields = std::collections::HashSet::new();
         self.current_class_state_fields.clear();
@@ -46,6 +69,7 @@ impl RustGenerator {
                 {
                     fields.push(field_tokens);
                     class_fields_meta.push((name.clone(), is_opt));
+                    own_field_names.push((name.clone(), type_str.clone()));
                     if is_dep {
                         dependency_fields.insert(name);
                     } else if is_service_or_controller {
@@ -207,6 +231,10 @@ impl RustGenerator {
 
         self.code.push_str(&struct_def.to_string());
         self.code.push('\n');
+
+        // Store field map for potential child classes
+        self.class_fields
+            .insert(class_name.clone(), own_field_names);
 
         // 2. Generate Impl (Methods)
         let mut impl_items = Vec::new();

--- a/crates/tyrus_codegen/src/convert/interface.rs
+++ b/crates/tyrus_codegen/src/convert/interface.rs
@@ -16,6 +16,8 @@ pub struct RustGenerator {
     pub main_body: String,
     pub has_declared_main: bool,
     pub current_class_state_fields: std::collections::HashMap<String, String>,
+    /// Track class field names for inheritance (parent fields flattened into child)
+    pub(crate) class_fields: std::collections::HashMap<String, Vec<(String, String)>>,
     /// Variables declared with `: string` type annotation (used for stdlib disambiguation)
     pub(crate) string_vars: std::cell::RefCell<std::collections::HashSet<String>>,
 }
@@ -31,6 +33,7 @@ impl RustGenerator {
             main_body: String::new(),
             has_declared_main: false,
             current_class_state_fields: std::collections::HashMap::new(),
+            class_fields: std::collections::HashMap::new(),
             string_vars: std::cell::RefCell::new(std::collections::HashSet::new()),
         }
     }

--- a/crates/tyrus_codegen/src/convert/interface.rs
+++ b/crates/tyrus_codegen/src/convert/interface.rs
@@ -16,8 +16,10 @@ pub struct RustGenerator {
     pub main_body: String,
     pub has_declared_main: bool,
     pub current_class_state_fields: std::collections::HashMap<String, String>,
-    /// Track class field names for inheritance (parent fields flattened into child)
-    pub(crate) class_fields: std::collections::HashMap<String, Vec<(String, String)>>,
+    /// Track class fields for inheritance (parent fields flattened into child)
+    /// Stores: field_name, TokenStream type, is_optional
+    pub(crate) class_fields:
+        std::collections::HashMap<String, Vec<(String, proc_macro2::TokenStream, bool)>>,
     /// Variables declared with `: string` type annotation (used for stdlib disambiguation)
     pub(crate) string_vars: std::cell::RefCell<std::collections::HashSet<String>>,
 }

--- a/docs/superpowers/plans/2026-03-13-nestjs-full-transpilation-roadmap.md
+++ b/docs/superpowers/plans/2026-03-13-nestjs-full-transpilation-roadmap.md
@@ -612,7 +612,7 @@ enum AnyAnimal { Animal(Animal), Dog(Dog) }
 
 #### Tasks
 
-- [ ] **Task 6.4.1: Write failing test for basic inheritance**
+- [x] **Task 6.4.1: Write failing test for basic inheritance** ✓
 
   ```rust
   #[test]
@@ -644,20 +644,20 @@ enum AnyAnimal { Animal(Animal), Dog(Dog) }
   }
   ```
 
-- [ ] **Task 6.4.2: Implement extends detection in class/mod.rs**
+- [x] **Task 6.4.2: Implement extends detection in class/mod.rs** ✓
 
   In `process_class_decl()`:
   - Detect `class.super_class` (optional Expr)
   - If present, add `base: ParentType` field to struct
   - Flatten parent fields for direct access (or use delegation)
 
-- [ ] **Task 6.4.3: Implement super() in constructor.rs**
+- [x] **Task 6.4.3: Implement super() in constructor.rs** ✓
 
   In `convert_constructor()`:
   - Detect `super(args)` calls in constructor body
   - Convert to `base: ParentType::new(args)` field initialization
 
-- [ ] **Task 6.4.4: Write test for method override**
+- [x] **Task 6.4.4: Write test for method override** ✓
 
   ```rust
   #[test]

--- a/tests/src/equivalence/inheritance.rs
+++ b/tests/src/equivalence/inheritance.rs
@@ -1,0 +1,66 @@
+use crate::helpers::assert_output_equivalent;
+
+#[test]
+fn test_equivalence_class_inheritance_basic() {
+    assert_output_equivalent(
+        r#"
+class Animal {
+    name: string;
+    constructor(name: string) {
+        this.name = name;
+    }
+    speak(): string {
+        return this.name + " makes a sound";
+    }
+}
+
+class Dog extends Animal {
+    breed: string;
+    constructor(name: string, breed: string) {
+        super(name);
+        this.breed = breed;
+    }
+    speak(): string {
+        return this.name + " barks";
+    }
+}
+
+function main(): void {
+    const dog = new Dog("Rex", "Labrador");
+    console.log(dog.speak());
+    console.log(dog.breed);
+}
+main();
+"#,
+    );
+}
+
+#[test]
+fn test_equivalence_class_inheritance_method_override() {
+    assert_output_equivalent(
+        r#"
+class Shape {
+    area(): number {
+        return 0;
+    }
+}
+
+class Circle extends Shape {
+    radius: number;
+    constructor(radius: number) {
+        super();
+        this.radius = radius;
+    }
+    area(): number {
+        return 3.14159 * this.radius * this.radius;
+    }
+}
+
+function main(): void {
+    const c = new Circle(5);
+    console.log(c.area());
+}
+main();
+"#,
+    );
+}

--- a/tests/src/equivalence/mod.rs
+++ b/tests/src/equivalence/mod.rs
@@ -3,6 +3,7 @@ mod basic;
 mod console;
 mod control_flow;
 mod error_handling;
+mod inheritance;
 mod math;
 mod spread;
 mod strings;


### PR DESCRIPTION
## Summary

Implement class inheritance transpilation via field flattening strategy.

## How it works

```typescript
class Animal {
    name: string;
    constructor(name: string) { this.name = name; }
    speak(): string { return this.name + " makes a sound"; }
}
class Dog extends Animal {
    breed: string;
    constructor(name: string, breed: string) {
        super(name);
        this.breed = breed;
    }
    speak(): string { return this.name + " barks"; }
}
```

→

```rust
struct Animal { pub name: String }
impl Animal {
    pub fn new(name: String) -> Self { Self { name } }
    pub fn speak(&self) -> String { format!("{} makes a sound", self.name) }
}
struct Dog { pub name: String, pub breed: String }  // name flattened from Animal
impl Dog {
    pub fn new(name: String, breed: String) -> Self { Self { name, breed } }
    pub fn speak(&self) -> String { format!("{} barks", self.name) }
}
```

## Changes

| File | Change |
|------|--------|
| `interface.rs` | Add `class_fields: HashMap` to RustGenerator |
| `class/mod.rs` | Detect `extends`, flatten parent fields, store field map |
| `class/constructor.rs` | Handle `super(args)` → parent field initialization |
| `inheritance.rs` | **NEW** — 2 equivalence tests |

## Test plan
- [x] `test_equivalence_class_inheritance_basic` — Animal → Dog with super()
- [x] `test_equivalence_class_inheritance_method_override` — Shape → Circle with area()
- [x] `cargo nextest run --workspace` — 170 passed (+2 new), 1 skipped
- [x] `cargo clippy --workspace -- -D warnings` — clean

Closes #56