### PR TITLE
feat(codegen): object spread — {...base, field} → struct update syntax

### DIFF
--- a/crates/tyrus_codegen/src/convert/expr/literal.rs
+++ b/crates/tyrus_codegen/src/convert/expr/literal.rs
@@ -145,21 +145,34 @@ impl RustGenerator {
         let type_ident = format_ident!("{}", type_name);
         let mut fields = Vec::new();
 
+        let mut spread_base: Option<TokenStream> = None;
+
         for prop in &obj.props {
-            if let swc_ecma_ast::PropOrSpread::Prop(p) = prop {
-                if let swc_ecma_ast::Prop::KeyValue(kv) = &**p {
-                    if let swc_ecma_ast::PropName::Ident(key_ident) = &kv.key {
-                        let field_name = format_ident!("{}", to_snake_case(key_ident.sym.as_ref()));
-                        let val = self.convert_expr(&kv.value);
-                        fields.push(quote! { #field_name: #val });
+            match prop {
+                swc_ecma_ast::PropOrSpread::Spread(spread) => {
+                    spread_base = Some(self.convert_expr(&spread.expr));
+                }
+                swc_ecma_ast::PropOrSpread::Prop(p) => {
+                    if let swc_ecma_ast::Prop::KeyValue(kv) = &**p {
+                        if let swc_ecma_ast::PropName::Ident(key_ident) = &kv.key {
+                            let field_name =
+                                format_ident!("{}", to_snake_case(key_ident.sym.as_ref()));
+                            let val = self.convert_expr(&kv.value);
+                            fields.push(quote! { #field_name: #val });
+                        }
+                    } else if let swc_ecma_ast::Prop::Shorthand(shorthand) = &**p {
+                        let field_name = format_ident!("{}", to_snake_case(shorthand.sym.as_ref()));
+                        fields.push(quote! { #field_name: #field_name.clone() });
                     }
-                } else if let swc_ecma_ast::Prop::Shorthand(shorthand) = &**p {
-                    let field_name = format_ident!("{}", to_snake_case(shorthand.sym.as_ref()));
-                    fields.push(quote! { #field_name: #field_name.clone() });
                 }
             }
         }
 
-        Some(quote! { #type_ident { #(#fields),* } })
+        // Rust struct update syntax: Type { field: val, ..base }
+        if let Some(base) = spread_base {
+            Some(quote! { #type_ident { #(#fields,)* ..#base } })
+        } else {
+            Some(quote! { #type_ident { #(#fields),* } })
+        }
     }
 }

--- a/tests/src/equivalence/spread.rs
+++ b/tests/src/equivalence/spread.rs
@@ -42,3 +42,47 @@ console.log(copy());
 "#,
     );
 }
+
+#[test]
+fn test_equivalence_object_spread_override() {
+    assert_output_equivalent(
+        r#"
+interface Config {
+    host: string;
+    port: number;
+    debug: boolean;
+}
+function createProd(base: Config): Config {
+    const prod: Config = { ...base, debug: false };
+    return prod;
+}
+function main(): void {
+    const dev: Config = { host: "localhost", port: 3100, debug: true };
+    const prod: Config = createProd(dev);
+    console.log(prod.host);
+    console.log(prod.port);
+    console.log(prod.debug);
+}
+main();
+"#,
+    );
+}
+
+#[test]
+fn test_equivalence_object_spread_copy() {
+    assert_output_equivalent(
+        r#"
+interface Point {
+    x: number;
+    y: number;
+}
+function main(): void {
+    const p: Point = { x: 10, y: 20 };
+    const copy: Point = { ...p };
+    console.log(copy.x);
+    console.log(copy.y);
+}
+main();
+"#,
+    );
+}


### PR DESCRIPTION
## Summary

Support TypeScript object spread syntax `{...base, field: value}` by generating Rust struct update syntax `Type { field: val, ..base }`.

```typescript
const prod: Config = { ...base, debug: false };
// → Rust: Config { debug: false, ..base }
```

## Test plan

- [x] `test_equivalence_object_spread_override` — Config with field override (TS↔Rust identical)
- [x] `test_equivalence_object_spread_copy` — Point full copy (TS↔Rust identical)
- [x] 188 tests passing (+2 new), 0 regressions

Closes #100