### PR TITLE
docs: comprehensive sync — Phase 6 complete, 174 tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,6 @@ tests/
 
 See `docs/superpowers/plans/2026-03-12-full-refactoring-roadmap.md` for the complete plan.
 
-**Completed:** Chunks 1-7 + Milestones 13A/13B + Milestone 14 HIGH + CLI/IR/Analyzer evolution + Phase 6.0-6.4
-**Current:** Phase 6.4 complete — class inheritance (extends, super(), method override), spread, try-catch, top-level
-**Status:** 170 tests passing (67 equivalence + 8 IR + 7 CLI + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped)
+**Completed:** Chunks 1-7 + Milestones 13A/13B + Milestone 14 HIGH + CLI/IR/Analyzer evolution + Phase 6.0-6.6
+**Current:** Phase 6 COMPLETE — try-catch, top-level, spread, inheritance, static methods, type assertions, enums
+**Status:** 174 tests passing (71 equivalence + 8 IR + 7 CLI + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Adhering to strict "Safe Transpilation" principles:
 - **Top-Level Statements**: `const`, `let`, expressions auto-wrapped in `fn main()`
 - **Spread Operator**: `[...arr1, ...arr2]` → iterator chain
 - **Class Inheritance**: `extends`, `super()`, method override via field flattening
+- **Static Methods**: `static add()` → associated function, `Class.method()` → `Class::method()`
+- **Type Assertions**: `as Type` → no-op (compile-time only)
+- **Numeric Enums**: `enum Direction { Up = 0 }` → `#[repr(i32)] enum` with `Display`
 - **Operators**: Arithmetic, comparison, logical, `**` (exponentiation), `%` (modulo)
 - **Class State**: Automatic `Arc<Mutex<T>>` wrapping for services/controllers
 - **Interfaces**: `interface` -> `#[derive(Serialize, Deserialize)] struct`
@@ -161,11 +164,11 @@ tyrus --quiet check ./src/index.ts
 
 ## 🧪 Test Suite
 
-170 tests across 7 test types and 4 feature tiers:
+174 tests across 7 test types and 4 feature tiers:
 
 | Type | Count | Description |
 |------|-------|-------------|
-| **Equivalence** | 67 | Semantic proof: TS and Rust produce identical stdout |
+| **Equivalence** | 71 | Semantic proof: TS and Rust produce identical stdout |
 | **CLI** | 7 | Integration tests for all CLI commands and flags |
 | **Unit** | 27 | Fast, isolated codegen function tests |
 | **Snapshot** | 6 | Full transpilation output via `insta` |

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -67,6 +67,9 @@ Aderindo aos princípios estritos de "Transpilação Segura":
 - **Top-Level Statements**: `const`, `let`, expressões auto-wrapped em `fn main()`
 - **Spread Operator**: `[...arr1, ...arr2]` → iterator chain
 - **Herança de Classe**: `extends`, `super()`, override de métodos via field flattening
+- **Métodos Estáticos**: `static add()` → função associada, `Class.method()` → `Class::method()`
+- **Type Assertions**: `as Type` → no-op (apenas compile-time)
+- **Enums Numéricos**: `enum Direction { Up = 0 }` → `#[repr(i32)] enum` com `Display`
 - **Operadores**: Aritméticos, comparação, lógicos, `**` (exponenciação), `%` (módulo)
 - **Estado de Classe**: Encapsulamento automático com `Arc<Mutex<T>>` para services/controllers
 - **Interfaces**: `interface` -> `#[derive(Serialize, Deserialize)] struct`
@@ -155,11 +158,11 @@ tyrus --quiet check ./src/index.ts
 
 ## 🧪 Suite de Testes
 
-170 testes distribuídos em 7 tipos de teste e 4 camadas de funcionalidades:
+174 testes distribuídos em 7 tipos de teste e 4 camadas de funcionalidades:
 
 | Tipo | Quantidade | Descrição |
 |------|-----------|-----------|
-| **Equivalência** | 67 | Prova semântica: TS e Rust produzem stdout idêntico |
+| **Equivalência** | 71 | Prova semântica: TS e Rust produzem stdout idêntico |
 | **CLI** | 7 | Testes de integração para todos os comandos e flags |
 | **Unitário** | 27 | Rápido, funções isoladas de codegen |
 | **Snapshot** | 6 | Saída completa de transpilação via `insta` |

--- a/docs/superpowers/plans/2026-03-13-nestjs-full-transpilation-roadmap.md
+++ b/docs/superpowers/plans/2026-03-13-nestjs-full-transpilation-roadmap.md
@@ -718,7 +718,7 @@ impl Config {
 
 #### Tasks
 
-- [ ] **Task 6.5.1: Write failing test for static methods**
+- [x] **Task 6.5.1: Write failing test for static methods** ✓
 
   ```rust
   #[test]
@@ -738,14 +738,14 @@ impl Config {
   }
   ```
 
-- [ ] **Task 6.5.2: Implement static method detection**
+- [x] **Task 6.5.2: Implement static method detection** ✓
 
   In `class/method.rs`:
   - Check `method.is_static` flag
   - Static methods: no `&self` parameter, called as `Type::method()`
   - Static properties: `const` associated items in impl block
 
-- [ ] **Task 6.5.2b: Implement static call-site transformation**
+- [x] **Task 6.5.2b: Implement static call-site transformation** ✓
 
   In `crates/tyrus_codegen/src/convert/expr/member.rs`:
   - Detect `ClassName.staticField` → `ClassName::STATIC_FIELD`
@@ -797,7 +797,7 @@ impl Config {
 
 #### Tasks
 
-- [ ] **Task 6.6.1: Write test for type assertion**
+- [x] **Task 6.6.1: Write test for type assertion** ✓
 
   ```rust
   #[test]
@@ -814,7 +814,7 @@ impl Config {
   }
   ```
 
-- [ ] **Task 6.6.2: Implement as Type assertion**
+- [x] **Task 6.6.2: Implement as Type assertion** ✓
 
   `expr as Type` → In most cases, this is a no-op in Rust (types are already known). For `value as string`, generate `.to_string()`. For struct casts, generate type annotation.
 

--- a/docs/superpowers/plans/MASTER_PLAN.md
+++ b/docs/superpowers/plans/MASTER_PLAN.md
@@ -11,9 +11,12 @@
 
 | Metric | Value |
 |--------|-------|
-| Tests passing | 168 (65 equivalence + 7 CLI + 8 IR + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped) |
-| Equivalence tests | 65 (proving TS↔Rust output identity) |
+| Tests passing | 174 (71 equivalence + 7 CLI + 8 IR + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped) |
+| Equivalence tests | 71 (proving TS↔Rust output identity) |
 | Array spread | `[...a, ...b]` → `a.iter().cloned().chain(b.iter().cloned()).collect()` |
+| Static methods | `Class.method()` → `Class::method()` (associated functions) |
+| Type assertions | `as Type` → no-op (4 SWC variants handled) |
+| Numeric enums | `enum Dir { Up = 0 }` → `#[repr(i32)] enum` with Display |
 | Supported expressions | 16+ types |
 | Control flow | while, for, for-of, do-while, switch, if/else, try-catch |
 | Top-level statements | const, let, expressions, console.log — auto-wrapped in fn main() |
@@ -41,7 +44,7 @@ Phase 4 ✅ Control Flow    (Milestone 13B)    — Unlock blocked constructs + b
 Phase 5 ✅ Stdlib Complete (Milestone 14)     — Full JS/TS method coverage (ALL methods done)
 Phase 5.5 ✅ Architecture  (CLI+IR+Analyzer)  — Branded CLI, typed IR, expanded analyzer
 Phase 6.0 ✅ Infrastructure (prettyplease, thiserror 2.0, trybuild) — See docs/superpowers/plans/2026-03-13-nestjs-full-transpilation-roadmap.md
-Phase 6 📋 Advanced TS     (Milestone 15)     — Class inheritance, enums, advanced patterns
+Phase 6 ✅ Advanced TS     (Milestone 15)     — Class inheritance, static, enums, type assertions, spread
 Phase 7 📋 Academic        (Milestone 16)     — Benchmarks, formal spec, paper
 ```
 


### PR DESCRIPTION
## Summary

Full documentation sync after Phase 6 completion.

## What was out of sync

| Document | Was | Now |
|----------|-----|-----|
| README.md | 170 tests, missing 6.5-6.6 features | 174 tests, +static methods, +type assertions, +numeric enums |
| README.pt-br.md | 170 tests | 174 tests, same features in Portuguese |
| CLAUDE.md | Phase 6.4, 170 tests | Phase 6.6 complete, 174 tests |
| MASTER_PLAN.md | 168 tests, Phase 6 as 📋 | 174 tests, Phase 6 as ✅ |
| NestJS Roadmap | Tasks 6.5-6.6 unchecked | 6.5.1-6.5.2b + 6.6.1-6.6.2 marked [x] |

## Why this happened

Doc updates were being created as separate PRs based on feature branches, but some weren't merged before the feature PRs. This comprehensive sync catches everything up.

## Test plan
- [x] Documentation only
- [x] Pre-commit passed

Closes #67