### PR TITLE
fix: deadlock in Mutex self-assignment — enables POST requests

### DIFF
--- a/crates/tyrus_codegen/src/convert/expr/misc.rs
+++ b/crates/tyrus_codegen/src/convert/expr/misc.rs
@@ -21,13 +21,26 @@ impl RustGenerator {
                             let prop_name = to_snake_case(prop_ident.sym.as_ref());
                             let field = format_ident!("{}", prop_name);
 
+                            let receiver = if self.use_state_for_this.get() {
+                                quote! { state }
+                            } else {
+                                quote! { self }
+                            };
+
                             if self
                                 .current_class_state_fields
                                 .contains_key(prop_ident.sym.as_ref())
                             {
-                                quote! { *self.#field.lock().unwrap_or_else(|e| e.into_inner()) }
+                                // Avoid deadlock: read value first, then write
+                                // This prevents double-locking the same Mutex
+                                return quote! {
+                                    {
+                                        let __new_val = #right;
+                                        *#receiver.#field.lock().unwrap_or_else(|e| e.into_inner()) = __new_val;
+                                    }
+                                };
                             } else {
-                                quote! { self.#field }
+                                quote! { #receiver.#field }
                             }
                         } else {
                             quote! { compile_error!("Tyrus: unsupported self member assignment") }


### PR DESCRIPTION
## Summary

Fixes deadlock in generated code when assigning to a Mutex-wrapped state field that references itself (e.g., `this.nextId = this.nextId + 1`).

## The Bug

```rust
// BEFORE — deadlocks:
*self.next_id.lock()... = *self.next_id.lock()... + 1f64;
// First lock held while second lock requested → DEADLOCK

// AFTER — works:
{
    let __new_val = *self.next_id.lock()... + 1f64;  // lock + release
    *self.next_id.lock()... = __new_val;              // lock + release
}
```

## Server Test Results

```
GET  /users      → []                                    ✅
POST /users      → {"id":0,"name":"Alice","email":"..."}  ✅
POST /users      → {"id":1,"name":"Bob","email":"..."}    ✅
GET  /users      → [{...},{...}]                          ✅
```

**The NestJS CRUD server is now fully functional!**

## Test plan
- [x] 179 tests pass
- [x] clippy clean
- [x] Manual: GET + POST + GET verified on port 3100

Closes #86