### PR TITLE
feat: NestJS HttpException → AppError mapping (Phase 7.3)

### DIFF
--- a/crates/tyrus_codegen/src/convert/stmt/mod.rs
+++ b/crates/tyrus_codegen/src/convert/stmt/mod.rs
@@ -14,6 +14,20 @@ use swc_ecma_ast::*;
 
 use super::interface::RustGenerator;
 
+/// Map NestJS exception class names to AppError variant names.
+fn nestjs_exception_to_app_error(class_name: &str) -> Option<&'static str> {
+    match class_name {
+        "NotFoundException" => Some("NotFound"),
+        "BadRequestException" => Some("BadRequest"),
+        "UnauthorizedException" => Some("Unauthorized"),
+        "ForbiddenException" => Some("Forbidden"),
+        "ConflictException" => Some("Conflict"),
+        "InternalServerErrorException" => Some("Internal"),
+        "Error" => None, // generic Error, use default handling
+        _ => None,
+    }
+}
+
 impl RustGenerator {
     /// Recursively convert statements with a custom return handler.
     /// Used by process_fn_decl to inject Result wrapping for async functions.
@@ -108,11 +122,35 @@ impl RustGenerator {
             Stmt::DoWhile(do_while) => self.convert_do_while_stmt(do_while),
             Stmt::Switch(switch_stmt) => self.convert_switch_stmt(switch_stmt),
             Stmt::Try(try_stmt) => self.convert_try_stmt(try_stmt),
-            Stmt::Throw(throw_stmt) => {
-                let arg = self.convert_expr(&throw_stmt.arg);
-                quote! { return Err(#arg.into()); }
-            }
+            Stmt::Throw(throw_stmt) => self.convert_throw(&throw_stmt.arg),
             _ => quote! { /* other stmts todo */ },
         }
+    }
+
+    /// Convert a throw statement, mapping NestJS exceptions to AppError variants.
+    fn convert_throw(&self, arg: &swc_ecma_ast::Expr) -> TokenStream {
+        // Detect: throw new XxxException("msg")
+        if let swc_ecma_ast::Expr::New(new_expr) = arg {
+            if let swc_ecma_ast::Expr::Ident(ident) = &*new_expr.callee {
+                let class_name = ident.sym.as_ref();
+
+                if let Some(variant) = nestjs_exception_to_app_error(class_name) {
+                    let variant_ident = quote::format_ident!("{}", variant);
+                    let msg = new_expr
+                        .args
+                        .as_ref()
+                        .and_then(|args| args.first())
+                        .map(|a| self.convert_expr(&a.expr))
+                        .unwrap_or_else(|| quote! { String::new() });
+                    return quote! {
+                        return Err(AppError::#variant_ident(#msg.to_string()));
+                    };
+                }
+            }
+        }
+
+        // Default: throw X → return Err(X.into())
+        let expr = self.convert_expr(arg);
+        quote! { return Err(#expr.into()); }
     }
 }

--- a/tests/src/unit/tier4_nestjs.rs
+++ b/tests/src/unit/tier4_nestjs.rs
@@ -85,3 +85,35 @@ class ItemsController {
         "Expected Query extractor in: {rust}"
     );
 }
+
+#[test]
+fn test_nestjs_not_found_exception_maps_to_app_error() {
+    let rust = crate::helpers::transpile(
+        r#"
+import { NotFoundException } from "@nestjs/common";
+function findUser(id: string): string {
+    throw new NotFoundException("User not found");
+}
+"#,
+    );
+    assert!(
+        rust.contains("AppError") && rust.contains("NotFound"),
+        "Expected AppError::NotFound in: {rust}"
+    );
+}
+
+#[test]
+fn test_nestjs_bad_request_exception_maps_to_app_error() {
+    let rust = crate::helpers::transpile(
+        r#"
+import { BadRequestException } from "@nestjs/common";
+function validate(input: string): string {
+    throw new BadRequestException("Invalid input");
+}
+"#,
+    );
+    assert!(
+        rust.contains("AppError") && rust.contains("BadRequest"),
+        "Expected AppError::BadRequest in: {rust}"
+    );
+}


### PR DESCRIPTION
## Summary

NestJS typed exceptions now map to Axum AppError variants.

## Mapping

| NestJS Exception | AppError Variant | HTTP Code |
|-----------------|-----------------|-----------|
| `NotFoundException` | `AppError::NotFound` | 404 |
| `BadRequestException` | `AppError::BadRequest` | 400 |
| `UnauthorizedException` | `AppError::Unauthorized` | 401 |
| `ForbiddenException` | `AppError::Forbidden` | 403 |
| `ConflictException` | `AppError::Conflict` | 409 |
| `InternalServerErrorException` | `AppError::Internal` | 500 |

## Generated Output

```typescript
throw new NotFoundException("User not found");
```
→
```rust
return Err(AppError::NotFound("User not found".to_string()));
```

## Test plan
- [x] `test_nestjs_not_found_exception_maps_to_app_error`
- [x] `test_nestjs_bad_request_exception_maps_to_app_error`
- [x] `cargo nextest run --workspace` — 178 passed, 1 skipped
- [x] `cargo clippy --workspace -- -D warnings` — clean

Closes #72