### PR TITLE
docs: sync after Phase 6.4 class inheritance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,6 @@ tests/
 
 See `docs/superpowers/plans/2026-03-12-full-refactoring-roadmap.md` for the complete plan.
 
-**Completed:** Chunks 1-7 + Milestones 13A/13B + Milestone 14 HIGH + CLI/IR/Analyzer evolution + Phase 6.0-6.3
-**Current:** Phase 6.3 complete — array spread, rest parameter declaration, try-catch, top-level stmts
-**Status:** 168 tests passing (65 equivalence + 8 IR + 7 CLI + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped)
+**Completed:** Chunks 1-7 + Milestones 13A/13B + Milestone 14 HIGH + CLI/IR/Analyzer evolution + Phase 6.0-6.4
+**Current:** Phase 6.4 complete — class inheritance (extends, super(), method override), spread, try-catch, top-level
+**Status:** 170 tests passing (67 equivalence + 8 IR + 7 CLI + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Adhering to strict "Safe Transpilation" principles:
 - **Control Flow**: `if/else`, `while`, `for`, `for-of`, `do-while`, `switch/case`, ternary, `try/catch`
 - **Top-Level Statements**: `const`, `let`, expressions auto-wrapped in `fn main()`
 - **Spread Operator**: `[...arr1, ...arr2]` → iterator chain
+- **Class Inheritance**: `extends`, `super()`, method override via field flattening
 - **Operators**: Arithmetic, comparison, logical, `**` (exponentiation), `%` (modulo)
 - **Class State**: Automatic `Arc<Mutex<T>>` wrapping for services/controllers
 - **Interfaces**: `interface` -> `#[derive(Serialize, Deserialize)] struct`
@@ -160,11 +161,11 @@ tyrus --quiet check ./src/index.ts
 
 ## 🧪 Test Suite
 
-168 tests across 7 test types and 4 feature tiers:
+170 tests across 7 test types and 4 feature tiers:
 
 | Type | Count | Description |
 |------|-------|-------------|
-| **Equivalence** | 65 | Semantic proof: TS and Rust produce identical stdout |
+| **Equivalence** | 67 | Semantic proof: TS and Rust produce identical stdout |
 | **CLI** | 7 | Integration tests for all CLI commands and flags |
 | **Unit** | 27 | Fast, isolated codegen function tests |
 | **Snapshot** | 6 | Full transpilation output via `insta` |

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -66,6 +66,7 @@ Aderindo aos princípios estritos de "Transpilação Segura":
 - **Fluxo de Controle**: `if/else`, `while`, `for`, `for-of`, `do-while`, `switch/case`, ternário, `try/catch`
 - **Top-Level Statements**: `const`, `let`, expressões auto-wrapped em `fn main()`
 - **Spread Operator**: `[...arr1, ...arr2]` → iterator chain
+- **Herança de Classe**: `extends`, `super()`, override de métodos via field flattening
 - **Operadores**: Aritméticos, comparação, lógicos, `**` (exponenciação), `%` (módulo)
 - **Estado de Classe**: Encapsulamento automático com `Arc<Mutex<T>>` para services/controllers
 - **Interfaces**: `interface` -> `#[derive(Serialize, Deserialize)] struct`
@@ -154,11 +155,11 @@ tyrus --quiet check ./src/index.ts
 
 ## 🧪 Suite de Testes
 
-168 testes distribuídos em 7 tipos de teste e 4 camadas de funcionalidades:
+170 testes distribuídos em 7 tipos de teste e 4 camadas de funcionalidades:
 
 | Tipo | Quantidade | Descrição |
 |------|-----------|-----------|
-| **Equivalência** | 65 | Prova semântica: TS e Rust produzem stdout idêntico |
+| **Equivalência** | 67 | Prova semântica: TS e Rust produzem stdout idêntico |
 | **CLI** | 7 | Testes de integração para todos os comandos e flags |
 | **Unitário** | 27 | Rápido, funções isoladas de codegen |
 | **Snapshot** | 6 | Saída completa de transpilação via `insta` |

--- a/docs/superpowers/plans/2026-03-13-nestjs-full-transpilation-roadmap.md
+++ b/docs/superpowers/plans/2026-03-13-nestjs-full-transpilation-roadmap.md
@@ -612,7 +612,7 @@ enum AnyAnimal { Animal(Animal), Dog(Dog) }
 
 #### Tasks
 
-- [ ] **Task 6.4.1: Write failing test for basic inheritance**
+- [x] **Task 6.4.1: Write failing test for basic inheritance** ✓
 
   ```rust
   #[test]
@@ -644,20 +644,20 @@ enum AnyAnimal { Animal(Animal), Dog(Dog) }
   }
   ```
 
-- [ ] **Task 6.4.2: Implement extends detection in class/mod.rs**
+- [x] **Task 6.4.2: Implement extends detection in class/mod.rs** ✓
 
   In `process_class_decl()`:
   - Detect `class.super_class` (optional Expr)
   - If present, add `base: ParentType` field to struct
   - Flatten parent fields for direct access (or use delegation)
 
-- [ ] **Task 6.4.3: Implement super() in constructor.rs**
+- [x] **Task 6.4.3: Implement super() in constructor.rs** ✓
 
   In `convert_constructor()`:
   - Detect `super(args)` calls in constructor body
   - Convert to `base: ParentType::new(args)` field initialization
 
-- [ ] **Task 6.4.4: Write test for method override**
+- [x] **Task 6.4.4: Write test for method override** ✓
 
   ```rust
   #[test]


### PR DESCRIPTION
## Summary

Sync docs after Phase 6.4 class inheritance (PR #57).

| Doc | Update |
|-----|--------|
| CLAUDE.md | Phase 6.0-6.4 complete, tests 168→170 |
| README.md | +class inheritance, tests 168→170, equiv 65→67 |
| README.pt-br.md | Same in Portuguese |
| NestJS Roadmap | Tasks 6.4.1-6.4.4 ✅ |

Closes #58