### PR TITLE
docs: milestone — first NestJS CRUD server compiled to Rust

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,7 @@ tests/
 
 See `docs/superpowers/plans/2026-03-12-full-refactoring-roadmap.md` for the complete plan.
 
-**Completed:** Chunks 1-7 + Milestones 13A/13B + Milestone 14 HIGH + CLI/IR/Analyzer evolution + Phase 6.0-6.6
-**Current:** Phase 7.3 complete — @Param, @Query, @HttpCode, HttpException, DI fix, function refactoring
+**Completed:** Phase 1-6 + Phase 7.1-7.3 + full function refactoring + working NestJS server
+**Current:** MILESTONE — First NestJS CRUD server compiled to Rust (GET + POST working)
 **Status:** 179 tests passing (71 equivalence + 8 IR + 7 CLI + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped)
+**Server:** `tyrus compile src/ --output build/` → Axum server with GET/POST endpoints

--- a/README.md
+++ b/README.md
@@ -8,7 +8,14 @@ _Academic Project in Compiler Theory & Semantic Preservation_
 ![Rust Version](https://img.shields.io/badge/rust-1.75%2B-orange)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 
-Tyrus is a source-to-source compiler designed to bridge the gap between high-level dynamic syntax (TypeScript) and low-level memory safety (Rust). As an academic initiative, it focuses on the formal mapping of higher-order abstractions to zero-cost Rust equivalents, exploring the boundaries of **Semantic Preservation** across differing execution models.
+Tyrus is a source-to-source compiler designed to bridge the gap between high-level dynamic syntax (TypeScript) and low-level memory safety (Rust). It focuses on the formal mapping of higher-order abstractions to zero-cost Rust equivalents, exploring the boundaries of **Semantic Preservation** across differing execution models.
+
+**Milestone:** Tyrus can now compile a NestJS CRUD API into a working Axum (Rust) server with a single command:
+
+```bash
+tyrus compile my-nestjs-project/src --output rust-server
+# → Rust binary with GET/POST endpoints, DI, and in-memory state
+```
 
 ---
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -8,7 +8,14 @@ _Projeto Acadêmico em Teoria de Compiladores e Preservação Semântica_
 ![Rust Version](https://img.shields.io/badge/rust-1.75%2B-orange)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 
-Tyrus é um compilador source-to-source projetado para conectar a sintaxe dinâmica de alto nível (TypeScript) à segurança de memória de baixo nível (Rust). Como uma iniciativa acadêmica, concentra-se no mapeamento formal de abstrações de ordem superior para equivalentes Rust de custo zero, explorando os limites da **Preservação Semântica** entre modelos de execução distintos.
+Tyrus é um compilador source-to-source projetado para conectar a sintaxe dinâmica de alto nível (TypeScript) à segurança de memória de baixo nível (Rust). Concentra-se no mapeamento formal de abstrações de ordem superior para equivalentes Rust de custo zero, explorando os limites da **Preservação Semântica** entre modelos de execução distintos.
+
+**Marco:** O Tyrus agora compila uma API NestJS CRUD em um servidor Axum (Rust) funcional:
+
+```bash
+tyrus compile meu-projeto-nestjs/src --output servidor-rust
+# → Binário Rust com endpoints GET/POST, DI e estado em memória
+```
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the major milestone: Tyrus can now compile a NestJS CRUD API into a working Axum server.

## What Works

```
tyrus compile my-nestjs-project/src --output rust-server

GET  /users      → []
POST /users      → {"id":0,"name":"Alice","email":"alice@test.com"}
POST /users      → {"id":1,"name":"Bob","email":"bob@test.com"}
GET  /users      → [{...},{...}]
```

## Test plan
- [x] Documentation only
- [x] Pre-commit passed

Closes #88