### PR TITLE
docs: sync all docs with Phase 8 completion (195 tests)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,8 +177,7 @@ tests/
 
 See `docs/superpowers/plans/2026-03-12-full-refactoring-roadmap.md` for the complete plan.
 
-**Completed:** Phase 1-6 + Phase 7.1-7.3 + full function refactoring + working NestJS CRUD server
-**Current:** MILESTONE — First NestJS CRUD server compiled to Rust (GET + POST working)
-**Pending PRs:** #91 (getter/setter, Phase 6.5), #93 (@UseGuards, Phase 7.4)
-**Status:** 179 tests on main (71 equivalence + 49 unit + 20 snapshot + 21 IR + 9 compilation + 7 CLI + 1 trybuild + 1 skipped)
-**Server:** `tyrus compile src/ --output build/` → Axum server with GET/POST endpoints
+**Completed:** Phase 1-8 complete. Full NestJS → Rust transpilation with HTTP equivalence verified.
+**Milestone:** Multi-module NestJS project transpiles, compiles, and serves correct HTTP responses.
+**Status:** 195 tests (81 equivalence + 49 unit + 20 snapshot + 21 IR + 9 compilation + 7 CLI + 5 E2E/build + 1 trybuild + 1 skipped)
+**E2E:** `test_http_equivalence_rust_server` — transpile → compile → start server → verify GET responses

--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ Adhering to strict "Safe Transpilation" principles:
 - **Console** (5): `log`, `error`, `warn`, `info`, `debug`
 - **Control Flow**: `if/else`, `while`, `for`, `for-of`, `do-while`, `switch/case`, ternary, `try/catch`
 - **Top-Level Statements**: `const`, `let`, expressions auto-wrapped in `fn main()`
-- **Spread Operator**: `[...arr1, ...arr2]` → iterator chain
+- **Spread Operator**: `[...arr1, ...arr2]` → iterator chain, `{...obj, field}` → struct update
 - **Class Inheritance**: `extends`, `super()`, method override via field flattening
+- **Getters/Setters**: `get prop()` → `fn prop(&self)`, `set prop(v)` → `fn set_prop(&mut self, v)`
 - **Static Methods**: `static add()` → associated function, `Class.method()` → `Class::method()`
 - **Type Assertions**: `as Type` → no-op (compile-time only)
 - **Numeric Enums**: `enum Direction { Up = 0 }` → `#[repr(i32)] enum` with `Display`
@@ -81,6 +82,7 @@ Adhering to strict "Safe Transpilation" principles:
 - **Class State**: Automatic `Arc<Mutex<T>>` wrapping for services/controllers
 - **Interfaces**: `interface` -> `#[derive(Serialize, Deserialize)] struct`
 - **String Unions**: `type Status = "a" | "b"` -> `enum` with `Display` and `PartialEq`
+- **NestJS Guards**: `@UseGuards(Guard)` → `axum::middleware::from_fn()` layer
 
 ---
 
@@ -171,19 +173,20 @@ tyrus --quiet check ./src/index.ts
 
 ## 🧪 Test Suite
 
-179 tests across 7 test types and 4 feature tiers:
+195 tests across 8 test types and 4 feature tiers:
 
 | Type | Count | Description |
 |------|-------|-------------|
-| **Equivalence** | 71 | Semantic proof: TS and Rust produce identical stdout |
+| **Equivalence** | 81 | Semantic proof: TS and Rust produce identical stdout |
 | **Unit** | 49 | Fast, isolated codegen function tests |
 | **Snapshot** | 20 | Full transpilation output via `insta` |
 | **IR** | 21 | Typed intermediate representation lowering |
 | **Compilation** | 9 | Generated Rust passes `cargo check` per tier |
 | **CLI** | 7 | Integration tests for all CLI commands and flags |
 | **Trybuild** | 1 | Compile-verification of generated Rust |
+| **E2E/Build** | 5 | Full pipeline: transpile → compile → run server → verify HTTP |
 
-Test types: **Equivalence** (TS↔Rust same output) · **Unit** (fast, isolated functions) · **Snapshot** (insta, codegen output) · **IR** (type lowering) · **Compilation** (generated Rust passes `cargo check`) · **CLI** (command integration) · **Trybuild** (compile-verification)
+Test types: **Equivalence** (TS↔Rust same output) · **Unit** (fast, isolated functions) · **Snapshot** (insta, codegen output) · **IR** (type lowering) · **Compilation** (generated Rust passes `cargo check`) · **CLI** (command integration) · **E2E** (HTTP server verification) · **Trybuild** (compile-verification)
 
 ---
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -72,8 +72,9 @@ Aderindo aos princípios estritos de "Transpilação Segura":
 - **Console** (5): `log`, `error`, `warn`, `info`, `debug`
 - **Fluxo de Controle**: `if/else`, `while`, `for`, `for-of`, `do-while`, `switch/case`, ternário, `try/catch`
 - **Top-Level Statements**: `const`, `let`, expressões auto-wrapped em `fn main()`
