### PR TITLE
fix: arrow closure flag leak + method.rs over 400 lines

### DIFF
--- a/crates/tyrus_codegen/src/convert/class/method.rs
+++ b/crates/tyrus_codegen/src/convert/class/method.rs
@@ -230,27 +230,7 @@ fn wrap_handler_return_type(
     }
 }
 
-/// Maps an HTTP status code to its axum StatusCode constant.
-fn map_status_code(code: u16) -> proc_macro2::TokenStream {
-    match code {
-        200 => quote! { axum::http::StatusCode::OK },
-        201 => quote! { axum::http::StatusCode::CREATED },
-        204 => quote! { axum::http::StatusCode::NO_CONTENT },
-        301 => quote! { axum::http::StatusCode::MOVED_PERMANENTLY },
-        400 => quote! { axum::http::StatusCode::BAD_REQUEST },
-        401 => quote! { axum::http::StatusCode::UNAUTHORIZED },
-        403 => quote! { axum::http::StatusCode::FORBIDDEN },
-        404 => quote! { axum::http::StatusCode::NOT_FOUND },
-        409 => quote! { axum::http::StatusCode::CONFLICT },
-        500 => quote! { axum::http::StatusCode::INTERNAL_SERVER_ERROR },
-        100..=999 => {
-            quote! { axum::http::StatusCode::from_u16(#code).unwrap_or(axum::http::StatusCode::INTERNAL_SERVER_ERROR) }
-        }
-        _ => {
-            quote! { compile_error!("Tyrus: @HttpCode value is not a valid HTTP status code (100-999)") }
-        }
-    }
-}
+use super::routing::{build_doc_comment, map_status_code};
 
 /// Builds a handler return expression with Json wrapping and optional StatusCode.
 fn build_handler_return(
@@ -354,24 +334,6 @@ fn build_return_stmt(
     }
 
     quote! { return #expr; }
-}
-
-/// Builds the doc comment for a handler method.
-fn build_doc_comment(http_method: &Option<String>, route_path: &str) -> proc_macro2::TokenStream {
-    let Some(m) = http_method.as_ref() else {
-        return quote! {};
-    };
-
-    let method_str = m.to_uppercase();
-    let route = if route_path.is_empty() {
-        "/".to_string()
-    } else {
-        route_path.to_string()
-    };
-
-    quote! {
-        #[doc = concat!("Route: ", #method_str, " ", #route)]
-    }
 }
 
 impl RustGenerator {

--- a/crates/tyrus_codegen/src/convert/class/routing.rs
+++ b/crates/tyrus_codegen/src/convert/class/routing.rs
@@ -112,6 +112,47 @@ pub(crate) fn generate_router_method(
     }
 }
 
+/// Maps an HTTP status code to its axum StatusCode constant.
+pub(crate) fn map_status_code(code: u16) -> proc_macro2::TokenStream {
+    use quote::quote;
+    match code {
+        200 => quote! { axum::http::StatusCode::OK },
+        201 => quote! { axum::http::StatusCode::CREATED },
+        204 => quote! { axum::http::StatusCode::NO_CONTENT },
+        301 => quote! { axum::http::StatusCode::MOVED_PERMANENTLY },
+        400 => quote! { axum::http::StatusCode::BAD_REQUEST },
+        401 => quote! { axum::http::StatusCode::UNAUTHORIZED },
+        403 => quote! { axum::http::StatusCode::FORBIDDEN },
+        404 => quote! { axum::http::StatusCode::NOT_FOUND },
+        409 => quote! { axum::http::StatusCode::CONFLICT },
+        500 => quote! { axum::http::StatusCode::INTERNAL_SERVER_ERROR },
+        100..=999 => {
+            quote! { axum::http::StatusCode::from_u16(#code).unwrap_or(axum::http::StatusCode::INTERNAL_SERVER_ERROR) }
+        }
+        _ => {
+            quote! { compile_error!("Tyrus: @HttpCode value is not a valid HTTP status code (100-999)") }
+        }
+    }
+}
+
+/// Builds the doc comment for a handler method.
+pub(crate) fn build_doc_comment(
+    http_method: &Option<String>,
+    route_path: &str,
+) -> proc_macro2::TokenStream {
+    use quote::quote;
+    let Some(m) = http_method.as_ref() else {
+        return quote! {};
+    };
+    let method_str = m.to_uppercase();
+    let route = if route_path.is_empty() {
+        "/".to_string()
+    } else {
+        route_path.to_string()
+    };
+    quote! { #[doc = concat!("Route: ", #method_str, " ", #route)] }
+}
+
 impl RustGenerator {
     /// Emits controller-specific code: `FromRequestParts` impl, router method,
     /// and records the controller metadata.

--- a/crates/tyrus_codegen/src/convert/expr/arrow.rs
+++ b/crates/tyrus_codegen/src/convert/expr/arrow.rs
@@ -24,6 +24,10 @@ impl RustGenerator {
             })
             .collect();
 
+        // Save and reset state flag — closures don't capture `state` from handler scope
+        let saved_flag = self.use_state_for_this.get();
+        self.use_state_for_this.set(false);
+
         let body = match &*arrow.body {
             BlockStmtOrExpr::BlockStmt(block) => {
                 let stmts: Vec<_> = block.stmts.iter().map(|s| self.convert_stmt(s)).collect();
@@ -31,6 +35,8 @@ impl RustGenerator {
             }
             BlockStmtOrExpr::Expr(expr) => self.convert_expr(expr),
         };
+
+        self.use_state_for_this.set(saved_flag);
 
         quote! {
             |#(#params),*| #body

--- a/tests/tests/tier4_tests.rs
+++ b/tests/tests/tier4_tests.rs
@@ -120,8 +120,7 @@ fn test_tier4_full_build() {
 
     // Check for Router Merge
     assert!(
-        main_content.contains("CatsController::router(cats_controller.clone())")
-            || main_content.contains("CatsController::router()"),
+        main_content.contains("CatsController::router(cats_controller.clone())"),
         "Router merge missing: {main_content}"
     );
 


### PR DESCRIPTION
## Summary

Code review fixes from PR #83 that weren't included in merge.

## Changes

1. **Arrow closure flag leak** — `convert_arrow_expr` now saves/restores `use_state_for_this` flag. Prevents `state` from leaking into closures inside handler bodies.

2. **method.rs over 400 lines** — Moved `map_status_code` + `build_doc_comment` to `routing.rs`. method.rs: 426 → 388 lines.

3. **Test assertion tightened** — Removed dead fallback branch for old `router()` pattern.

## Test plan
- [x] 179 tests pass
- [x] clippy clean
- [x] method.rs at 388 lines (< 400)

Closes #84