### PR TITLE
feat: static methods — declaration + call-site transformation (Phase 6.5)

### DIFF
--- a/crates/tyrus_codegen/src/convert/class/method.rs
+++ b/crates/tyrus_codegen/src/convert/class/method.rs
@@ -46,25 +46,24 @@ impl RustGenerator {
         // Build parameters
         let mut params = Vec::new();
 
-        // Handle self parameter
-        if is_handler {
-            // For handlers, we consume self (injected via FromRequest)
-            params.push(quote! { self });
-        } else if is_service_or_controller {
-            // For services/controllers (Singletons), we must use immutable &self (with interior mutability)
-            // to allow sharing via Arc across threads.
-            params.push(quote! { &self });
-        } else {
-            // For regular classes, detect if the method mutates self fields
-            let mutates = method
-                .function
-                .body
-                .as_ref()
-                .is_some_and(|body| Self::body_mutates_self(&body.stmts));
-            if mutates {
-                params.push(quote! { &mut self });
-            } else {
+        // Handle self parameter — static methods have no self
+        let is_static = method.is_static;
+        if !is_static {
+            if is_handler {
+                params.push(quote! { self });
+            } else if is_service_or_controller {
                 params.push(quote! { &self });
+            } else {
+                let mutates = method
+                    .function
+                    .body
+                    .as_ref()
+                    .is_some_and(|body| Self::body_mutates_self(&body.stmts));
+                if mutates {
+                    params.push(quote! { &mut self });
+                } else {
+                    params.push(quote! { &self });
+                }
             }
         }
 

--- a/crates/tyrus_codegen/src/convert/class/mod.rs
+++ b/crates/tyrus_codegen/src/convert/class/mod.rs
@@ -83,9 +83,15 @@ impl RustGenerator {
         }
 
         // Pass 2: Process Methods and Constructor
+        let mut static_method_names = std::collections::HashSet::new();
         for member in &n.class.body {
             match member {
                 ClassMember::Method(method) => {
+                    if method.is_static {
+                        if let Some(ident) = method.key.as_ident() {
+                            static_method_names.insert(ident.sym.to_string());
+                        }
+                    }
                     methods.push(method);
                 }
                 ClassMember::Constructor(cons) => {
@@ -237,6 +243,12 @@ impl RustGenerator {
         // Store field map for potential child classes
         self.class_fields
             .insert(class_name.clone(), own_field_names);
+
+        // Store static method names for call-site transformation
+        if !static_method_names.is_empty() {
+            self.static_methods
+                .insert(class_name.clone(), static_method_names);
+        }
 
         // 2. Generate Impl (Methods)
         let mut impl_items = Vec::new();

--- a/crates/tyrus_codegen/src/convert/expr/call.rs
+++ b/crates/tyrus_codegen/src/convert/expr/call.rs
@@ -23,6 +23,26 @@ impl RustGenerator {
         // Check for axios and stdlib method calls
         if let Callee::Expr(expr) = &call.callee {
             if let Expr::Member(member) = &**expr {
+                // Check for static method call: ClassName.method(args) → ClassName::method(args)
+                if let Expr::Ident(obj_ident) = &*member.obj {
+                    let class_name = obj_ident.sym.as_ref();
+                    if let Some(static_set) = self.static_methods.get(class_name) {
+                        if let Some(method_ident) = member.prop.as_ident() {
+                            let method_str = method_ident.sym.as_ref();
+                            if static_set.contains(method_str) {
+                                let cls = format_ident!("{}", class_name);
+                                let meth = format_ident!("{}", to_snake_case(method_str));
+                                let args: Vec<_> = call
+                                    .args
+                                    .iter()
+                                    .map(|a| self.convert_expr(&a.expr))
+                                    .collect();
+                                return quote! { #cls::#meth(#(#args),*) };
+                            }
+                        }
+                    }
+                }
+
                 if let Some(tokens) = self.try_convert_axios_call(member, call) {
                     return tokens;
                 }

--- a/crates/tyrus_codegen/src/convert/interface.rs
+++ b/crates/tyrus_codegen/src/convert/interface.rs
@@ -17,9 +17,10 @@ pub struct RustGenerator {
     pub has_declared_main: bool,
     pub current_class_state_fields: std::collections::HashMap<String, String>,
     /// Track class fields for inheritance (parent fields flattened into child)
-    /// Stores: field_name, TokenStream type, is_optional
     pub(crate) class_fields:
         std::collections::HashMap<String, Vec<(String, proc_macro2::TokenStream, bool)>>,
+    /// Track static methods per class (ClassName → [method_names])
+    pub(crate) static_methods: std::collections::HashMap<String, std::collections::HashSet<String>>,
     /// Variables declared with `: string` type annotation (used for stdlib disambiguation)
     pub(crate) string_vars: std::cell::RefCell<std::collections::HashSet<String>>,
 }
@@ -36,6 +37,7 @@ impl RustGenerator {
             has_declared_main: false,
             current_class_state_fields: std::collections::HashMap::new(),
             class_fields: std::collections::HashMap::new(),
+            static_methods: std::collections::HashMap::new(),
             string_vars: std::cell::RefCell::new(std::collections::HashSet::new()),
         }
     }

--- a/tests/src/equivalence/mod.rs
+++ b/tests/src/equivalence/mod.rs
@@ -6,5 +6,6 @@ mod error_handling;
 mod inheritance;
 mod math;
 mod spread;
+mod static_members;
 mod strings;
 mod top_level;

--- a/tests/src/equivalence/static_members.rs
+++ b/tests/src/equivalence/static_members.rs
@@ -1,0 +1,51 @@
+use crate::helpers::assert_output_equivalent;
+
+#[test]
+fn test_equivalence_static_method() {
+    assert_output_equivalent(
+        r#"
+class MathUtils {
+    static add(a: number, b: number): number {
+        return a + b;
+    }
+    static multiply(a: number, b: number): number {
+        return a * b;
+    }
+}
+
+function main(): void {
+    console.log(MathUtils.add(3, 4));
+    console.log(MathUtils.multiply(5, 6));
+}
+main();
+"#,
+    );
+}
+
+#[test]
+fn test_equivalence_static_and_instance() {
+    assert_output_equivalent(
+        r#"
+class Counter {
+    count: number;
+    constructor() {
+        this.count = 0;
+    }
+    static create(): Counter {
+        return new Counter();
+    }
+    increment(): number {
+        this.count = this.count + 1;
+        return this.count;
+    }
+}
+
+function main(): void {
+    let c = Counter.create();
+    console.log(c.increment());
+    console.log(c.increment());
+}
+main();
+"#,
+    );
+}


### PR DESCRIPTION
## Summary

Implement static method transpilation with both declaration and call-site transformation.

## Changes

| File | Change |
|------|--------|
| `class/method.rs` | Skip `&self` for `is_static` methods |
| `class/mod.rs` | Track static method names per class |
| `expr/call.rs` | `ClassName.method()` → `ClassName::method()` |
| `interface.rs` | Add `static_methods: HashMap` to RustGenerator |

## Test plan
- [x] `test_equivalence_static_method` — MathUtils.add/multiply
- [x] `test_equivalence_static_and_instance` — Counter.create() + c.increment()
- [x] `cargo nextest run --workspace` — 172 passed (+2), 1 skipped
- [x] `cargo clippy --workspace -- -D warnings` — clean

Closes #60