-- **Spread Operator**: `[...arr1, ...arr2]` → iterator chain
+- **Spread Operator**: `[...arr1, ...arr2]` → iterator chain, `{...obj, field}` → struct update
 - **Herança de Classe**: `extends`, `super()`, override de métodos via field flattening
+- **Getters/Setters**: `get prop()` → `fn prop(&self)`, `set prop(v)` → `fn set_prop(&mut self, v)`
 - **Métodos Estáticos**: `static add()` → função associada, `Class.method()` → `Class::method()`
 - **Type Assertions**: `as Type` → no-op (apenas compile-time)
 - **Enums Numéricos**: `enum Direction { Up = 0 }` → `#[repr(i32)] enum` com `Display`
@@ -81,6 +82,7 @@ Aderindo aos princípios estritos de "Transpilação Segura":
 - **Estado de Classe**: Encapsulamento automático com `Arc<Mutex<T>>` para services/controllers
 - **Interfaces**: `interface` -> `#[derive(Serialize, Deserialize)] struct`
 - **Unions de String**: `type Status = "a" | "b"` -> `enum` com `Display` e `PartialEq`
+- **Guards NestJS**: `@UseGuards(Guard)` → `axum::middleware::from_fn()` layer
 
 ---
 
@@ -165,19 +167,20 @@ tyrus --quiet check ./src/index.ts
 
 ## 🧪 Suite de Testes
 
-179 testes distribuídos em 7 tipos de teste e 4 camadas de funcionalidades:
+195 testes distribuídos em 8 tipos de teste e 4 camadas de funcionalidades:
 
 | Tipo | Quantidade | Descrição |
 |------|-----------|-----------|
-| **Equivalência** | 71 | Prova semântica: TS e Rust produzem stdout idêntico |
+| **Equivalência** | 81 | Prova semântica: TS e Rust produzem stdout idêntico |
 | **Unitário** | 49 | Rápido, funções isoladas de codegen |
 | **Snapshot** | 20 | Saída completa de transpilação via `insta` |
 | **IR** | 21 | Lowering de representação intermediária tipada |
 | **Compilação** | 9 | Rust gerado passa no `cargo check` por camada |
 | **CLI** | 7 | Testes de integração para todos os comandos e flags |
 | **Trybuild** | 1 | Verificação de compilação do Rust gerado |
+| **E2E/Build** | 5 | Pipeline completo: transpilar → compilar → executar servidor → verificar HTTP |
 
-Tipos de teste: **Equivalência** (TS↔Rust mesma saída) · **Unitário** (funções rápidas e isoladas) · **Snapshot** (insta, saída do codegen) · **IR** (type lowering) · **Compilação** (Rust gerado passa no `cargo check`) · **CLI** (integração de comandos) · **Trybuild** (verificação de compilação)
+Tipos de teste: **Equivalência** (TS↔Rust mesma saída) · **Unitário** (funções rápidas e isoladas) · **Snapshot** (insta, saída do codegen) · **IR** (type lowering) · **Compilação** (Rust gerado passa no `cargo check`) · **CLI** (integração de comandos) · **E2E** (verificação de servidor HTTP) · **Trybuild** (verificação de compilação)
 
 ---
 

--- a/tests/tests/tier4_tests.rs
+++ b/tests/tests/tier4_tests.rs
@@ -262,20 +262,21 @@ fn test_http_equivalence_rust_server() {
         .spawn()
         .expect("start server");
 
-    // 5. Wait for server to be ready (poll health)
+    // 5. Wait for server to be ready
     let ready = wait_for_server("http://127.0.0.1:3100/", 30);
-
-    // 6. Run HTTP checks
-    if ready {
-        verify_endpoint("http://127.0.0.1:3100/", "ok");
-        verify_endpoint("http://127.0.0.1:3100/users", "[]");
+    if !ready {
+        server.kill().ok();
+        server.wait().ok();
+        panic!("Server did not start within 30 attempts");
     }
+
+    // 6. Verify HTTP responses
+    verify_endpoint("http://127.0.0.1:3100/", "ok");
+    verify_endpoint("http://127.0.0.1:3100/users", "[]");
 
     // 7. Cleanup
     server.kill().ok();
     server.wait().ok();
-
-    assert!(ready, "Server did not start within 30 attempts");
 }
 
 fn wait_for_server(url: &str, max_attempts: u32) -> bool {


### PR DESCRIPTION
## Summary

- CLAUDE.md: Phase 1-8 complete, 195 tests, E2E milestone
- README.md: +3 patterns (getters/setters, object spread, @UseGuards)
- README.md: test table 179→195, new E2E/Build category
- README.pt-br.md: synced with English
- Fix: test function length 51→48 lines (code review)

## Test plan

- [x] 195 tests passing, 0 regressions