### PR TITLE
feat: @Param and @Query decorator transpilation (Phase 7.1)

### DIFF
--- a/crates/tyrus_codegen/src/convert/class/method.rs
+++ b/crates/tyrus_codegen/src/convert/class/method.rs
@@ -82,6 +82,7 @@ impl RustGenerator {
                                 let dec_name = dec_ident.sym.as_ref();
                                 if matches!(dec_name, "Body" | "Param" | "Query") {
                                     param_decorator = Some(dec_name.to_string());
+                                    break;
                                 }
                             }
                         }

--- a/crates/tyrus_codegen/src/convert/class/method.rs
+++ b/crates/tyrus_codegen/src/convert/class/method.rs
@@ -72,26 +72,39 @@ impl RustGenerator {
                 let param_name = format_ident!("{}", to_snake_case(ident.sym.as_ref()));
                 let param_type = map_ts_type(ident.type_ann.as_ref());
 
-                // Check for @Body decorator on parameters
-                let mut is_body = false;
+                // Check for NestJS parameter decorators (@Body, @Param, @Query)
+                let mut param_decorator = None;
 
-                // Correctly check decorators on the Param node
                 for decorator in &param.decorators {
                     if let Expr::Call(call) = &*decorator.expr {
                         if let swc_ecma_ast::Callee::Expr(expr) = &call.callee {
-                            if let Expr::Ident(ident) = &**expr {
-                                if ident.sym == "Body" {
-                                    is_body = true;
+                            if let Expr::Ident(dec_ident) = &**expr {
+                                let dec_name = dec_ident.sym.as_ref();
+                                if matches!(dec_name, "Body" | "Param" | "Query") {
+                                    param_decorator = Some(dec_name.to_string());
                                 }
                             }
                         }
                     }
                 }
 
-                if is_body {
-                    params.push(quote! { axum::Json(#param_name): axum::Json<#param_type> });
-                } else {
-                    params.push(quote! { #param_name: #param_type });
+                match param_decorator.as_deref() {
+                    Some("Body") => {
+                        params.push(quote! { axum::Json(#param_name): axum::Json<#param_type> });
+                    }
+                    Some("Param") => {
+                        params.push(
+                            quote! { axum::extract::Path(#param_name): axum::extract::Path<#param_type> },
+                        );
+                    }
+                    Some("Query") => {
+                        params.push(
+                            quote! { axum::extract::Query(#param_name): axum::extract::Query<#param_type> },
+                        );
+                    }
+                    _ => {
+                        params.push(quote! { #param_name: #param_type });
+                    }
                 }
             }
         }

--- a/tests/src/unit/tier4_nestjs.rs
+++ b/tests/src/unit/tier4_nestjs.rs
@@ -48,3 +48,40 @@ fn test_controller_handler_uses_json() {
         "Expected 'Json' extractor in: {rust}"
     );
 }
+
+#[test]
+fn test_param_decorator_generates_path_extractor() {
+    let rust = crate::helpers::transpile(
+        r#"
+import { Controller, Get, Param } from "@nestjs/common";
+@Controller("/users")
+class UsersController {
+    @Get(":id")
+    findOne(@Param("id") id: string): string {
+        return id;
+    }
+}
+"#,
+    );
+    assert!(rust.contains("Path("), "Expected Path extractor in: {rust}");
+}
+
+#[test]
+fn test_query_decorator_generates_query_extractor() {
+    let rust = crate::helpers::transpile(
+        r#"
+import { Controller, Get, Query } from "@nestjs/common";
+@Controller("/items")
+class ItemsController {
+    @Get("/")
+    search(@Query("q") q: string): string {
+        return q;
+    }
+}
+"#,
+    );
+    assert!(
+        rust.contains("Query("),
+        "Expected Query extractor in: {rust}"
+    );
+}


### PR DESCRIPTION
## Summary

NestJS parameter decorators now transpile to Axum extractors.

## Mapping

| NestJS Decorator | Axum Extractor | Example |
|-----------------|---------------|---------|
| `@Body() dto: Type` | `Json(dto): Json<Type>` | POST body |
| `@Param('id') id: string` | `Path(id): Path<String>` | Route param `/users/:id` |
| `@Query('page') page: string` | `Query(page): Query<String>` | Query string `?page=1` |

## Generated Output

```typescript
@Get(':id')
findOne(@Param('id') id: string): User { ... }
```
→
```rust
pub async fn find_one(self, Path(id): Path<String>) -> Result<Json<User>, AppError> { ... }
// Route: .route("/users/:id", get(Self::find_one))
```

## Test plan
- [x] `cargo nextest run --workspace` — 174 passed, 1 skipped
- [x] `cargo clippy --workspace -- -D warnings` — clean

Closes #66