### PR TITLE
refactor: split all large functions — 18 violations → 10 remaining

### DIFF
--- a/crates/tyrus_codegen/src/convert/class/constructor.rs
+++ b/crates/tyrus_codegen/src/convert/class/constructor.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use quote::{format_ident, quote};
 use swc_ecma_ast::{AssignTarget, Constructor, Expr, ExprStmt, Pat, Stmt};
 
@@ -5,339 +7,450 @@ use crate::convert::helpers::to_snake_case;
 use crate::convert::interface::RustGenerator;
 use crate::convert::type_mapper::map_ts_type;
 
+/// Context for constructor conversion, replacing many positional arguments.
+pub(crate) struct ConstructorCtx<'a> {
+    pub(crate) constructor: &'a Constructor,
+    pub(crate) class_fields: &'a [(String, bool)],
+    pub(crate) has_generics: bool,
+    pub(crate) generic_params: &'a HashSet<String>,
+    pub(crate) dependency_fields: &'a HashSet<String>,
+    pub(crate) is_service_or_controller: bool,
+}
+
+/// Check whether a type annotation refers to a dependency (non-primitive TypeRef).
+fn is_dependency_type(
+    type_ann: Option<&swc_ecma_ast::TsTypeAnn>,
+    generic_params: &HashSet<String>,
+) -> bool {
+    let ann = match type_ann {
+        Some(a) => a,
+        None => return false,
+    };
+    let type_ref = match ann.type_ann.as_ts_type_ref() {
+        Some(r) => r,
+        None => return false,
+    };
+    match type_ref.type_name.as_ident() {
+        Some(ident) => {
+            let name = ident.sym.as_str();
+            if generic_params.contains(name) {
+                return false;
+            }
+            !matches!(
+                name,
+                "String" | "f64" | "bool" | "i32" | "Vec" | "Option" | "Array"
+            )
+        }
+        None => true,
+    }
+}
+
+/// Result of extracting constructor parameters from `TsParamProp` and `Param` nodes.
+struct ExtractedParams {
+    params: Vec<proc_macro2::TokenStream>,
+    dependency_params: HashSet<String>,
+    initialized_fields: HashSet<String>,
+    field_inits: Vec<proc_macro2::TokenStream>,
+}
+
+/// Extract constructor parameters and auto-field-inits from `TsParamProp` / `Param` nodes.
+fn extract_constructor_params(
+    constructor: &Constructor,
+    generic_params: &HashSet<String>,
+) -> ExtractedParams {
+    let mut result = ExtractedParams {
+        params: Vec::new(),
+        dependency_params: HashSet::new(),
+        initialized_fields: HashSet::new(),
+        field_inits: Vec::new(),
+    };
+
+    for param in &constructor.params {
+        match param {
+            swc_ecma_ast::ParamOrTsParamProp::TsParamProp(prop) => {
+                extract_ts_param_prop(prop, generic_params, &mut result);
+            }
+            swc_ecma_ast::ParamOrTsParamProp::Param(pat_param) => {
+                extract_plain_param(pat_param, generic_params, &mut result);
+            }
+        }
+    }
+
+    result
+}
+
+/// Handle a `TsParamProp` — creates both a parameter and a field initializer.
+fn extract_ts_param_prop(
+    prop: &swc_ecma_ast::TsParamProp,
+    generic_params: &HashSet<String>,
+    result: &mut ExtractedParams,
+) {
+    let ident = match &prop.param {
+        swc_ecma_ast::TsParamPropParam::Ident(id) => id,
+        _ => return,
+    };
+
+    let param_name_str = ident.sym.to_string();
+    let param_name = format_ident!("{}", to_snake_case(&param_name_str));
+    let type_ann = ident.type_ann.as_ref();
+    let mut param_type = map_ts_type(type_ann);
+
+    if is_dependency_type(type_ann.map(std::convert::AsRef::as_ref), generic_params) {
+        param_type = quote! { std::sync::Arc<#param_type> };
+        result.dependency_params.insert(param_name_str.clone());
+    }
+
+    result.params.push(quote! { #param_name: #param_type });
+    result.field_inits.push(quote! { #param_name: #param_name });
+    result.initialized_fields.insert(param_name_str);
+}
+
+/// Handle a plain `Param` — creates a parameter but no auto-field-init.
+fn extract_plain_param(
+    pat_param: &swc_ecma_ast::Param,
+    generic_params: &HashSet<String>,
+    result: &mut ExtractedParams,
+) {
+    let ident = match &pat_param.pat {
+        Pat::Ident(id) => id,
+        _ => return,
+    };
+
+    let param_name = format_ident!("{}", to_snake_case(ident.sym.as_ref()));
+    let mut param_type = map_ts_type(ident.type_ann.as_ref());
+
+    if is_dependency_type(ident.type_ann.as_deref(), generic_params) {
+        param_type = quote! { std::sync::Arc<#param_type> };
+        result.dependency_params.insert(ident.sym.to_string());
+    }
+
+    result.params.push(quote! { #param_name: #param_type });
+}
+
+/// Context for extracting field initializations from the constructor body.
+struct FieldInitCtx<'a> {
+    class_fields: &'a [(String, bool)],
+    dependency_fields: &'a HashSet<String>,
+    dependency_params: &'a HashSet<String>,
+    is_service_or_controller: bool,
+}
+
+/// Extract field assignments (`this.field = value`) and `super()` calls from the body.
+fn extract_field_inits(
+    generator: &RustGenerator,
+    constructor: &Constructor,
+    ctx: &FieldInitCtx<'_>,
+    field_inits: &mut Vec<proc_macro2::TokenStream>,
+    initialized_fields: &mut HashSet<String>,
+) {
+    let body = match &constructor.body {
+        Some(b) => b,
+        None => return,
+    };
+
+    for stmt in &body.stmts {
+        let expr_stmt = match stmt {
+            Stmt::Expr(ExprStmt { expr, .. }) => expr,
+            _ => continue,
+        };
+
+        if let Expr::Call(call) = &**expr_stmt {
+            if let swc_ecma_ast::Callee::Super(_) = &call.callee {
+                extract_super_call(
+                    generator,
+                    call,
+                    ctx.class_fields,
+                    field_inits,
+                    initialized_fields,
+                );
+                continue;
+            }
+        }
+
+        if let Expr::Assign(assign) = &**expr_stmt {
+            extract_this_assign(generator, assign, ctx, field_inits, initialized_fields);
+        }
+    }
+}
+
+/// Map `super(args)` arguments to parent fields by position.
+fn extract_super_call(
+    generator: &RustGenerator,
+    call: &swc_ecma_ast::CallExpr,
+    class_fields: &[(String, bool)],
+    field_inits: &mut Vec<proc_macro2::TokenStream>,
+    initialized_fields: &mut HashSet<String>,
+) {
+    let parent_fields: Vec<&String> = class_fields
+        .iter()
+        .filter(|(name, _)| !initialized_fields.contains(name.as_str()))
+        .map(|(n, _)| n)
+        .collect();
+
+    for (idx, arg) in call.args.iter().enumerate() {
+        if idx < parent_fields.len() {
+            let field_name_str = parent_fields[idx];
+            let field_name = format_ident!("{}", to_snake_case(field_name_str));
+            let value = generator.convert_expr(&arg.expr);
+            field_inits.push(quote! { #field_name: #value });
+            initialized_fields.insert(field_name_str.clone());
+        }
+    }
+}
+
+/// Extract a `this.field = value` assignment into a field initializer.
+fn extract_this_assign(
+    generator: &RustGenerator,
+    assign: &swc_ecma_ast::AssignExpr,
+    ctx: &FieldInitCtx<'_>,
+    field_inits: &mut Vec<proc_macro2::TokenStream>,
+    initialized_fields: &mut HashSet<String>,
+) {
+    let simple = match &assign.left {
+        AssignTarget::Simple(s) => s,
+        _ => return,
+    };
+    let member = match simple.as_member() {
+        Some(m) if m.obj.is_this() => m,
+        _ => return,
+    };
+    let prop_ident = match member.prop.as_ident() {
+        Some(id) => id,
+        None => return,
+    };
+
+    let field_name_str = prop_ident.sym.to_string();
+    let field_name = format_ident!("{}", to_snake_case(&field_name_str));
+    let value = generator.convert_expr(&assign.right);
+
+    let is_optional = ctx
+        .class_fields
+        .iter()
+        .find(|(n, _)| n == &field_name_str)
+        .map(|(_, opt)| *opt)
+        .unwrap_or(false);
+
+    let value = if is_optional {
+        quote! { Some(#value) }
+    } else {
+        value
+    };
+
+    let value = wrap_field_value(&assign.right, &field_name_str, &value, ctx);
+
+    field_inits.push(quote! { #field_name: #value });
+    initialized_fields.insert(field_name_str);
+}
+
+/// Wrap a field value in Arc / Arc<Mutex> as needed.
+fn wrap_field_value(
+    rhs: &Expr,
+    field_name_str: &str,
+    value: &proc_macro2::TokenStream,
+    ctx: &FieldInitCtx<'_>,
+) -> proc_macro2::TokenStream {
+    if ctx.dependency_fields.contains(field_name_str) {
+        let is_already_wrapped = if let Expr::Ident(ident) = rhs {
+            ctx.dependency_params.contains(&ident.sym.to_string())
+        } else {
+            false
+        };
+        if is_already_wrapped {
+            value.clone()
+        } else {
+            quote! { std::sync::Arc::new(#value) }
+        }
+    } else if ctx.is_service_or_controller {
+        quote! { std::sync::Arc::new(std::sync::Mutex::new(#value)) }
+    } else {
+        value.clone()
+    }
+}
+
+/// Fill missing optional fields with `None` and add `PhantomData` if generic.
+fn fill_missing_fields(
+    class_fields: &[(String, bool)],
+    has_generics: bool,
+    initialized_fields: &HashSet<String>,
+    field_inits: &mut Vec<proc_macro2::TokenStream>,
+) {
+    for (name, is_optional) in class_fields {
+        if *is_optional && !initialized_fields.contains(name) {
+            let field_name = format_ident!("{}", to_snake_case(name));
+            field_inits.push(quote! { #field_name: None });
+        }
+    }
+    if has_generics {
+        field_inits.push(quote! { _marker: std::marker::PhantomData });
+    }
+}
+
+/// Build the `new_di(...)` DI constructor from constructor params.
+fn build_di_constructor(
+    constructor: &Constructor,
+    ctx: &ConstructorCtx<'_>,
+) -> proc_macro2::TokenStream {
+    let mut di_params = Vec::new();
+    let mut di_field_inits = Vec::new();
+    let mut di_initialized = HashSet::new();
+
+    for param in &constructor.params {
+        match param {
+            swc_ecma_ast::ParamOrTsParamProp::TsParamProp(prop) => {
+                build_di_ts_param(
+                    prop,
+                    ctx.generic_params,
+                    &mut di_params,
+                    &mut di_field_inits,
+                    &mut di_initialized,
+                );
+            }
+            swc_ecma_ast::ParamOrTsParamProp::Param(pat_param) => {
+                build_di_plain_param(
+                    pat_param,
+                    ctx,
+                    &mut di_params,
+                    &mut di_field_inits,
+                    &mut di_initialized,
+                );
+            }
+        }
+    }
+
+    if ctx.has_generics {
+        di_field_inits.push(quote! { _marker: std::marker::PhantomData });
+    }
+
+    fill_di_defaults(
+        ctx.class_fields,
+        ctx.is_service_or_controller,
+        &di_initialized,
+        &mut di_field_inits,
+    );
+
+    quote! {
+        pub fn new_di(#(#di_params),*) -> Self {
+            Self {
+                #(#di_field_inits),*
+            }
+        }
+    }
+}
+
+/// Process a `TsParamProp` for the DI constructor.
+fn build_di_ts_param(
+    prop: &swc_ecma_ast::TsParamProp,
+    generic_params: &HashSet<String>,
+    di_params: &mut Vec<proc_macro2::TokenStream>,
+    di_field_inits: &mut Vec<proc_macro2::TokenStream>,
+    di_initialized: &mut HashSet<String>,
+) {
+    let ident = match &prop.param {
+        swc_ecma_ast::TsParamPropParam::Ident(id) => id,
+        _ => return,
+    };
+
+    let param_name_str = ident.sym.to_string();
+    let param_name = format_ident!("{}", to_snake_case(&param_name_str));
+    let type_ann = ident.type_ann.as_ref();
+    let mut param_type = map_ts_type(type_ann);
+
+    if is_dependency_type(type_ann.map(std::convert::AsRef::as_ref), generic_params) {
+        param_type = quote! { std::sync::Arc<#param_type> };
+    }
+
+    di_params.push(quote! { #param_name: #param_type });
+    di_field_inits.push(quote! { #param_name: #param_name });
+    di_initialized.insert(param_name_str);
+}
+
+/// Process a plain `Param` for the DI constructor.
+fn build_di_plain_param(
+    pat_param: &swc_ecma_ast::Param,
+    ctx: &ConstructorCtx<'_>,
+    di_params: &mut Vec<proc_macro2::TokenStream>,
+    di_field_inits: &mut Vec<proc_macro2::TokenStream>,
+    di_initialized: &mut HashSet<String>,
+) {
+    let ident = match &pat_param.pat {
+        Pat::Ident(id) => id,
+        _ => return,
+    };
+
+    let param_name_str = ident.sym.to_string();
+    let param_name = format_ident!("{}", &param_name_str);
+    let param_type = map_ts_type(ident.type_ann.as_ref());
+
+    if !is_dependency_type(ident.type_ann.as_deref(), ctx.generic_params) {
+        return;
+    }
+
+    let arc_type = quote! { std::sync::Arc<#param_type> };
+    di_params.push(quote! { #param_name: #arc_type });
+
+    if ctx.class_fields.iter().any(|(n, _)| n == &param_name_str) {
+        di_field_inits.push(quote! { #param_name: #param_name });
+        di_initialized.insert(param_name_str);
+    }
+}
+
+/// Fill uninitialized DI fields with `Default::default()`.
+fn fill_di_defaults(
+    class_fields: &[(String, bool)],
+    is_service_or_controller: bool,
+    di_initialized: &HashSet<String>,
+    di_field_inits: &mut Vec<proc_macro2::TokenStream>,
+) {
+    for (name, _) in class_fields {
+        if !di_initialized.contains(name) {
+            let field_name = format_ident!("{}", to_snake_case(name));
+            if is_service_or_controller {
+                di_field_inits.push(
+                    quote! { #field_name: std::sync::Arc::new(std::sync::Mutex::new(Default::default())) },
+                );
+            } else {
+                di_field_inits.push(quote! { #field_name: Default::default() });
+            }
+        }
+    }
+}
+
 impl RustGenerator {
-    #[allow(clippy::too_many_arguments)]
+    /// Dispatcher: convert a TypeScript constructor into `new()` + `new_di()` methods.
     pub(crate) fn convert_constructor(
         &self,
         _struct_name: &proc_macro2::Ident,
-        constructor: &Constructor,
-        class_fields: &[(String, bool)],
-        has_generics: bool,
-        generic_params: &std::collections::HashSet<String>,
-        dependency_fields: &std::collections::HashSet<String>,
-        is_service_or_controller: bool,
+        ctx: &ConstructorCtx<'_>,
     ) -> proc_macro2::TokenStream {
-        let mut params = Vec::new();
-        let mut field_inits = Vec::new();
-        let mut initialized_fields = std::collections::HashSet::new();
-        let mut dependency_params: std::collections::HashSet<String> =
-            std::collections::HashSet::new();
+        let mut extracted = extract_constructor_params(ctx.constructor, ctx.generic_params);
 
-        for param in &constructor.params {
-            match param {
-                swc_ecma_ast::ParamOrTsParamProp::TsParamProp(prop) => {
-                    if let swc_ecma_ast::TsParamPropParam::Ident(ident) = &prop.param {
-                        let param_name_str = ident.sym.to_string();
-                        let param_name = format_ident!("{}", to_snake_case(&param_name_str));
+        let init_ctx = FieldInitCtx {
+            class_fields: ctx.class_fields,
+            dependency_fields: ctx.dependency_fields,
+            dependency_params: &extracted.dependency_params,
+            is_service_or_controller: ctx.is_service_or_controller,
+        };
 
-                        let type_ann = ident.type_ann.as_ref();
-                        let mut param_type = map_ts_type(type_ann);
+        extract_field_inits(
+            self,
+            ctx.constructor,
+            &init_ctx,
+            &mut extracted.field_inits,
+            &mut extracted.initialized_fields,
+        );
 
-                        // Heuristic: If it's a TypeRef (not primitive), wrap in Arc
-                        let is_dependency = if let Some(ann) = type_ann {
-                            if let Some(type_ref) = ann.type_ann.as_ts_type_ref() {
-                                if let Some(ident) = type_ref.type_name.as_ident() {
-                                    let name = ident.sym.as_str();
-                                    if generic_params.contains(name) {
-                                        false
-                                    } else {
-                                        !matches!(
-                                            name,
-                                            "String"
-                                                | "f64"
-                                                | "bool"
-                                                | "i32"
-                                                | "Vec"
-                                                | "Option"
-                                                | "Array"
-                                        )
-                                    }
-                                } else {
-                                    true
-                                }
-                            } else {
-                                false
-                            }
-                        } else {
-                            false
-                        };
+        fill_missing_fields(
+            ctx.class_fields,
+            ctx.has_generics,
+            &extracted.initialized_fields,
+            &mut extracted.field_inits,
+        );
 
-                        if is_dependency {
-                            param_type = quote! { std::sync::Arc<#param_type> };
-                            dependency_params.insert(param_name_str.clone());
-                        }
-
-                        params.push(quote! { #param_name: #param_type });
-                        field_inits.push(quote! { #param_name: #param_name });
-                        initialized_fields.insert(param_name_str);
-                    }
-                }
-                swc_ecma_ast::ParamOrTsParamProp::Param(pat_param) => {
-                    if let Pat::Ident(ident) = &pat_param.pat {
-                        let param_name = format_ident!("{}", to_snake_case(ident.sym.as_ref()));
-                        let mut param_type = map_ts_type(ident.type_ann.as_ref());
-
-                        // Check dependency
-                        let is_dependency = if let Some(ann) = ident.type_ann.as_ref() {
-                            if let Some(type_ref) = ann.type_ann.as_ts_type_ref() {
-                                if let Some(ident) = type_ref.type_name.as_ident() {
-                                    let name = ident.sym.as_str();
-                                    if generic_params.contains(name) {
-                                        false
-                                    } else {
-                                        !matches!(
-                                            name,
-                                            "String"
-                                                | "f64"
-                                                | "bool"
-                                                | "i32"
-                                                | "Vec"
-                                                | "Option"
-                                                | "Array"
-                                        )
-                                    }
-                                } else {
-                                    true
-                                }
-                            } else {
-                                false
-                            }
-                        } else {
-                            false
-                        };
-
-                        if is_dependency {
-                            param_type = quote! { std::sync::Arc<#param_type> };
-                            dependency_params.insert(ident.sym.to_string());
-                        }
-
-                        params.push(quote! { #param_name: #param_type });
-                    }
-                }
-            }
-        }
-
-        // Try to extract field assignments from constructor body
-        if let Some(body) = &constructor.body {
-            for stmt in &body.stmts {
-                if let Stmt::Expr(ExprStmt { expr, .. }) = stmt {
-                    // Handle super(args) — map args to parent field initializations
-                    if let Expr::Call(call) = &**expr {
-                        if let swc_ecma_ast::Callee::Super(_) = &call.callee {
-                            // Map super() arguments to parent fields by position
-                            let parent_fields: Vec<(String, String)> = class_fields
-                                .iter()
-                                .filter(|(name, _)| !initialized_fields.contains(name.as_str()))
-                                .map(|(n, _)| (n.clone(), String::new()))
-                                .collect();
-
-                            for (idx, arg) in call.args.iter().enumerate() {
-                                if idx < parent_fields.len() {
-                                    let field_name_str = &parent_fields[idx].0;
-                                    let field_name =
-                                        format_ident!("{}", to_snake_case(field_name_str));
-                                    let value = self.convert_expr(&arg.expr);
-                                    field_inits.push(quote! { #field_name: #value });
-                                    initialized_fields.insert(field_name_str.clone());
-                                }
-                            }
-                            continue;
-                        }
-                    }
-
-                    if let Expr::Assign(assign) = &**expr {
-                        // Check if left side is this.field
-                        if let AssignTarget::Simple(simple) = &assign.left {
-                            if let Some(member) = simple.as_member() {
-                                if member.obj.is_this() {
-                                    if let Some(prop_ident) = member.prop.as_ident() {
-                                        let field_name_str = prop_ident.sym.to_string();
-                                        let field_name =
-                                            format_ident!("{}", to_snake_case(&field_name_str));
-                                        let value = self.convert_expr(&assign.right);
-
-                                        let is_optional = class_fields
-                                            .iter()
-                                            .find(|(n, _)| n == &field_name_str)
-                                            .map(|(_, opt)| *opt)
-                                            .unwrap_or(false);
-
-                                        let value = if is_optional {
-                                            quote! { Some(#value) }
-                                        } else {
-                                            value
-                                        };
-
-                                        let value = if dependency_fields.contains(&field_name_str) {
-                                            // Check if the assigned value is a parameter that is already a dependency
-                                            let is_already_wrapped = if let Expr::Ident(ident) =
-                                                &*assign.right
-                                            {
-                                                dependency_params.contains(&ident.sym.to_string())
-                                            } else {
-                                                false
-                                            };
-
-                                            if is_already_wrapped {
-                                                value
-                                            } else {
-                                                quote! { std::sync::Arc::new(#value) }
-                                            }
-                                        } else if is_service_or_controller {
-                                            // State field: Wrap in Arc::new(Mutex::new(value))
-                                            quote! { std::sync::Arc::new(std::sync::Mutex::new(#value)) }
-                                        } else {
-                                            // Plain field initialization
-                                            value
-                                        };
-
-                                        field_inits.push(quote! { #field_name: #value });
-                                        initialized_fields.insert(field_name_str);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Fill in missing optional fields with None
-        for (name, is_optional) in class_fields {
-            if *is_optional && !initialized_fields.contains(name) {
-                let field_name = format_ident!("{}", to_snake_case(name));
-                field_inits.push(quote! { #field_name: None });
-            }
-        }
-
-        // Initialize _marker if generics exist
-        if has_generics {
-            field_inits.push(quote! { _marker: std::marker::PhantomData });
-        }
+        let params = &extracted.params;
+        let field_inits = &extracted.field_inits;
 
         if !field_inits.is_empty() {
-            // Generate new_di (Dependency Injection constructor)
-            // It takes only dependencies and defaults primitives
-            let mut di_params = Vec::new();
-            let mut di_field_inits = Vec::new();
-            let mut di_initialized_fields = std::collections::HashSet::new();
-
-            for param in &constructor.params {
-                match param {
-                    swc_ecma_ast::ParamOrTsParamProp::TsParamProp(prop) => {
-                        if let swc_ecma_ast::TsParamPropParam::Ident(ident) = &prop.param {
-                            let param_name_str = ident.sym.to_string();
-                            let param_name = format_ident!("{}", to_snake_case(&param_name_str));
-                            let type_ann = ident.type_ann.as_ref();
-                            let mut param_type = map_ts_type(type_ann);
-
-                            // Check if it's a dependency (not primitive/std type)
-                            let is_dependency = if let Some(ann) = type_ann {
-                                if let Some(type_ref) = ann.type_ann.as_ts_type_ref() {
-                                    if let Some(ident) = type_ref.type_name.as_ident() {
-                                        let name = ident.sym.as_str();
-                                        if generic_params.contains(name) {
-                                            false
-                                        } else {
-                                            !matches!(
-                                                name,
-                                                "String"
-                                                    | "f64"
-                                                    | "bool"
-                                                    | "i32"
-                                                    | "Vec"
-                                                    | "Option"
-                                                    | "Array"
-                                            )
-                                        }
-                                    } else {
-                                        true
-                                    }
-                                } else {
-                                    false
-                                }
-                            } else {
-                                false
-                            };
-
-                            if is_dependency {
-                                param_type = quote! { std::sync::Arc<#param_type> };
-                                di_params.push(quote! { #param_name: #param_type });
-                                di_field_inits.push(quote! { #param_name: #param_name });
-                            } else {
-                                di_params.push(quote! { #param_name: #param_type });
-                                di_field_inits.push(quote! { #param_name: #param_name });
-                            }
-                            // Always mark as initialized for TsParamProp as it creates a field
-                            di_initialized_fields.insert(ident.sym.to_string());
-                        }
-                    }
-                    swc_ecma_ast::ParamOrTsParamProp::Param(pat_param) => {
-                        if let Pat::Ident(ident) = &pat_param.pat {
-                            let param_name_str = ident.sym.to_string();
-                            let param_name = format_ident!("{}", param_name_str);
-                            let param_type = map_ts_type(ident.type_ann.as_ref());
-
-                            // Check dependency using same logic
-                            let is_dependency = if let Some(ann) = ident.type_ann.as_ref() {
-                                if let Some(type_ref) = ann.type_ann.as_ts_type_ref() {
-                                    if let Some(ident) = type_ref.type_name.as_ident() {
-                                        let name = ident.sym.as_str();
-                                        if generic_params.contains(name) {
-                                            false
-                                        } else {
-                                            !matches!(
-                                                name,
-                                                "String"
-                                                    | "f64"
-                                                    | "bool"
-                                                    | "i32"
-                                                    | "Vec"
-                                                    | "Option"
-                                                    | "Array"
-                                            )
-                                        }
-                                    } else {
-                                        true
-                                    }
-                                } else {
-                                    false
-                                }
-                            } else {
-                                false
-                            };
-
-                            if is_dependency {
-                                let arc_type = quote! { std::sync::Arc<#param_type> };
-                                di_params.push(quote! { #param_name: #arc_type });
-
-                                // If this param matches a class field, initialize it
-                                if class_fields.iter().any(|(n, _)| n == &param_name_str) {
-                                    di_field_inits.push(quote! { #param_name: #param_name });
-                                    di_initialized_fields.insert(param_name_str);
-                                }
-                            }
-                            // If not dependency, we don't add to params, and we don't add to inits.
-                            // We also do NOT add to di_initialized_fields, so it gets Default::default() later.
-                        }
-                    }
-                }
-            }
-
-            if has_generics {
-                di_field_inits.push(quote! { _marker: std::marker::PhantomData });
-            }
-
-            for (name, _) in class_fields {
-                if !di_initialized_fields.contains(name) {
-                    let field_name = format_ident!("{}", to_snake_case(name));
-                    if is_service_or_controller {
-                        di_field_inits.push(quote! { #field_name: std::sync::Arc::new(std::sync::Mutex::new(Default::default())) });
-                    } else {
-                        di_field_inits.push(quote! { #field_name: Default::default() });
-                    }
-                }
-            }
+            let di_tokens = build_di_constructor(ctx.constructor, ctx);
 
             quote! {
                 pub fn new(#(#params),*) -> Self {
@@ -346,14 +459,9 @@ impl RustGenerator {
                     }
                 }
 
-                pub fn new_di(#(#di_params),*) -> Self {
-                    Self {
-                        #(#di_field_inits),*
-                    }
-                }
+                #di_tokens
             }
         } else {
-            // Fallback if we can't parse constructor body
             quote! {
                 pub fn new(#(#params),*) -> Self {
                     compile_error!("Tyrus: complex constructor pattern not yet supported")

--- a/crates/tyrus_codegen/src/convert/class/method.rs
+++ b/crates/tyrus_codegen/src/convert/class/method.rs
@@ -5,7 +5,366 @@ use crate::convert::helpers::to_snake_case;
 use crate::convert::interface::RustGenerator;
 use crate::convert::type_mapper::{is_optional_type, map_ts_type};
 
+/// Extracted decorator metadata from a class method.
+struct MethodDecorators {
+    http_method: Option<String>,
+    route_path: String,
+    http_code: Option<u16>,
+}
+
+/// Context flags computed from decorators and method properties.
+struct MethodContext {
+    is_handler: bool,
+    is_static: bool,
+    is_async: bool,
+    http_code: Option<u16>,
+    returns_option: bool,
+}
+
+/// Scans method decorators for @Get/@Post/@Put/@Delete/@Patch and @HttpCode.
+fn extract_method_decorators(method: &swc_ecma_ast::ClassMethod) -> MethodDecorators {
+    let mut http_method = None;
+    let mut route_path = String::new();
+    let mut http_code: Option<u16> = None;
+
+    for decorator in &method.function.decorators {
+        if let Expr::Call(call) = &*decorator.expr {
+            if let swc_ecma_ast::Callee::Expr(expr) = &call.callee {
+                if let Expr::Ident(ident) = &**expr {
+                    extract_single_decorator(
+                        ident.sym.as_str(),
+                        call,
+                        &mut http_method,
+                        &mut route_path,
+                        &mut http_code,
+                    );
+                }
+            }
+        }
+    }
+
+    MethodDecorators {
+        http_method,
+        route_path,
+        http_code,
+    }
+}
+
+/// Processes a single decorator call to extract HTTP method or status code.
+fn extract_single_decorator(
+    name: &str,
+    call: &swc_ecma_ast::CallExpr,
+    http_method: &mut Option<String>,
+    route_path: &mut String,
+    http_code: &mut Option<u16>,
+) {
+    if matches!(name, "Get" | "Post" | "Put" | "Delete" | "Patch") {
+        *http_method = Some(name.to_string());
+        if let Some(arg) = call.args.first() {
+            if let Expr::Lit(Lit::Str(s)) = &*arg.expr {
+                *route_path = s.value.as_str().unwrap_or_default().to_string();
+            }
+        }
+    } else if name == "HttpCode" {
+        if let Some(arg) = call.args.first() {
+            if let Expr::Lit(Lit::Num(num)) = &*arg.expr {
+                *http_code = Some(num.value as u16);
+            }
+        }
+    }
+}
+
+/// Builds the self parameter token based on method kind and mutation analysis.
+fn build_self_param(
+    method: &swc_ecma_ast::ClassMethod,
+    ctx: &MethodContext,
+    is_service_or_controller: bool,
+) -> Option<proc_macro2::TokenStream> {
+    if ctx.is_static {
+        return None;
+    }
+
+    if ctx.is_handler {
+        return Some(quote! { self });
+    }
+
+    if is_service_or_controller {
+        return Some(quote! { &self });
+    }
+
+    let mutates = method
+        .function
+        .body
+        .as_ref()
+        .is_some_and(|body| RustGenerator::body_mutates_self(&body.stmts));
+
+    if mutates {
+        Some(quote! { &mut self })
+    } else {
+        Some(quote! { &self })
+    }
+}
+
+/// Converts a single method parameter, handling @Body/@Param/@Query decorators.
+fn convert_single_param(param: &swc_ecma_ast::Param) -> Option<proc_macro2::TokenStream> {
+    let Pat::Ident(ident) = &param.pat else {
+        return None;
+    };
+
+    let param_name = format_ident!("{}", to_snake_case(ident.sym.as_ref()));
+    let param_type = map_ts_type(ident.type_ann.as_ref());
+    let decorator = find_param_decorator(param);
+
+    let tokens = match decorator.as_deref() {
+        Some("Body") => {
+            quote! { axum::Json(#param_name): axum::Json<#param_type> }
+        }
+        Some("Param") => {
+            quote! { axum::extract::Path(#param_name): axum::extract::Path<#param_type> }
+        }
+        Some("Query") => {
+            quote! { axum::extract::Query(#param_name): axum::extract::Query<#param_type> }
+        }
+        _ => {
+            quote! { #param_name: #param_type }
+        }
+    };
+    Some(tokens)
+}
+
+/// Finds the first NestJS parameter decorator (@Body, @Param, @Query) on a param.
+fn find_param_decorator(param: &swc_ecma_ast::Param) -> Option<String> {
+    for decorator in &param.decorators {
+        if let Expr::Call(call) = &*decorator.expr {
+            if let swc_ecma_ast::Callee::Expr(expr) = &call.callee {
+                if let Expr::Ident(dec_ident) = &**expr {
+                    let dec_name = dec_ident.sym.as_ref();
+                    if matches!(dec_name, "Body" | "Param" | "Query") {
+                        return Some(dec_name.to_string());
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Builds the full parameter list including self and method params.
+fn build_method_params(
+    method: &swc_ecma_ast::ClassMethod,
+    ctx: &MethodContext,
+    is_service_or_controller: bool,
+) -> Vec<proc_macro2::TokenStream> {
+    let mut params = Vec::new();
+
+    if let Some(self_param) = build_self_param(method, ctx, is_service_or_controller) {
+        params.push(self_param);
+    }
+
+    for param in &method.function.params {
+        if let Some(p) = convert_single_param(param) {
+            params.push(p);
+        }
+    }
+
+    params
+}
+
+/// Computes the return type, wrapping in Json/StatusCode for handlers.
+fn compute_return_type(
+    method: &swc_ecma_ast::ClassMethod,
+    ctx: &MethodContext,
+) -> proc_macro2::TokenStream {
+    let base = compute_base_return_type(method, ctx.is_handler);
+
+    if !ctx.is_handler {
+        return base;
+    }
+
+    wrap_handler_return_type(&base, ctx.http_code)
+}
+
+/// Computes the raw return type before handler wrapping.
+fn compute_base_return_type(
+    method: &swc_ecma_ast::ClassMethod,
+    is_handler: bool,
+) -> proc_macro2::TokenStream {
+    if method.function.is_async {
+        let inner = if method.function.return_type.is_none() {
+            quote! { () }
+        } else {
+            super::super::type_mapper::unwrap_promise_type(method.function.return_type.as_ref())
+        };
+
+        if is_handler {
+            inner
+        } else {
+            quote! { Result<#inner, crate::AppError> }
+        }
+    } else if method.function.return_type.is_none() {
+        quote! { () }
+    } else {
+        map_ts_type(method.function.return_type.as_ref())
+    }
+}
+
+/// Wraps a handler return type in Json<T> and optionally (StatusCode, T).
+fn wrap_handler_return_type(
+    base: &proc_macro2::TokenStream,
+    http_code: Option<u16>,
+) -> proc_macro2::TokenStream {
+    let return_type_str = base.to_string();
+    let inner_type = if return_type_str != "String" {
+        quote! { axum::Json<#base> }
+    } else {
+        quote! { String }
+    };
+
+    if http_code.is_some() {
+        quote! { Result<(axum::http::StatusCode, #inner_type), crate::AppError> }
+    } else {
+        quote! { Result<#inner_type, crate::AppError> }
+    }
+}
+
+/// Maps an HTTP status code to its axum StatusCode constant.
+fn map_status_code(code: u16) -> proc_macro2::TokenStream {
+    match code {
+        200 => quote! { axum::http::StatusCode::OK },
+        201 => quote! { axum::http::StatusCode::CREATED },
+        204 => quote! { axum::http::StatusCode::NO_CONTENT },
+        301 => quote! { axum::http::StatusCode::MOVED_PERMANENTLY },
+        400 => quote! { axum::http::StatusCode::BAD_REQUEST },
+        401 => quote! { axum::http::StatusCode::UNAUTHORIZED },
+        403 => quote! { axum::http::StatusCode::FORBIDDEN },
+        404 => quote! { axum::http::StatusCode::NOT_FOUND },
+        409 => quote! { axum::http::StatusCode::CONFLICT },
+        500 => quote! { axum::http::StatusCode::INTERNAL_SERVER_ERROR },
+        100..=999 => {
+            quote! { axum::http::StatusCode::from_u16(#code).unwrap_or(axum::http::StatusCode::INTERNAL_SERVER_ERROR) }
+        }
+        _ => {
+            quote! { compile_error!("Tyrus: @HttpCode value is not a valid HTTP status code (100-999)") }
+        }
+    }
+}
+
+/// Builds a handler return expression with Json wrapping and optional StatusCode.
+fn build_handler_return(
+    expr: &proc_macro2::TokenStream,
+    return_type: &proc_macro2::TokenStream,
+    http_code: Option<u16>,
+) -> proc_macro2::TokenStream {
+    let ret_str = return_type.to_string();
+    let uses_json = ret_str.contains("axum :: Json");
+
+    if let Some(code) = http_code {
+        let status = map_status_code(code);
+        if uses_json {
+            quote! { return Ok((#status, axum::Json(#expr.into()))); }
+        } else {
+            quote! { return Ok((#status, #expr.into())); }
+        }
+    } else if uses_json {
+        quote! { return Ok(axum::Json(#expr.into())); }
+    } else {
+        quote! { return Ok(#expr.into()); }
+    }
+}
+
+/// Builds a return statement for an Option-returning method.
+fn build_option_return(arg: &Expr, expr: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    let is_null = matches!(arg, Expr::Lit(Lit::Null(_)));
+    let is_undefined = matches!(arg, Expr::Ident(id) if id.sym.as_ref() == "undefined");
+
+    if is_null || is_undefined {
+        quote! { return None; }
+    } else {
+        quote! { return Some(#expr); }
+    }
+}
+
+/// Builds body statements using the appropriate return handler for the method kind.
+fn build_method_body(
+    generator: &RustGenerator,
+    method: &swc_ecma_ast::ClassMethod,
+    return_type: &proc_macro2::TokenStream,
+    ctx: &MethodContext,
+) -> Vec<proc_macro2::TokenStream> {
+    let mut body_stmts = Vec::new();
+    let Some(body) = &method.function.body else {
+        return body_stmts;
+    };
+
+    let needs_custom_return = ctx.is_handler || ctx.is_async || ctx.returns_option;
+
+    if needs_custom_return {
+        let mut return_handler = |ret: &swc_ecma_ast::ReturnStmt| -> proc_macro2::TokenStream {
+            build_return_stmt(generator, ret, return_type, ctx)
+        };
+        for stmt in &body.stmts {
+            body_stmts.push(generator.convert_stmt_recursive(stmt, &mut return_handler));
+        }
+    } else {
+        for stmt in &body.stmts {
+            body_stmts.push(generator.convert_stmt(stmt));
+        }
+    }
+
+    body_stmts
+}
+
+/// Builds a single return statement based on method context.
+fn build_return_stmt(
+    generator: &RustGenerator,
+    ret: &swc_ecma_ast::ReturnStmt,
+    return_type: &proc_macro2::TokenStream,
+    ctx: &MethodContext,
+) -> proc_macro2::TokenStream {
+    let Some(arg) = &ret.arg else {
+        if ctx.returns_option {
+            return quote! { return None; };
+        }
+        return quote! { return Ok(().into()); };
+    };
+
+    let expr = generator.convert_expr(arg);
+
+    if ctx.is_handler {
+        return build_handler_return(&expr, return_type, ctx.http_code);
+    }
+
+    if ctx.is_async {
+        return quote! { return Ok(#expr); };
+    }
+
+    if ctx.returns_option {
+        return build_option_return(arg, &expr);
+    }
+
+    quote! { return #expr; }
+}
+
+/// Builds the doc comment for a handler method.
+fn build_doc_comment(http_method: &Option<String>, route_path: &str) -> proc_macro2::TokenStream {
+    let Some(m) = http_method.as_ref() else {
+        return quote! {};
+    };
+
+    let method_str = m.to_uppercase();
+    let route = if route_path.is_empty() {
+        "/".to_string()
+    } else {
+        route_path.to_string()
+    };
+
+    quote! {
+        #[doc = concat!("Route: ", #method_str, " ", #route)]
+    }
+}
+
 impl RustGenerator {
+    /// Converts a class method into a Rust fn definition and optional route info.
     pub(crate) fn convert_method(
         &self,
         method: &swc_ecma_ast::ClassMethod,
@@ -18,239 +377,27 @@ impl RustGenerator {
         };
         let method_name = format_ident!("{}", to_snake_case(&method_name_str));
 
-        // Check for NestJS decorators (@Get, @Post, @HttpCode, etc.)
-        let mut http_method = None;
-        let mut route_path = String::new();
-        let mut http_code: Option<u16> = None;
+        let decorators = extract_method_decorators(method);
 
-        for decorator in &method.function.decorators {
-            if let Expr::Call(call) = &*decorator.expr {
-                if let swc_ecma_ast::Callee::Expr(expr) = &call.callee {
-                    if let Expr::Ident(ident) = &**expr {
-                        let name = ident.sym.as_str();
-                        if matches!(name, "Get" | "Post" | "Put" | "Delete" | "Patch") {
-                            http_method = Some(name.to_string());
-                            if let Some(arg) = call.args.first() {
-                                if let Expr::Lit(Lit::Str(s)) = &*arg.expr {
-                                    route_path = s.value.as_str().unwrap_or_default().to_string();
-                                }
-                            }
-                        } else if name == "HttpCode" {
-                            if let Some(arg) = call.args.first() {
-                                if let Expr::Lit(Lit::Num(num)) = &*arg.expr {
-                                    http_code = Some(num.value as u16);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        let is_handler = http_method.is_some();
-
-        // Build parameters
-        let mut params = Vec::new();
-
-        // Handle self parameter — static methods have no self
-        let is_static = method.is_static;
-        if !is_static {
-            if is_handler {
-                params.push(quote! { self });
-            } else if is_service_or_controller {
-                params.push(quote! { &self });
-            } else {
-                let mutates = method
-                    .function
-                    .body
-                    .as_ref()
-                    .is_some_and(|body| Self::body_mutates_self(&body.stmts));
-                if mutates {
-                    params.push(quote! { &mut self });
-                } else {
-                    params.push(quote! { &self });
-                }
-            }
-        }
-
-        for param in &method.function.params {
-            if let Pat::Ident(ident) = &param.pat {
-                let param_name = format_ident!("{}", to_snake_case(ident.sym.as_ref()));
-                let param_type = map_ts_type(ident.type_ann.as_ref());
-
-                // Check for NestJS parameter decorators (@Body, @Param, @Query)
-                let mut param_decorator = None;
-
-                for decorator in &param.decorators {
-                    if let Expr::Call(call) = &*decorator.expr {
-                        if let swc_ecma_ast::Callee::Expr(expr) = &call.callee {
-                            if let Expr::Ident(dec_ident) = &**expr {
-                                let dec_name = dec_ident.sym.as_ref();
-                                if matches!(dec_name, "Body" | "Param" | "Query") {
-                                    param_decorator = Some(dec_name.to_string());
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-
-                match param_decorator.as_deref() {
-                    Some("Body") => {
-                        params.push(quote! { axum::Json(#param_name): axum::Json<#param_type> });
-                    }
-                    Some("Param") => {
-                        params.push(
-                            quote! { axum::extract::Path(#param_name): axum::extract::Path<#param_type> },
-                        );
-                    }
-                    Some("Query") => {
-                        params.push(
-                            quote! { axum::extract::Query(#param_name): axum::extract::Query<#param_type> },
-                        );
-                    }
-                    _ => {
-                        params.push(quote! { #param_name: #param_type });
-                    }
-                }
-            }
-        }
-
-        let mut return_type = if method.function.is_async {
-            let inner = if method.function.return_type.is_none() {
-                quote! { () }
-            } else {
-                super::super::type_mapper::unwrap_promise_type(method.function.return_type.as_ref())
-            };
-
-            if !is_handler {
-                quote! { Result<#inner, crate::AppError> }
-            } else {
-                inner
-            }
-        } else if method.function.return_type.is_none() {
-            quote! { () }
-        } else {
-            map_ts_type(method.function.return_type.as_ref())
+        let ctx = MethodContext {
+            is_handler: decorators.http_method.is_some(),
+            is_static: method.is_static,
+            is_async: method.function.is_async,
+            http_code: decorators.http_code,
+            returns_option: is_optional_type(method.function.return_type.as_deref()),
         };
 
-        // If it's a handler, wrap return type in Json and Result
-        if is_handler {
-            let return_type_str = return_type.to_string();
-            let inner_type = if return_type_str != "String" {
-                quote! { axum::Json<#return_type> }
-            } else {
-                quote! { String }
-            };
+        let params = build_method_params(method, &ctx, is_service_or_controller);
+        let return_type = compute_return_type(method, &ctx);
+        let body_stmts = build_method_body(self, method, &return_type, &ctx);
 
-            // @HttpCode wraps in (StatusCode, inner_type) tuple
-            if http_code.is_some() {
-                return_type =
-                    quote! { Result<(axum::http::StatusCode, #inner_type), crate::AppError> };
-            } else {
-                return_type = quote! { Result<#inner_type, crate::AppError> };
-            }
-        }
-
-        // Check if this method returns Option<T> (from T | null union)
-        let returns_option = is_optional_type(method.function.return_type.as_deref());
-
-        // Convert body
-        let mut body_stmts = Vec::new();
-        if let Some(body) = &method.function.body {
-            // Define return handler
-            let mut return_handler = |ret: &swc_ecma_ast::ReturnStmt| -> proc_macro2::TokenStream {
-                if let Some(arg) = &ret.arg {
-                    let expr = self.convert_expr(arg);
-
-                    if is_handler {
-                        let ret_str = return_type.to_string();
-                        let uses_json = ret_str.contains("axum :: Json");
-
-                        if let Some(code) = http_code {
-                            let status = match code {
-                                200 => quote! { axum::http::StatusCode::OK },
-                                201 => quote! { axum::http::StatusCode::CREATED },
-                                204 => quote! { axum::http::StatusCode::NO_CONTENT },
-                                301 => quote! { axum::http::StatusCode::MOVED_PERMANENTLY },
-                                400 => quote! { axum::http::StatusCode::BAD_REQUEST },
-                                401 => quote! { axum::http::StatusCode::UNAUTHORIZED },
-                                403 => quote! { axum::http::StatusCode::FORBIDDEN },
-                                404 => quote! { axum::http::StatusCode::NOT_FOUND },
-                                409 => quote! { axum::http::StatusCode::CONFLICT },
-                                500 => quote! { axum::http::StatusCode::INTERNAL_SERVER_ERROR },
-                                100..=999 => {
-                                    quote! { axum::http::StatusCode::from_u16(#code).unwrap_or(axum::http::StatusCode::INTERNAL_SERVER_ERROR) }
-                                }
-                                _ => {
-                                    quote! { compile_error!("Tyrus: @HttpCode value is not a valid HTTP status code (100-999)") }
-                                }
-                            };
-                            if uses_json {
-                                quote! { return Ok((#status, axum::Json(#expr.into()))); }
-                            } else {
-                                quote! { return Ok((#status, #expr.into())); }
-                            }
-                        } else if uses_json {
-                            quote! { return Ok(axum::Json(#expr.into())); }
-                        } else {
-                            quote! { return Ok(#expr.into()); }
-                        }
-                    } else if method.function.is_async {
-                        // For async methods, wrap in Ok
-                        quote! { return Ok(#expr); }
-                    } else if returns_option {
-                        // For methods returning Option<T>, wrap non-null returns in Some()
-                        let is_null = matches!(&**arg, Expr::Lit(Lit::Null(_)));
-                        let is_undefined =
-                            matches!(&**arg, Expr::Ident(id) if id.sym.as_ref() == "undefined");
-                        if is_null || is_undefined {
-                            quote! { return None; }
-                        } else {
-                            quote! { return Some(#expr); }
-                        }
-                    } else {
-                        quote! { return #expr; }
-                    }
-                } else if returns_option {
-                    quote! { return None; }
-                } else {
-                    quote! { return Ok(().into()); } // For handlers returning void?
-                }
-            };
-
-            for stmt in &body.stmts {
-                if is_handler || method.function.is_async || returns_option {
-                    body_stmts.push(self.convert_stmt_recursive(stmt, &mut return_handler));
-                } else {
-                    body_stmts.push(self.convert_stmt(stmt));
-                }
-            }
-        }
-
-        let fn_keyword = if is_handler || method.function.is_async {
+        let fn_keyword = if ctx.is_handler || ctx.is_async {
             quote! { async fn }
         } else {
             quote! { fn }
         };
 
-        let doc_comment = if is_handler {
-            let method_str = if let Some(m) = http_method.as_ref() {
-                m.to_uppercase()
-            } else {
-                "GET".to_string() // Default or unreachable if guarded
-            };
-            let route = if route_path.is_empty() {
-                "/".to_string()
-            } else {
-                route_path.clone()
-            };
-            quote! {
-                #[doc = concat!("Route: ", #method_str, " ", #route)]
-            }
-        } else {
-            quote! {}
-        };
+        let doc_comment = build_doc_comment(&decorators.http_method, &decorators.route_path);
 
         let tokens = quote! {
             #doc_comment
@@ -259,7 +406,9 @@ impl RustGenerator {
             }
         };
 
-        let route_info = http_method.map(|method| (method_name.to_string(), method, route_path));
+        let route_info = decorators
+            .http_method
+            .map(|m| (method_name.to_string(), m, decorators.route_path));
 
         (tokens, route_info)
     }

--- a/crates/tyrus_codegen/src/convert/class/mod.rs
+++ b/crates/tyrus_codegen/src/convert/class/mod.rs
@@ -252,15 +252,15 @@ impl RustGenerator {
 
         // Constructor
         if let Some(cons) = constructor {
-            let constructor_tokens = self.convert_constructor(
-                &struct_name,
-                cons,
-                &class_fields_meta,
-                n.class.type_params.is_some(),
-                &generic_params,
-                &dependency_fields,
+            let ctx = constructor::ConstructorCtx {
+                constructor: cons,
+                class_fields: &class_fields_meta,
+                has_generics: n.class.type_params.is_some(),
+                generic_params: &generic_params,
+                dependency_fields: &dependency_fields,
                 is_service_or_controller,
-            );
+            };
+            let constructor_tokens = self.convert_constructor(&struct_name, &ctx);
             impl_items.push(constructor_tokens);
         } else {
             // Default constructor if none exists

--- a/crates/tyrus_codegen/src/convert/fn_decl.rs
+++ b/crates/tyrus_codegen/src/convert/fn_decl.rs
@@ -3,8 +3,9 @@
 //! Converts TypeScript function declarations to Rust function items.
 //! Handles: sync/async, return types, parameter mapping, Result wrapping.
 
+use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use swc_ecma_ast::{FnDecl, Pat};
+use swc_ecma_ast::{FnDecl, Function, Pat};
 
 use super::helpers::to_snake_case;
 use super::interface::RustGenerator;
@@ -20,110 +21,15 @@ impl RustGenerator {
             self.has_declared_main = true;
         }
 
-        // Check if async
         let is_async = n.function.is_async;
-
-        // Extract parameters — mark all as `mut` since TS allows reassignment
-        let mut params = Vec::new();
-        for param in &n.function.params {
-            match &param.pat {
-                Pat::Ident(ident_pat) => {
-                    let param_name = format_ident!("{}", ident_pat.sym.to_string());
-                    let param_type = map_ts_type(ident_pat.type_ann.as_ref());
-                    params.push(quote! { mut #param_name: #param_type });
-                }
-                Pat::Rest(rest_pat) => {
-                    // ...args: T[] → args: Vec<T>
-                    if let Pat::Ident(ident) = &*rest_pat.arg {
-                        let param_name = format_ident!("{}", ident.sym.to_string());
-                        // RestPat carries the type annotation, not the inner ident
-                        let param_type =
-                            map_ts_type(rest_pat.type_ann.as_ref().or(ident.type_ann.as_ref()));
-                        params.push(quote! { mut #param_name: #param_type });
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        // Extract return type - unwrap Promise<T> for async functions
-        let return_type = if is_async {
-            if n.function.return_type.is_none() {
-                quote! { Result<(), crate::AppError> }
-            } else {
-                let inner = unwrap_promise_type(n.function.return_type.as_ref());
-                quote! { Result<#inner, crate::AppError> }
-            }
-        } else if n.function.return_type.is_none() {
-            quote! { () }
-        } else {
-            map_ts_type(n.function.return_type.as_ref())
-        };
-
-        // Check if void
-        let is_void = if n.function.return_type.is_none() {
-            true
-        } else {
-            super::type_mapper::is_void_or_promise_void(n.function.return_type.as_deref())
-        };
-
-        // Convert body
-        let mut body_stmts = Vec::new();
-        if let Some(block_stmt) = &n.function.body {
-            if is_async {
-                for stmt in &block_stmt.stmts {
-                    body_stmts.push(self.convert_stmt_recursive(stmt, &mut |ret_stmt| {
-                        if let Some(arg) = &ret_stmt.arg {
-                            let expr = self.convert_expr(arg);
-                            if !is_void && matches!(arg.as_ref(), swc_ecma_ast::Expr::Object(_)) {
-                                quote! {
-                                    return Ok(serde_json::from_value(#expr).unwrap_or_default());
-                                }
-                            } else {
-                                quote! { return Ok(#expr); }
-                            }
-                        } else {
-                            quote! { return Ok(()); }
-                        }
-                    }));
-                }
-            } else {
-                for stmt in &block_stmt.stmts {
-                    body_stmts.push(self.convert_stmt_recursive(stmt, &mut |ret_stmt| {
-                        if let Some(arg) = &ret_stmt.arg {
-                            let expr = self.convert_expr(arg);
-                            if !is_void && matches!(arg.as_ref(), swc_ecma_ast::Expr::Object(_)) {
-                                quote! {
-                                    return serde_json::from_value(#expr).unwrap_or_default();
-                                }
-                            } else {
-                                quote! { return #expr; }
-                            }
-                        } else {
-                            quote! { return; }
-                        }
-                    }));
-                }
-            }
-        }
+        let params = Self::extract_fn_params(&n.function);
+        let return_type = Self::resolve_return_type(&n.function, is_async);
+        let is_void = Self::is_void_return(&n.function);
+        let body_stmts = self.build_fn_body(&n.function, is_async, is_void);
+        let generics = Self::build_generics(&n.function);
 
         let vis = if self.is_exporting {
             quote! { pub }
-        } else {
-            quote! {}
-        };
-
-        let generics = if let Some(type_params) = &n.function.type_params {
-            let params: Vec<_> = type_params
-                .params
-                .iter()
-                .map(|p| {
-                    let name = p.name.sym.to_string();
-                    let ident = format_ident!("{}", name);
-                    quote! { #ident: serde::de::DeserializeOwned + serde::Serialize + Clone }
-                })
-                .collect();
-            quote! { <#(#params),*> }
         } else {
             quote! {}
         };
@@ -134,7 +40,6 @@ impl RustGenerator {
             } else {
                 quote! {}
             };
-
             quote! {
                 #vis async fn #fn_ident #generics (#(#params),*) -> #return_type {
                     #(#body_stmts)*
@@ -151,5 +56,124 @@ impl RustGenerator {
 
         self.code.push_str(&fn_def.to_string());
         self.code.push('\n');
+    }
+
+    /// Extract parameters from a TypeScript function, mapping each to Rust syntax.
+    fn extract_fn_params(function: &Function) -> Vec<TokenStream> {
+        let mut params = Vec::new();
+        for param in &function.params {
+            match &param.pat {
+                Pat::Ident(ident_pat) => {
+                    let param_name = format_ident!("{}", ident_pat.sym.to_string());
+                    let param_type = map_ts_type(ident_pat.type_ann.as_ref());
+                    params.push(quote! { mut #param_name: #param_type });
+                }
+                Pat::Rest(rest_pat) => {
+                    // ...args: T[] -> args: Vec<T>
+                    if let Pat::Ident(ident) = &*rest_pat.arg {
+                        let param_name = format_ident!("{}", ident.sym.to_string());
+                        let param_type =
+                            map_ts_type(rest_pat.type_ann.as_ref().or(ident.type_ann.as_ref()));
+                        params.push(quote! { mut #param_name: #param_type });
+                    }
+                }
+                _ => {}
+            }
+        }
+        params
+    }
+
+    /// Resolve the Rust return type from a TS function, wrapping async in Result.
+    fn resolve_return_type(function: &Function, is_async: bool) -> TokenStream {
+        if is_async {
+            if function.return_type.is_none() {
+                quote! { Result<(), crate::AppError> }
+            } else {
+                let inner = unwrap_promise_type(function.return_type.as_ref());
+                quote! { Result<#inner, crate::AppError> }
+            }
+        } else if function.return_type.is_none() {
+            quote! { () }
+        } else {
+            map_ts_type(function.return_type.as_ref())
+        }
+    }
+
+    /// Check whether the function has a void (or Promise<void>) return type.
+    fn is_void_return(function: &Function) -> bool {
+        if function.return_type.is_none() {
+            return true;
+        }
+        super::type_mapper::is_void_or_promise_void(function.return_type.as_deref())
+    }
+
+    /// Convert the function body statements, wrapping returns in Ok() for async.
+    fn build_fn_body(
+        &self,
+        function: &Function,
+        is_async: bool,
+        is_void: bool,
+    ) -> Vec<TokenStream> {
+        let Some(block_stmt) = &function.body else {
+            return Vec::new();
+        };
+
+        block_stmt
+            .stmts
+            .iter()
+            .map(|stmt| {
+                self.convert_stmt_recursive(stmt, &mut |ret_stmt| {
+                    Self::convert_return(self, ret_stmt, is_async, is_void)
+                })
+            })
+            .collect()
+    }
+
+    /// Produce the return expression for a single ReturnStmt.
+    fn convert_return(
+        &self,
+        ret_stmt: &swc_ecma_ast::ReturnStmt,
+        is_async: bool,
+        is_void: bool,
+    ) -> TokenStream {
+        let Some(arg) = &ret_stmt.arg else {
+            return if is_async {
+                quote! { return Ok(()); }
+            } else {
+                quote! { return; }
+            };
+        };
+
+        let expr = self.convert_expr(arg);
+        let is_object = !is_void && matches!(arg.as_ref(), swc_ecma_ast::Expr::Object(_));
+
+        match (is_async, is_object) {
+            (_, true) if is_async => quote! {
+                return Ok(serde_json::from_value(#expr).unwrap_or_default());
+            },
+            (_, true) => quote! {
+                return serde_json::from_value(#expr).unwrap_or_default();
+            },
+            (true, false) => quote! { return Ok(#expr); },
+            (false, false) => quote! { return #expr; },
+        }
+    }
+
+    /// Build generic type parameters with Serde + Clone bounds.
+    fn build_generics(function: &Function) -> TokenStream {
+        let Some(type_params) = &function.type_params else {
+            return quote! {};
+        };
+
+        let params: Vec<_> = type_params
+            .params
+            .iter()
+            .map(|p| {
+                let ident = format_ident!("{}", p.name.sym.to_string());
+                quote! { #ident: serde::de::DeserializeOwned + serde::Serialize + Clone }
+            })
+            .collect();
+
+        quote! { <#(#params),*> }
     }
 }

--- a/crates/tyrus_codegen/src/convert/type_mapper.rs
+++ b/crates/tyrus_codegen/src/convert/type_mapper.rs
@@ -2,110 +2,115 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use swc_ecma_ast::{TsType, TsTypeAnn};
 
-/// Core type mapping logic: converts a `TsType` to a Rust `TokenStream`.
-/// Handles keywords, arrays, type references (including generics), and unions.
+/// Maps a TS keyword type (string, number, boolean, void) to its Rust equivalent.
+fn map_keyword_type(kind: swc_ecma_ast::TsKeywordTypeKind) -> TokenStream {
+    match kind {
+        swc_ecma_ast::TsKeywordTypeKind::TsStringKeyword => quote! { String },
+        swc_ecma_ast::TsKeywordTypeKind::TsNumberKeyword => quote! { f64 },
+        swc_ecma_ast::TsKeywordTypeKind::TsBooleanKeyword => quote! { bool },
+        swc_ecma_ast::TsKeywordTypeKind::TsVoidKeyword => quote! { () },
+        _ => quote! { serde_json::Value },
+    }
+}
+
+/// Maps a TS type reference (Date, Array<T>, Record<K,V>, user-defined) to Rust.
+fn map_type_ref(type_ref: &swc_ecma_ast::TsTypeRef) -> TokenStream {
+    let Some(ident) = type_ref.type_name.as_ident() else {
+        return quote! { serde_json::Value };
+    };
+    let name = ident.sym.as_str();
+    match name {
+        "Date" => quote! { String },
+        "Array" => map_array_type(&type_ref.type_params),
+        "Record" => map_record_type(&type_ref.type_params),
+        _ => map_user_defined_type(name, &type_ref.type_params),
+    }
+}
+
+/// Extracts the first generic param as `Vec<T>`, defaulting to `Vec<Value>`.
+fn map_array_type(
+    type_params: &Option<Box<swc_ecma_ast::TsTypeParamInstantiation>>,
+) -> TokenStream {
+    if let Some(params) = type_params {
+        if let Some(first) = params.params.first() {
+            let inner = map_type_core(first);
+            return quote! { Vec<#inner> };
+        }
+    }
+    quote! { Vec<serde_json::Value> }
+}
+
+/// Maps Record<K,V> to HashMap<K,V>, defaulting to HashMap<String, Value>.
+fn map_record_type(
+    type_params: &Option<Box<swc_ecma_ast::TsTypeParamInstantiation>>,
+) -> TokenStream {
+    if let Some(params) = type_params {
+        if params.params.len() >= 2 {
+            let key = map_type_core(&params.params[0]);
+            let value = map_type_core(&params.params[1]);
+            return quote! { std::collections::HashMap<#key, #value> };
+        }
+    }
+    quote! { std::collections::HashMap<String, serde_json::Value> }
+}
+
+/// Maps a user-defined type reference, preserving generic parameters.
+fn map_user_defined_type(
+    name: &str,
+    type_params: &Option<Box<swc_ecma_ast::TsTypeParamInstantiation>>,
+) -> TokenStream {
+    let type_ident = proc_macro2::Ident::new(name, proc_macro2::Span::call_site());
+    if let Some(params) = type_params {
+        let mapped: Vec<_> = params.params.iter().map(|p| map_type_core(p)).collect();
+        quote! { #type_ident<#(#mapped),*> }
+    } else {
+        quote! { #type_ident }
+    }
+}
+
+/// Maps a TS union type (T | undefined -> Option<T>), falling back to Value.
+fn map_union_type(union_or_intersection: &swc_ecma_ast::TsUnionOrIntersectionType) -> TokenStream {
+    let swc_ecma_ast::TsUnionOrIntersectionType::TsUnionType(union) = union_or_intersection else {
+        return quote! { serde_json::Value };
+    };
+
+    let mut is_optional = false;
+    let mut inner_type = None;
+
+    for type_opt in &union.types {
+        match &**type_opt {
+            TsType::TsKeywordType(k)
+                if k.kind == swc_ecma_ast::TsKeywordTypeKind::TsUndefinedKeyword
+                    || k.kind == swc_ecma_ast::TsKeywordTypeKind::TsNullKeyword =>
+            {
+                is_optional = true;
+            }
+            _ => {
+                if inner_type.is_none() {
+                    inner_type = Some(map_type_core(type_opt));
+                }
+            }
+        }
+    }
+
+    if is_optional {
+        let inner = inner_type.unwrap_or_else(|| quote! { serde_json::Value });
+        quote! { Option<#inner> }
+    } else {
+        quote! { serde_json::Value }
+    }
+}
+
+/// Core type mapping dispatcher: routes a `TsType` to the appropriate handler.
 fn map_type_core(ts_type: &TsType) -> TokenStream {
     match ts_type {
-        TsType::TsKeywordType(k) => match k.kind {
-            swc_ecma_ast::TsKeywordTypeKind::TsStringKeyword => quote! { String },
-            swc_ecma_ast::TsKeywordTypeKind::TsNumberKeyword => quote! { f64 },
-            swc_ecma_ast::TsKeywordTypeKind::TsBooleanKeyword => quote! { bool },
-            swc_ecma_ast::TsKeywordTypeKind::TsVoidKeyword => quote! { () },
-            _ => quote! { serde_json::Value },
-        },
-        TsType::TsArrayType(array_type) => {
-            let inner_type = map_type_core(&array_type.elem_type);
-            quote! { Vec<#inner_type> }
+        TsType::TsKeywordType(k) => map_keyword_type(k.kind),
+        TsType::TsArrayType(arr) => {
+            let inner = map_type_core(&arr.elem_type);
+            quote! { Vec<#inner> }
         }
-        TsType::TsTypeRef(t) => {
-            if let Some(ident) = t.type_name.as_ident() {
-                let name = ident.sym.as_str();
-                match name {
-                    "Date" => quote! { String },
-                    "Array" => {
-                        if let Some(type_params) = &t.type_params {
-                            if let Some(first_param) = type_params.params.first() {
-                                let inner = map_type_core(first_param);
-                                quote! { Vec<#inner> }
-                            } else {
-                                quote! { Vec<serde_json::Value> }
-                            }
-                        } else {
-                            quote! { Vec<serde_json::Value> }
-                        }
-                    }
-                    "Record" => {
-                        if let Some(type_params) = &t.type_params {
-                            if type_params.params.len() >= 2 {
-                                let key = map_type_core(&type_params.params[0]);
-                                let value = map_type_core(&type_params.params[1]);
-                                quote! { std::collections::HashMap<#key, #value> }
-                            } else {
-                                quote! { std::collections::HashMap<String, serde_json::Value> }
-                            }
-                        } else {
-                            quote! { std::collections::HashMap<String, serde_json::Value> }
-                        }
-                    }
-                    _ => {
-                        // User defined type (Struct or Enum)
-                        let type_ident =
-                            proc_macro2::Ident::new(name, proc_macro2::Span::call_site());
-
-                        if let Some(type_params) = &t.type_params {
-                            let params: Vec<_> = type_params
-                                .params
-                                .iter()
-                                .map(|p| map_type_core(p))
-                                .collect();
-                            quote! { #type_ident<#(#params),*> }
-                        } else {
-                            quote! { #type_ident }
-                        }
-                    }
-                }
-            } else {
-                quote! { serde_json::Value }
-            }
-        }
-        TsType::TsUnionOrIntersectionType(union_or_intersection) => {
-            // Check for Optional (T | undefined)
-            if let swc_ecma_ast::TsUnionOrIntersectionType::TsUnionType(union) =
-                union_or_intersection
-            {
-                let mut is_optional = false;
-                let mut inner_type = None;
-
-                for type_opt in &union.types {
-                    match &**type_opt {
-                        TsType::TsKeywordType(k)
-                            if k.kind == swc_ecma_ast::TsKeywordTypeKind::TsUndefinedKeyword
-                                || k.kind == swc_ecma_ast::TsKeywordTypeKind::TsNullKeyword =>
-                        {
-                            is_optional = true;
-                        }
-                        _ => {
-                            if inner_type.is_none() {
-                                inner_type = Some(map_type_core(type_opt));
-                            }
-                        }
-                    }
-                }
-
-                if is_optional {
-                    if let Some(inner) = inner_type {
-                        quote! { Option<#inner> }
-                    } else {
-                        quote! { Option<serde_json::Value> }
-                    }
-                } else {
-                    // Regular union - fallback to Value for now
-                    quote! { serde_json::Value }
-                }
-            } else {
-                quote! { serde_json::Value }
-            }
-        }
+        TsType::TsTypeRef(t) => map_type_ref(t),
+        TsType::TsUnionOrIntersectionType(u) => map_union_type(u),
         _ => quote! { serde_json::Value },
     }
 }
@@ -187,11 +192,6 @@ pub fn is_void_or_promise_void(type_ann: Option<&TsTypeAnn>) -> bool {
             _ => false,
         }
     } else {
-        // If no return type, assume void for functions (in this context)
-        // But map_ts_type maps None to Value.
-        // We need consistency.
-        // For now, let's say None is NOT void if we map it to Value.
-        // But in process_fn_decl we might override this.
         false
     }
 }

--- a/crates/tyrus_codegen/src/stdlib/array.rs
+++ b/crates/tyrus_codegen/src/stdlib/array.rs
@@ -13,129 +13,172 @@ pub(crate) fn handle(
 ) -> Option<TokenStream> {
     let obj_tokens = gen.convert_expr(obj);
     match method {
-        "push" => None, // Falls through to generic conversion: arr.push(x) works in Rust
-        "map" => {
-            // arr.map(x => x+1) -> arr.iter().map(|x| x+1).collect::<Vec<_>>()
-            // This requires context of the closure.
-            None
+        "push" => None,
+        "map" => None,
+        "filter" => None,
+        "find" => handle_find(gen, &obj_tokens, args),
+        "join" => handle_join(gen, &obj_tokens, args),
+        "includes" => handle_includes(gen, &obj_tokens, args),
+        "indexOf" => handle_index_of(gen, &obj_tokens, args),
+        "slice" => handle_slice(gen, &obj_tokens, args),
+        "concat" => handle_concat(gen, &obj_tokens, args),
+        "reverse" => nullary_method(&obj_tokens, args, |o| quote! { #o.reverse() }),
+        "pop" => nullary_method(&obj_tokens, args, |o| quote! { #o.pop() }),
+        "sort" => handle_sort(&obj_tokens, args),
+        "shift" => handle_shift(&obj_tokens, args),
+        "flat" => handle_flat(&obj_tokens, args),
+        "flatMap" => handle_flat_map(gen, &obj_tokens, args),
+        _ => None,
+    }
+}
+
+fn nullary_method(
+    obj_tokens: &TokenStream,
+    args: &[ExprOrSpread],
+    emit: impl FnOnce(&TokenStream) -> TokenStream,
+) -> Option<TokenStream> {
+    if args.is_empty() {
+        Some(emit(obj_tokens))
+    } else {
+        None
+    }
+}
+
+fn handle_find(
+    gen: &RustGenerator,
+    obj_tokens: &TokenStream,
+    args: &[ExprOrSpread],
+) -> Option<TokenStream> {
+    if args.len() == 1 {
+        let predicate = gen.convert_expr_or_spread(&args[0]);
+        Some(quote! { #obj_tokens.iter().find(|item| (#predicate)(**item)).cloned() })
+    } else {
+        None
+    }
+}
+
+fn handle_join(
+    gen: &RustGenerator,
+    obj_tokens: &TokenStream,
+    args: &[ExprOrSpread],
+) -> Option<TokenStream> {
+    if args.len() == 1 {
+        let separator = gen.convert_expr_or_spread(&args[0]);
+        Some(quote! { #obj_tokens.join(&#separator) })
+    } else {
+        None
+    }
+}
+
+fn handle_includes(
+    gen: &RustGenerator,
+    obj_tokens: &TokenStream,
+    args: &[ExprOrSpread],
+) -> Option<TokenStream> {
+    if let Some(arg) = args.first() {
+        let val = gen.convert_expr_or_spread(arg);
+        Some(quote! { #obj_tokens.contains(&#val) })
+    } else {
+        None
+    }
+}
+
+fn handle_index_of(
+    gen: &RustGenerator,
+    obj_tokens: &TokenStream,
+    args: &[ExprOrSpread],
+) -> Option<TokenStream> {
+    if args.len() == 1 {
+        let val = gen.convert_expr_or_spread(&args[0]);
+        Some(quote! {
+            #obj_tokens.iter().position(|x| x == &#val).map(|i| i as f64).unwrap_or(-1.0)
+        })
+    } else {
+        None
+    }
+}
+
+fn handle_slice(
+    gen: &RustGenerator,
+    obj_tokens: &TokenStream,
+    args: &[ExprOrSpread],
+) -> Option<TokenStream> {
+    match args.len() {
+        1 => {
+            let start = gen.convert_expr_or_spread(&args[0]);
+            Some(quote! { #obj_tokens[(#start as usize)..].to_vec() })
         }
-        "filter" => {
-            // arr.filter(x => x > 1)
-            None
-        }
-        "find" => {
-            if args.len() == 1 {
-                let predicate = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! { #obj_tokens.iter().find(|item| (#predicate)(**item)).cloned() })
-            } else {
-                None
-            }
-        }
-        "join" => {
-            if args.len() == 1 {
-                let separator = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! { #obj_tokens.join(&#separator) })
-            } else {
-                None
-            }
-        }
-        "includes" => {
-            if let Some(arg) = args.first() {
-                let val = gen.convert_expr_or_spread(arg);
-                Some(quote! { #obj_tokens.contains(&#val) })
-            } else {
-                None
-            }
-        }
-        "indexOf" => {
-            if args.len() == 1 {
-                let val = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! {
-                    #obj_tokens.iter().position(|x| x == &#val).map(|i| i as f64).unwrap_or(-1.0)
-                })
-            } else {
-                None
-            }
-        }
-        "slice" => match args.len() {
-            1 => {
-                let start = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! { #obj_tokens[(#start as usize)..].to_vec() })
-            }
-            2 => {
-                let start = gen.convert_expr_or_spread(&args[0]);
-                let end = gen.convert_expr_or_spread(&args[1]);
-                Some(quote! { #obj_tokens[(#start as usize)..(#end as usize)].to_vec() })
-            }
-            _ => None,
-        },
-        "concat" => {
-            if args.len() == 1 {
-                let other = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! {
-                    #obj_tokens.iter().chain(#other.iter()).cloned().collect::<Vec<_>>()
-                })
-            } else {
-                None
-            }
-        }
-        "reverse" => {
-            if args.is_empty() {
-                Some(quote! { #obj_tokens.reverse() })
-            } else {
-                None
-            }
-        }
-        "pop" => {
-            if args.is_empty() {
-                Some(quote! { #obj_tokens.pop() })
-            } else {
-                None
-            }
-        }
-        "sort" => {
-            if args.is_empty() {
-                Some(quote! {
-                    {
-                        #obj_tokens.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-                    }
-                })
-            } else {
-                None
-            }
-        }
-        "shift" => {
-            if args.is_empty() {
-                Some(quote! {
-                    if #obj_tokens.is_empty() {
-                        Default::default()
-                    } else {
-                        #obj_tokens.remove(0)
-                    }
-                })
-            } else {
-                None
-            }
-        }
-        "flat" => {
-            if args.is_empty() {
-                Some(quote! {
-                    #obj_tokens.iter().flatten().cloned().collect::<Vec<_>>()
-                })
-            } else {
-                None
-            }
-        }
-        "flatMap" => {
-            if args.len() == 1 {
-                let callback = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! {
-                    #obj_tokens.iter().flat_map(|x| (#callback)(x.clone())).collect::<Vec<_>>()
-                })
-            } else {
-                None
-            }
+        2 => {
+            let start = gen.convert_expr_or_spread(&args[0]);
+            let end = gen.convert_expr_or_spread(&args[1]);
+            Some(quote! { #obj_tokens[(#start as usize)..(#end as usize)].to_vec() })
         }
         _ => None,
+    }
+}
+
+fn handle_concat(
+    gen: &RustGenerator,
+    obj_tokens: &TokenStream,
+    args: &[ExprOrSpread],
+) -> Option<TokenStream> {
+    if args.len() == 1 {
+        let other = gen.convert_expr_or_spread(&args[0]);
+        Some(quote! {
+            #obj_tokens.iter().chain(#other.iter()).cloned().collect::<Vec<_>>()
+        })
+    } else {
+        None
+    }
+}
+
+fn handle_sort(obj_tokens: &TokenStream, args: &[ExprOrSpread]) -> Option<TokenStream> {
+    if args.is_empty() {
+        Some(quote! {
+            {
+                #obj_tokens.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            }
+        })
+    } else {
+        None
+    }
+}
+
+fn handle_shift(obj_tokens: &TokenStream, args: &[ExprOrSpread]) -> Option<TokenStream> {
+    if args.is_empty() {
+        Some(quote! {
+            if #obj_tokens.is_empty() {
+                Default::default()
+            } else {
+                #obj_tokens.remove(0)
+            }
+        })
+    } else {
+        None
+    }
+}
+
+fn handle_flat(obj_tokens: &TokenStream, args: &[ExprOrSpread]) -> Option<TokenStream> {
+    if args.is_empty() {
+        Some(quote! {
+            #obj_tokens.iter().flatten().cloned().collect::<Vec<_>>()
+        })
+    } else {
+        None
+    }
+}
+
+fn handle_flat_map(
+    gen: &RustGenerator,
+    obj_tokens: &TokenStream,
+    args: &[ExprOrSpread],
+) -> Option<TokenStream> {
+    if args.len() == 1 {
+        let callback = gen.convert_expr_or_spread(&args[0]);
+        Some(quote! {
+            #obj_tokens.iter().flat_map(|x| (#callback)(x.clone())).collect::<Vec<_>>()
+        })
+    } else {
+        None
     }
 }

--- a/crates/tyrus_codegen/src/stdlib/math.rs
+++ b/crates/tyrus_codegen/src/stdlib/math.rs
@@ -4,163 +4,100 @@ use swc_ecma_ast::*;
 
 use super::super::convert::interface::RustGenerator;
 
-/// Handle Math.* calls
 pub(crate) fn handle(
     gen: &RustGenerator,
     method: &str,
     args: &[ExprOrSpread],
 ) -> Option<TokenStream> {
     match method {
-        "max" => {
-            if args.len() == 1 && args[0].spread.is_some() {
-                // Math.max(...arr)
-                let arg = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! {
-                    #arg.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b))
-                })
-            } else if args.len() == 2 {
-                if args[0].spread.is_some() {
-                    // Math.max(...arr, val)
-                    let arr = gen.convert_expr_or_spread(&args[0]);
-                    let val = gen.convert_expr_or_spread(&args[1]);
-                    Some(quote! {
-                        #arr.iter().fold(#val, |a, &b| a.max(b))
-                    })
-                } else {
-                    // Math.max(a, b)
-                    let a = gen.convert_expr_or_spread(&args[0]);
-                    let b = gen.convert_expr_or_spread(&args[1]);
-                    Some(quote! { #a.max(#b) })
-                }
-            } else {
-                None
-            }
-        }
-        "min" => {
-            if args.len() == 1 && args[0].spread.is_some() {
-                // Math.min(...arr) -> arr.iter().fold(f64::INFINITY, |a, &b| a.min(b))
-                let arg = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! {
-                    #arg.iter().fold(f64::INFINITY, |a, &b| a.min(b))
-                })
-            } else if args.len() == 2 {
-                let a = gen.convert_expr_or_spread(&args[0]);
-                let b = gen.convert_expr_or_spread(&args[1]);
-                Some(quote! { #a.min(#b) })
-            } else {
-                None
-            }
-        }
-        "round" => {
-            if args.len() == 1 {
-                let x = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! { (#x).round() })
-            } else {
-                None
-            }
-        }
-        "floor" => {
-            if args.len() == 1 {
-                let x = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! { (#x).floor() })
-            } else {
-                None
-            }
-        }
-        "ceil" => {
-            if args.len() == 1 {
-                let x = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! { (#x).ceil() })
-            } else {
-                None
-            }
-        }
-        "abs" => {
-            if args.len() == 1 {
-                let x = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! { (#x).abs() })
-            } else {
-                None
-            }
-        }
-        "random" => {
-            if args.is_empty() {
-                Some(quote! { rand::random::<f64>() })
-            } else {
-                None
-            }
-        }
-        "pow" => {
-            if args.len() == 2 {
-                let base = gen.convert_expr_or_spread(&args[0]);
-                let exp = gen.convert_expr_or_spread(&args[1]);
-                Some(quote! { (#base as f64).powf(#exp as f64) })
-            } else {
-                None
-            }
-        }
-        "sqrt" => {
-            if args.len() == 1 {
-                let x = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! { (#x as f64).sqrt() })
-            } else {
-                None
-            }
-        }
-        "log" => {
-            if args.len() == 1 {
-                let x = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! { (#x as f64).ln() })
-            } else {
-                None
-            }
-        }
-        "trunc" => {
-            if args.len() == 1 {
-                let x = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! { (#x).trunc() })
-            } else {
-                None
-            }
-        }
-        "sin" => {
-            if args.len() == 1 {
-                let x = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! { (#x as f64).sin() })
-            } else {
-                None
-            }
-        }
-        "cos" => {
-            if args.len() == 1 {
-                let x = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! { (#x as f64).cos() })
-            } else {
-                None
-            }
-        }
-        "tan" => {
-            if args.len() == 1 {
-                let x = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! { (#x as f64).tan() })
-            } else {
-                None
-            }
-        }
-        "sign" => {
-            if args.len() == 1 {
-                let x = gen.convert_expr_or_spread(&args[0]);
-                // JS Math.sign(0) returns 0, but Rust f64::signum() returns 1.0
-                Some(quote! {
-                    {
-                        let __v = #x;
-                        if __v == 0.0 { 0.0 } else { __v.signum() }
-                    }
-                })
-            } else {
-                None
-            }
-        }
+        "max" => handle_max(gen, args),
+        "min" => handle_min(gen, args),
+        "pow" => handle_pow(gen, args),
+        "random" => handle_random(args),
+        "sign" => handle_sign(gen, args),
+        "round" => unary_method(gen, args, |x| quote! { (#x).round() }),
+        "floor" => unary_method(gen, args, |x| quote! { (#x).floor() }),
+        "ceil" => unary_method(gen, args, |x| quote! { (#x).ceil() }),
+        "abs" => unary_method(gen, args, |x| quote! { (#x).abs() }),
+        "sqrt" => unary_method(gen, args, |x| quote! { (#x as f64).sqrt() }),
+        "log" => unary_method(gen, args, |x| quote! { (#x as f64).ln() }),
+        "trunc" => unary_method(gen, args, |x| quote! { (#x).trunc() }),
+        "sin" => unary_method(gen, args, |x| quote! { (#x as f64).sin() }),
+        "cos" => unary_method(gen, args, |x| quote! { (#x as f64).cos() }),
+        "tan" => unary_method(gen, args, |x| quote! { (#x as f64).tan() }),
         _ => None,
+    }
+}
+
+fn unary_method(
+    gen: &RustGenerator,
+    args: &[ExprOrSpread],
+    emit: impl FnOnce(TokenStream) -> TokenStream,
+) -> Option<TokenStream> {
+    if args.len() == 1 {
+        Some(emit(gen.convert_expr_or_spread(&args[0])))
+    } else {
+        None
+    }
+}
+
+fn handle_max(gen: &RustGenerator, args: &[ExprOrSpread]) -> Option<TokenStream> {
+    if args.len() == 1 && args[0].spread.is_some() {
+        let arg = gen.convert_expr_or_spread(&args[0]);
+        Some(quote! { #arg.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b)) })
+    } else if args.len() == 2 {
+        if args[0].spread.is_some() {
+            let arr = gen.convert_expr_or_spread(&args[0]);
+            let val = gen.convert_expr_or_spread(&args[1]);
+            Some(quote! { #arr.iter().fold(#val, |a, &b| a.max(b)) })
+        } else {
+            let a = gen.convert_expr_or_spread(&args[0]);
+            let b = gen.convert_expr_or_spread(&args[1]);
+            Some(quote! { #a.max(#b) })
+        }
+    } else {
+        None
+    }
+}
+
+fn handle_min(gen: &RustGenerator, args: &[ExprOrSpread]) -> Option<TokenStream> {
+    if args.len() == 1 && args[0].spread.is_some() {
+        let arg = gen.convert_expr_or_spread(&args[0]);
+        Some(quote! { #arg.iter().fold(f64::INFINITY, |a, &b| a.min(b)) })
+    } else if args.len() == 2 {
+        let a = gen.convert_expr_or_spread(&args[0]);
+        let b = gen.convert_expr_or_spread(&args[1]);
+        Some(quote! { #a.min(#b) })
+    } else {
+        None
+    }
+}
+
+fn handle_pow(gen: &RustGenerator, args: &[ExprOrSpread]) -> Option<TokenStream> {
+    if args.len() == 2 {
+        let base = gen.convert_expr_or_spread(&args[0]);
+        let exp = gen.convert_expr_or_spread(&args[1]);
+        Some(quote! { (#base as f64).powf(#exp as f64) })
+    } else {
+        None
+    }
+}
+
+fn handle_random(args: &[ExprOrSpread]) -> Option<TokenStream> {
+    if args.is_empty() {
+        Some(quote! { rand::random::<f64>() })
+    } else {
+        None
+    }
+}
+
+fn handle_sign(gen: &RustGenerator, args: &[ExprOrSpread]) -> Option<TokenStream> {
+    if args.len() == 1 {
+        let x = gen.convert_expr_or_spread(&args[0]);
+        Some(quote! {
+            { let __v = #x; if __v == 0.0 { 0.0 } else { __v.signum() } }
+        })
+    } else {
+        None
     }
 }

--- a/crates/tyrus_codegen/src/stdlib/string.rs
+++ b/crates/tyrus_codegen/src/stdlib/string.rs
@@ -13,121 +13,130 @@ pub(crate) fn handle(
 ) -> Option<TokenStream> {
     let obj_tokens = gen.convert_expr(obj);
     match method {
-        "includes" => {
-            if let Some(arg) = args.first() {
-                let val = gen.convert_expr_or_spread(arg);
-                Some(quote! { #obj_tokens.contains(&#val as &str) })
-            } else {
-                None
-            }
-        }
-        "replace" => {
-            if args.len() == 2 {
-                let pattern = gen.convert_expr_or_spread(&args[0]);
-                let replacement = gen.convert_expr_or_spread(&args[1]);
-                Some(quote! { #obj_tokens.replacen(&#pattern, &#replacement, 1) })
-            } else {
-                None
-            }
-        }
-        "split" => {
-            if let Some(arg) = args.first() {
-                let delimiter = gen.convert_expr_or_spread(arg);
-                Some(quote! { #obj_tokens.split(&#delimiter).collect::<Vec<_>>() })
-            } else {
-                None
-            }
-        }
-        "toUpperCase" => {
-            if args.is_empty() {
-                Some(quote! { #obj_tokens.to_uppercase() })
-            } else {
-                None
-            }
-        }
-        "toLowerCase" => {
-            if args.is_empty() {
-                Some(quote! { #obj_tokens.to_lowercase() })
-            } else {
-                None
-            }
-        }
-        "trim" => {
-            if args.is_empty() {
-                Some(quote! { #obj_tokens.trim().to_string() })
-            } else {
-                None
-            }
-        }
-        "startsWith" => {
-            if let Some(arg) = args.first() {
-                let val = gen.convert_expr_or_spread(arg);
-                Some(quote! { #obj_tokens.starts_with(&#val as &str) })
-            } else {
-                None
-            }
-        }
-        "endsWith" => {
-            if let Some(arg) = args.first() {
-                let val = gen.convert_expr_or_spread(arg);
-                Some(quote! { #obj_tokens.ends_with(&#val as &str) })
-            } else {
-                None
-            }
-        }
-        "toString" => {
-            if args.is_empty() {
-                Some(quote! { #obj_tokens.to_string() })
-            } else {
-                None
-            }
-        }
-        "substring" | "slice" => match args.len() {
-            1 => {
-                let start = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! { #obj_tokens[(#start as usize)..].to_string() })
-            }
-            2 => {
-                let start = gen.convert_expr_or_spread(&args[0]);
-                let end = gen.convert_expr_or_spread(&args[1]);
-                Some(quote! { #obj_tokens[(#start as usize)..(#end as usize)].to_string() })
-            }
-            _ => None,
-        },
-        "charAt" => {
-            if args.len() == 1 {
-                let idx = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! {
-                    #obj_tokens.chars().nth(#idx as usize).map(|c| c.to_string()).unwrap_or_default()
-                })
-            } else {
-                None
-            }
-        }
-        "indexOf" => {
-            if args.len() == 1 {
-                let substr = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! {
-                    match #obj_tokens.find(&#substr as &str) {
-                        Some(i) => i as f64,
-                        None => -1.0,
-                    }
-                })
-            } else {
-                None
-            }
-        }
-        "repeat" => {
-            if args.len() == 1 {
-                let n = gen.convert_expr_or_spread(&args[0]);
-                Some(quote! { #obj_tokens.repeat(#n as usize) })
-            } else {
-                None
-            }
-        }
+        "includes" => unary_str_method(gen, args, &obj_tokens, |v| {
+            quote! { #obj_tokens.contains(&#v as &str) }
+        }),
+        "replace" => handle_replace(gen, args, &obj_tokens),
+        "split" => unary_str_method(gen, args, &obj_tokens, |d| {
+            quote! { #obj_tokens.split(&#d).collect::<Vec<_>>() }
+        }),
+        "toUpperCase" => nullary_method(args, || quote! { #obj_tokens.to_uppercase() }),
+        "toLowerCase" => nullary_method(args, || quote! { #obj_tokens.to_lowercase() }),
+        "trim" => nullary_method(args, || quote! { #obj_tokens.trim().to_string() }),
+        "startsWith" => unary_str_method(gen, args, &obj_tokens, |v| {
+            quote! { #obj_tokens.starts_with(&#v as &str) }
+        }),
+        "endsWith" => unary_str_method(gen, args, &obj_tokens, |v| {
+            quote! { #obj_tokens.ends_with(&#v as &str) }
+        }),
+        "toString" => nullary_method(args, || quote! { #obj_tokens.to_string() }),
+        "substring" | "slice" => handle_substring(gen, args, &obj_tokens),
+        "charAt" => handle_char_at(gen, args, &obj_tokens),
+        "indexOf" => handle_index_of(gen, args, &obj_tokens),
+        "repeat" => handle_repeat(gen, args, &obj_tokens),
         "padStart" => pad_tokens(&obj_tokens, args, gen, true),
         "padEnd" => pad_tokens(&obj_tokens, args, gen, false),
         _ => None,
+    }
+}
+
+fn nullary_method(
+    args: &[ExprOrSpread],
+    emit: impl FnOnce() -> TokenStream,
+) -> Option<TokenStream> {
+    if args.is_empty() {
+        Some(emit())
+    } else {
+        None
+    }
+}
+
+fn unary_str_method(
+    gen: &RustGenerator,
+    args: &[ExprOrSpread],
+    _obj_tokens: &TokenStream,
+    emit: impl FnOnce(TokenStream) -> TokenStream,
+) -> Option<TokenStream> {
+    args.first()
+        .map(|arg| emit(gen.convert_expr_or_spread(arg)))
+}
+
+fn handle_replace(
+    gen: &RustGenerator,
+    args: &[ExprOrSpread],
+    obj_tokens: &TokenStream,
+) -> Option<TokenStream> {
+    if args.len() == 2 {
+        let pattern = gen.convert_expr_or_spread(&args[0]);
+        let replacement = gen.convert_expr_or_spread(&args[1]);
+        Some(quote! { #obj_tokens.replacen(&#pattern, &#replacement, 1) })
+    } else {
+        None
+    }
+}
+
+fn handle_substring(
+    gen: &RustGenerator,
+    args: &[ExprOrSpread],
+    obj_tokens: &TokenStream,
+) -> Option<TokenStream> {
+    match args.len() {
+        1 => {
+            let start = gen.convert_expr_or_spread(&args[0]);
+            Some(quote! { #obj_tokens[(#start as usize)..].to_string() })
+        }
+        2 => {
+            let start = gen.convert_expr_or_spread(&args[0]);
+            let end = gen.convert_expr_or_spread(&args[1]);
+            Some(quote! { #obj_tokens[(#start as usize)..(#end as usize)].to_string() })
+        }
+        _ => None,
+    }
+}
+
+fn handle_char_at(
+    gen: &RustGenerator,
+    args: &[ExprOrSpread],
+    obj_tokens: &TokenStream,
+) -> Option<TokenStream> {
+    if args.len() == 1 {
+        let idx = gen.convert_expr_or_spread(&args[0]);
+        Some(quote! {
+            #obj_tokens.chars().nth(#idx as usize).map(|c| c.to_string()).unwrap_or_default()
+        })
+    } else {
+        None
+    }
+}
+
+fn handle_index_of(
+    gen: &RustGenerator,
+    args: &[ExprOrSpread],
+    obj_tokens: &TokenStream,
+) -> Option<TokenStream> {
+    if args.len() == 1 {
+        let substr = gen.convert_expr_or_spread(&args[0]);
+        Some(quote! {
+            match #obj_tokens.find(&#substr as &str) {
+                Some(i) => i as f64,
+                None => -1.0,
+            }
+        })
+    } else {
+        None
+    }
+}
+
+fn handle_repeat(
+    gen: &RustGenerator,
+    args: &[ExprOrSpread],
+    obj_tokens: &TokenStream,
+) -> Option<TokenStream> {
+    if args.len() == 1 {
+        let n = gen.convert_expr_or_spread(&args[0]);
+        Some(quote! { #obj_tokens.repeat(#n as usize) })
+    } else {
+        None
     }
 }
 
@@ -143,57 +152,57 @@ fn pad_tokens(
     }
     let target_len = gen.convert_expr_or_spread(&args[0]);
     if args.len() >= 2 {
-        let fill = gen.convert_expr_or_spread(&args[1]);
-        Some(if is_start {
-            quote! {{
-                let __s = #obj_tokens;
-                let __target = #target_len as usize;
-                let __fill: String = #fill.to_string();
-                let __char_count = __s.chars().count();
-                if __char_count >= __target {
-                    __s
-                } else {
-                    let __pad_len = __target - __char_count;
-                    let __pad: String = __fill.chars().cycle().take(__pad_len).collect();
-                    format!("{}{}", __pad, __s)
-                }
-            }}
-        } else {
-            quote! {{
-                let __s = #obj_tokens;
-                let __target = #target_len as usize;
-                let __fill: String = #fill.to_string();
-                let __char_count = __s.chars().count();
-                if __char_count >= __target {
-                    __s
-                } else {
-                    let __pad_len = __target - __char_count;
-                    let __pad: String = __fill.chars().cycle().take(__pad_len).collect();
-                    format!("{}{}", __s, __pad)
-                }
-            }}
-        })
+        pad_with_fill(obj_tokens, &target_len, gen, args, is_start)
     } else {
-        Some(if is_start {
-            quote! {{
-                let __s = #obj_tokens;
-                let __target = #target_len as usize;
-                if __s.chars().count() >= __target {
-                    __s
-                } else {
-                    format!("{:>width$}", __s, width = __target)
-                }
-            }}
-        } else {
-            quote! {{
-                let __s = #obj_tokens;
-                let __target = #target_len as usize;
-                if __s.chars().count() >= __target {
-                    __s
-                } else {
-                    format!("{:<width$}", __s, width = __target)
-                }
-            }}
-        })
+        pad_with_space(obj_tokens, &target_len, is_start)
     }
+}
+
+fn pad_with_fill(
+    obj_tokens: &TokenStream,
+    target_len: &TokenStream,
+    gen: &RustGenerator,
+    args: &[ExprOrSpread],
+    is_start: bool,
+) -> Option<TokenStream> {
+    let fill = gen.convert_expr_or_spread(&args[1]);
+    let fmt = if is_start {
+        quote! { format!("{}{}", __pad, __s) }
+    } else {
+        quote! { format!("{}{}", __s, __pad) }
+    };
+    Some(quote! {{
+        let __s = #obj_tokens;
+        let __target = #target_len as usize;
+        let __fill: String = #fill.to_string();
+        let __char_count = __s.chars().count();
+        if __char_count >= __target {
+            __s
+        } else {
+            let __pad_len = __target - __char_count;
+            let __pad: String = __fill.chars().cycle().take(__pad_len).collect();
+            #fmt
+        }
+    }})
+}
+
+fn pad_with_space(
+    obj_tokens: &TokenStream,
+    target_len: &TokenStream,
+    is_start: bool,
+) -> Option<TokenStream> {
+    let fmt = if is_start {
+        quote! { format!("{:>width$}", __s, width = __target) }
+    } else {
+        quote! { format!("{:<width$}", __s, width = __target) }
+    };
+    Some(quote! {{
+        let __s = #obj_tokens;
+        let __target = #target_len as usize;
+        if __s.chars().count() >= __target {
+            __s
+        } else {
+            #fmt
+        }
+    }})
 }


### PR DESCRIPTION
## Summary

Phase R1-R4 + R7 of function size refactoring. Reduced violations from 18 to 10.

## Results

| Function | Before | After | Phase |
|----------|--------|-------|-------|
| convert_method | **256** | 48 | R1 |
| convert_constructor | **193** | 47 | R2 |
| math::handle | **158** | 23 | R3 |
| process_fn_decl | **139** | 43 | R4 |
| array::handle | **133** | 25 | R3 |
| string::handle | **124** | 33 | R3 |
| map_type_core | **104** | 12 | R7 |

## Patterns used
- Dispatcher + helpers (stdlib match arms)
- Context structs replacing long param lists (MethodContext, ConstructorCtx)
- Generic helpers (unary_method, nullary_method)

## Test plan
- [x] `cargo nextest run --workspace` — 179 passed after EACH commit
- [x] `cargo clippy --workspace` — clean after EACH commit
- [x] Zero behavior changes — pure structural refactoring

Closes #76