### PR TITLE
refactor(codegen): decorator registry foundation (PR #1 of 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,6 +1985,7 @@ dependencies = [
  "swc_ecma_ast",
  "swc_ecma_visit",
  "tyrus_common",
+ "tyrus_decorator_kinds",
  "tyrus_di",
  "tyrus_diagnostics",
 ]
@@ -2030,6 +2031,7 @@ dependencies = [
  "syn",
  "tyrus_ast",
  "tyrus_common",
+ "tyrus_decorator_kinds",
 ]
 
 [[package]]
@@ -2040,6 +2042,10 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tyrus_decorator_kinds"
+version = "0.1.0"
 
 [[package]]
 name = "tyrus_di"

--- a/crates/tyrus_analyzer/Cargo.toml
+++ b/crates/tyrus_analyzer/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 tyrus_common = { path = "../tyrus_common" }
 tyrus_diagnostics = { path = "../tyrus_diagnostics" }
 tyrus_di = { path = "../tyrus_di" }
+tyrus_decorator_kinds = { path = "../tyrus_decorator_kinds" }
 swc_ecma_ast = "18.0.0"
 swc_ecma_visit = "18.0.0"
 swc_common = { version = "17.0.1", features = ["tty-emitter"] }

--- a/crates/tyrus_analyzer/src/decorators.rs
+++ b/crates/tyrus_analyzer/src/decorators.rs
@@ -1,5 +1,6 @@
 use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitWith};
+use tyrus_decorator_kinds::DecoratorKind;
 use tyrus_di::graph::DiGraph;
 use tyrus_di::module::Module;
 use tyrus_di::provider::{InjectionScope, Provider};
@@ -35,6 +36,69 @@ impl DecoratorVisitor {
         }
         None
     }
+
+    /// Parses an `@Module({ imports, providers, controllers, exports })`
+    /// decorator into a [`Module`] for the DI graph.
+    fn parse_module_metadata(&self, class_name: &str, decorator: &Decorator) -> Module {
+        let mut module = Module {
+            name: class_name.to_string(),
+            imports: vec![],
+            providers: vec![],
+            controllers: vec![],
+            exports: vec![],
+        };
+        let Some(obj) = self.extract_decorator_args(decorator) else {
+            return module;
+        };
+        for prop in obj.props {
+            let PropOrSpread::Prop(prop) = prop else {
+                continue;
+            };
+            let Prop::KeyValue(kv) = *prop else { continue };
+            let PropName::Ident(key) = kv.key else {
+                continue;
+            };
+            let Expr::Array(arr) = *kv.value else {
+                continue;
+            };
+            let values = collect_ident_array(&arr);
+            match key.sym.as_ref() {
+                "imports" => module.imports = values,
+                "providers" => module.providers = values_to_providers(values),
+                "controllers" => module.controllers = values,
+                "exports" => module.exports = values,
+                _ => {}
+            }
+        }
+        module
+    }
+}
+
+/// Collects ident expressions from an array literal, ignoring spreads/non-idents.
+fn collect_ident_array(arr: &ArrayLit) -> Vec<String> {
+    arr.elems
+        .iter()
+        .filter_map(|e| {
+            let ExprOrSpread { expr, .. } = e.as_ref()?;
+            if let Expr::Ident(i) = &**expr {
+                return Some(i.sym.to_string());
+            }
+            None
+        })
+        .collect()
+}
+
+/// Wraps each ident name in a `Provider` (singleton, deps filled later).
+fn values_to_providers(values: Vec<String>) -> Vec<Provider> {
+    values
+        .into_iter()
+        .map(|v| Provider {
+            token: v.clone(),
+            implementation: v,
+            scope: InjectionScope::Singleton,
+            dependencies: vec![],
+        })
+        .collect()
 }
 
 impl Visit for DecoratorVisitor {
@@ -43,73 +107,30 @@ impl Visit for DecoratorVisitor {
         let mut is_injectable = false;
 
         for decorator in &n.class.decorators {
-            if let Expr::Call(call_expr) = &*decorator.expr {
-                if let Callee::Expr(expr) = &call_expr.callee {
-                    if let Expr::Ident(ident) = &**expr {
-                        if ident.sym == *"Module" {
-                            // Extract Module Metadata
-                            let mut module = Module {
-                                name: class_name.clone(),
-                                imports: vec![],
-                                providers: vec![],
-                                controllers: vec![],
-                                exports: vec![],
-                            };
-
-                            if let Some(obj) = self.extract_decorator_args(decorator) {
-                                for prop in obj.props {
-                                    if let PropOrSpread::Prop(prop) = prop {
-                                        if let Prop::KeyValue(kv) = *prop {
-                                            if let PropName::Ident(key) = kv.key {
-                                                if let Expr::Array(arr) = *kv.value {
-                                                    let values: Vec<String> = arr
-                                                        .elems
-                                                        .iter()
-                                                        .filter_map(|e| {
-                                                            if let Some(ExprOrSpread {
-                                                                expr, ..
-                                                            }) = e
-                                                            {
-                                                                if let Expr::Ident(i) = &**expr {
-                                                                    return Some(i.sym.to_string());
-                                                                }
-                                                            }
-                                                            None
-                                                        })
-                                                        .collect();
-
-                                                    match key.sym.as_ref() {
-                                                        "imports" => module.imports = values,
-                                                        "providers" => {
-                                                            module.providers = values
-                                                                .into_iter()
-                                                                .map(|v| Provider {
-                                                                    token: v.clone(),
-                                                                    implementation: v,
-                                                                    scope:
-                                                                        InjectionScope::Singleton,
-                                                                    dependencies: vec![], // Will be filled later
-                                                                })
-                                                                .collect();
-                                                        }
-                                                        "controllers" => {
-                                                            module.controllers = values
-                                                        }
-                                                        "exports" => module.exports = values,
-                                                        _ => {}
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            self.graph.add_module(module);
-                        } else if ident.sym == *"Injectable" || ident.sym == *"Controller" {
-                            is_injectable = true;
-                        }
-                    }
+            let Expr::Call(call_expr) = &*decorator.expr else {
+                continue;
+            };
+            let Callee::Expr(callee_expr) = &call_expr.callee else {
+                continue;
+            };
+            let Expr::Ident(ident) = &**callee_expr else {
+                continue;
+            };
+            // Single source of truth for decorator name → kind classification.
+            // Adding a new decorator requires extending tyrus_decorator_kinds,
+            // not this match arm.
+            let Some(kind) = DecoratorKind::from_name(ident.sym.as_ref()) else {
+                continue;
+            };
+            match kind {
+                DecoratorKind::Module => {
+                    let module = self.parse_module_metadata(&class_name, decorator);
+                    self.graph.add_module(module);
                 }
+                DecoratorKind::Injectable | DecoratorKind::Controller => {
+                    is_injectable = true;
+                }
+                _ => {}
             }
         }
 

--- a/crates/tyrus_codegen/Cargo.toml
+++ b/crates/tyrus_codegen/Cargo.toml
@@ -12,3 +12,4 @@ swc_ecma_visit = "18.0.0"
 swc_common = { version = "17.0.1", features = ["tty-emitter"] }
 tyrus_common = { path = "../tyrus_common" }
 tyrus_ast = { path = "../tyrus_ast" }
+tyrus_decorator_kinds = { path = "../tyrus_decorator_kinds" }

--- a/crates/tyrus_codegen/src/convert/class/mod.rs
+++ b/crates/tyrus_codegen/src/convert/class/mod.rs
@@ -23,11 +23,13 @@ impl RustGenerator {
             self.code.push('\n');
         }
 
-        self.is_controller = class_name.ends_with("Controller");
+        // Decorator-driven detection — replaces the previous heuristic
+        // `class_name.ends_with("Controller")`. The Service heuristic stays
+        // until all fixtures gain `@Injectable` (tracked separately).
+        let controller_info = routing::extract_controller_info(n);
+        self.is_controller = controller_info.is_controller;
 
-        let is_service_or_controller = class_name.ends_with("Service")
-            || class_name.ends_with("Controller")
-            || self.is_controller;
+        let is_service_or_controller = self.is_controller || class_name.ends_with("Service");
 
         // Extract generic params early
         let mut generic_params = std::collections::HashSet::new();
@@ -301,7 +303,7 @@ impl RustGenerator {
         }
 
         // Generate controller routing if applicable
-        let controller_info = routing::extract_controller_info(n);
+        // (controller_info was extracted at the start of this function)
         if controller_info.is_controller {
             self.emit_controller_routing(
                 &struct_name,

--- a/crates/tyrus_codegen/src/convert/class/routing.rs
+++ b/crates/tyrus_codegen/src/convert/class/routing.rs
@@ -1,8 +1,9 @@
 use quote::{format_ident, quote};
-use swc_ecma_ast::{ClassDecl, Expr, Lit};
+use swc_ecma_ast::ClassDecl;
 
 use crate::convert::helpers::to_snake_case;
 use crate::convert::interface::RustGenerator;
+use crate::decorators;
 
 /// Extracted controller decorator information.
 pub(crate) struct ControllerInfo {
@@ -12,40 +13,18 @@ pub(crate) struct ControllerInfo {
     pub guard_names: Vec<String>,
 }
 
-/// Extracts `@Controller("/path")` and `@UseGuards(...)` decorator info from a class.
+/// Extracts `@Controller("/path")` and `@UseGuards(...)` decorator info from
+/// a class via the shared [`crate::decorators::DecoratorRegistry`]. The
+/// per-decorator parsing logic lives in the handler files
+/// (`decorators/controller.rs`, `decorators/use_guards.rs`); this function
+/// is the bridge that exposes the registry's `ClassContext` to legacy callers.
 pub(crate) fn extract_controller_info(n: &ClassDecl) -> ControllerInfo {
-    let mut is_controller = false;
-    let mut controller_path = String::new();
-    let mut guard_names = Vec::new();
-
-    for decorator in &n.class.decorators {
-        if let Expr::Call(call) = &*decorator.expr {
-            if let swc_ecma_ast::Callee::Expr(expr) = &call.callee {
-                if let Expr::Ident(ident) = &**expr {
-                    match ident.sym.as_ref() {
-                        "Controller" => {
-                            is_controller = true;
-                            if let Some(arg) = call.args.first() {
-                                if let Expr::Lit(Lit::Str(s)) = &*arg.expr {
-                                    controller_path =
-                                        s.value.as_str().unwrap_or_default().to_string();
-                                }
-                            }
-                        }
-                        "UseGuards" => {
-                            extract_guard_args(call, &mut guard_names);
-                        }
-                        _ => {}
-                    }
-                }
-            }
-        }
-    }
-
+    let mut ctx = decorators::ClassContext::default();
+    decorators::shared_registry().apply_class_decorators(n, &mut ctx);
     ControllerInfo {
-        is_controller,
-        controller_path,
-        guard_names,
+        is_controller: ctx.is_controller,
+        controller_path: ctx.controller_path,
+        guard_names: ctx.guard_names,
     }
 }
 
@@ -61,15 +40,6 @@ fn find_can_activate_method(n: &ClassDecl) -> Option<&swc_ecma_ast::ClassMethod>
         }
         None
     })
-}
-
-/// Extracts guard class names from `@UseGuards(Guard1, Guard2)` arguments.
-fn extract_guard_args(call: &swc_ecma_ast::CallExpr, guard_names: &mut Vec<String>) {
-    for arg in &call.args {
-        if let Expr::Ident(ident) = &*arg.expr {
-            guard_names.push(ident.sym.to_string());
-        }
-    }
 }
 
 /// Generates the `FromRequestParts` implementation for a controller struct.

--- a/crates/tyrus_codegen/src/decorators/controller.rs
+++ b/crates/tyrus_codegen/src/decorators/controller.rs
@@ -1,0 +1,23 @@
+//! `@Controller("/path")` handler.
+
+use swc_ecma_ast::{CallExpr, ClassDecl, Expr, Lit};
+use tyrus_decorator_kinds::DecoratorKind;
+
+use super::{ClassContext, ClassDecoratorHandler};
+
+pub(crate) struct ControllerHandler;
+
+impl ClassDecoratorHandler for ControllerHandler {
+    fn kind(&self) -> DecoratorKind {
+        DecoratorKind::Controller
+    }
+
+    fn apply(&self, _class: &ClassDecl, call: &CallExpr, ctx: &mut ClassContext) {
+        ctx.is_controller = true;
+        if let Some(arg) = call.args.first() {
+            if let Expr::Lit(Lit::Str(s)) = &*arg.expr {
+                ctx.controller_path = s.value.as_str().unwrap_or_default().to_string();
+            }
+        }
+    }
+}

--- a/crates/tyrus_codegen/src/decorators/mod.rs
+++ b/crates/tyrus_codegen/src/decorators/mod.rs
@@ -1,0 +1,173 @@
+//! Decorator handler registry.
+//!
+//! This module is the architectural answer to the prior approach where every
+//! NestJS decorator required hardcoded match arms scattered across
+//! `class/mod.rs`, `class/method.rs`, `class/routing.rs`, and the analyzer.
+//!
+//! ## Design
+//!
+//! Three traits, one per scope:
+//!
+//! - [`ClassDecoratorHandler`] — runs over a `ClassDecl`, mutates a [`ClassContext`]
+//! - [`MethodDecoratorHandler`] — runs over a `ClassMethod`, mutates a [`MethodContext`]
+//! - [`ParamDecoratorHandler`] — runs over a `Param`, emits an Axum extractor token
+//!
+//! A [`DecoratorRegistry`] dispatches a decorator's identifier to the right
+//! handler via [`tyrus_decorator_kinds::DecoratorKind`]. Adding a new decorator
+//! means: add one variant to `DecoratorKind`, write one handler file, register
+//! it in [`default_registry`]. No hot-path file is touched.
+//!
+//! ## What's here today (PR #1)
+//!
+//! Only the **class-level** half of the registry is wired:
+//! [`ControllerHandler`] and [`UseGuardsHandler`]. Method- and param-level
+//! handlers are stubbed (the trait + storage exists, but `default_registry`
+//! does not register any yet — those land in PR #2 and PR #3).
+
+pub(crate) mod controller;
+pub(crate) mod use_guards;
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+use swc_ecma_ast::{CallExpr, ClassDecl, ClassMethod, Param};
+use tyrus_decorator_kinds::DecoratorKind;
+
+/// Mutable bag of class-level metadata that handlers populate.
+///
+/// `ControllerHandler` flips `is_controller` and writes `controller_path`;
+/// `UseGuardsHandler` appends to `guard_names`. Code outside this module
+/// reads the resulting struct — it never observes which handler wrote what.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct ClassContext {
+    pub(crate) is_controller: bool,
+    pub(crate) controller_path: String,
+    pub(crate) guard_names: Vec<String>,
+}
+
+/// Mutable bag of method-level metadata. Populated in PR #2.
+#[derive(Debug, Default, Clone)]
+#[allow(dead_code)]
+pub(crate) struct MethodContext {
+    pub(crate) http_method: Option<String>,
+    pub(crate) route_path: String,
+    pub(crate) http_code: Option<u16>,
+}
+
+/// Handler for class-level decorators (`@Controller`, `@UseGuards`, ...).
+pub(crate) trait ClassDecoratorHandler: Send + Sync {
+    fn kind(&self) -> DecoratorKind;
+    fn apply(&self, class: &ClassDecl, call: &CallExpr, ctx: &mut ClassContext);
+}
+
+/// Handler for method-level decorators (`@Get`, `@Post`, `@HttpCode`, ...).
+/// Wired in PR #2.
+#[allow(dead_code)]
+pub(crate) trait MethodDecoratorHandler: Send + Sync {
+    fn kind(&self) -> DecoratorKind;
+    fn apply(&self, method: &ClassMethod, call: &CallExpr, ctx: &mut MethodContext);
+}
+
+/// Handler for param-level decorators (`@Body`, `@Param`, `@Query`, ...).
+/// Wired in PR #3. `emit_extractor` returns the Axum extractor token to
+/// substitute for the parameter binding.
+#[allow(dead_code)]
+pub(crate) trait ParamDecoratorHandler: Send + Sync {
+    fn kind(&self) -> DecoratorKind;
+    fn emit_extractor(
+        &self,
+        param: &Param,
+        param_name: &proc_macro2::Ident,
+        param_type: &proc_macro2::TokenStream,
+    ) -> proc_macro2::TokenStream;
+}
+
+/// Central registry. Owned by `RustGenerator` (or built ad-hoc). Lookup is
+/// `O(1)` via `HashMap` keyed on [`DecoratorKind`].
+pub(crate) struct DecoratorRegistry {
+    class: HashMap<DecoratorKind, Box<dyn ClassDecoratorHandler>>,
+    #[allow(dead_code)]
+    method: HashMap<DecoratorKind, Box<dyn MethodDecoratorHandler>>,
+    #[allow(dead_code)]
+    param: HashMap<DecoratorKind, Box<dyn ParamDecoratorHandler>>,
+}
+
+impl DecoratorRegistry {
+    pub(crate) fn new() -> Self {
+        Self {
+            class: HashMap::new(),
+            method: HashMap::new(),
+            param: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn register_class(&mut self, handler: Box<dyn ClassDecoratorHandler>) {
+        self.class.insert(handler.kind(), handler);
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn register_method(&mut self, handler: Box<dyn MethodDecoratorHandler>) {
+        self.method.insert(handler.kind(), handler);
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn register_param(&mut self, handler: Box<dyn ParamDecoratorHandler>) {
+        self.param.insert(handler.kind(), handler);
+    }
+
+    pub(crate) fn class_handler(&self, kind: DecoratorKind) -> Option<&dyn ClassDecoratorHandler> {
+        self.class.get(&kind).map(std::convert::AsRef::as_ref)
+    }
+
+    /// Iterates the class decorators of `n`, classifies each by name,
+    /// and invokes the corresponding handler. Unknown decorators are
+    /// silently ignored — generic translation responsibility lies elsewhere.
+    pub(crate) fn apply_class_decorators(&self, n: &ClassDecl, ctx: &mut ClassContext) {
+        for decorator in &n.class.decorators {
+            let swc_ecma_ast::Expr::Call(call) = &*decorator.expr else {
+                continue;
+            };
+            let swc_ecma_ast::Callee::Expr(callee_expr) = &call.callee else {
+                continue;
+            };
+            let swc_ecma_ast::Expr::Ident(ident) = &**callee_expr else {
+                continue;
+            };
+            let Some(kind) = DecoratorKind::from_name(ident.sym.as_ref()) else {
+                continue;
+            };
+            if let Some(handler) = self.class_handler(kind) {
+                handler.apply(n, call, ctx);
+            }
+        }
+    }
+}
+
+/// The default registry used by the transpiler. Adding a new built-in
+/// decorator means adding one `register_*` line here.
+pub(crate) fn default_registry() -> DecoratorRegistry {
+    let mut registry = DecoratorRegistry::new();
+    registry.register_class(Box::new(controller::ControllerHandler));
+    registry.register_class(Box::new(use_guards::UseGuardsHandler));
+    registry
+}
+
+/// Process-wide singleton of [`default_registry`]. Built once on first access;
+/// subsequent calls are a pointer load.
+pub(crate) fn shared_registry() -> &'static DecoratorRegistry {
+    static REGISTRY: OnceLock<DecoratorRegistry> = OnceLock::new();
+    REGISTRY.get_or_init(default_registry)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_registry_has_class_handlers() {
+        let r = default_registry();
+        assert!(r.class_handler(DecoratorKind::Controller).is_some());
+        assert!(r.class_handler(DecoratorKind::UseGuards).is_some());
+        // Method-/param-level handlers land in PR #2 and #3.
+        assert!(r.class_handler(DecoratorKind::HttpGet).is_none());
+    }
+}

--- a/crates/tyrus_codegen/src/decorators/use_guards.rs
+++ b/crates/tyrus_codegen/src/decorators/use_guards.rs
@@ -1,0 +1,22 @@
+//! `@UseGuards(Guard1, Guard2)` handler.
+
+use swc_ecma_ast::{CallExpr, ClassDecl, Expr};
+use tyrus_decorator_kinds::DecoratorKind;
+
+use super::{ClassContext, ClassDecoratorHandler};
+
+pub(crate) struct UseGuardsHandler;
+
+impl ClassDecoratorHandler for UseGuardsHandler {
+    fn kind(&self) -> DecoratorKind {
+        DecoratorKind::UseGuards
+    }
+
+    fn apply(&self, _class: &ClassDecl, call: &CallExpr, ctx: &mut ClassContext) {
+        for arg in &call.args {
+            if let Expr::Ident(ident) = &*arg.expr {
+                ctx.guard_names.push(ident.sym.to_string());
+            }
+        }
+    }
+}

--- a/crates/tyrus_codegen/src/lib.rs
+++ b/crates/tyrus_codegen/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod convert;
+pub(crate) mod decorators;
 pub mod stdlib;
 
 use convert::interface::RustGenerator;

--- a/crates/tyrus_decorator_kinds/Cargo.toml
+++ b/crates/tyrus_decorator_kinds/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "tyrus_decorator_kinds"
+version = "0.1.0"
+edition = "2021"
+description = "Single source of truth for NestJS decorator name → kind classification, shared between analyzer and codegen."
+
+[dependencies]

--- a/crates/tyrus_decorator_kinds/src/lib.rs
+++ b/crates/tyrus_decorator_kinds/src/lib.rs
@@ -1,0 +1,187 @@
+//! Single source of truth for NestJS decorator name → kind classification.
+//!
+//! This crate is intentionally lightweight (zero dependencies) so it can be
+//! shared by both `tyrus_analyzer` and `tyrus_codegen` without dragging
+//! `proc_macro2`/`quote` into the analyzer.
+//!
+//! Usage:
+//! ```
+//! use tyrus_decorator_kinds::{DecoratorKind, DecoratorScope};
+//!
+//! assert_eq!(DecoratorKind::from_name("Controller"), Some(DecoratorKind::Controller));
+//! assert_eq!(DecoratorKind::Controller.scope(), DecoratorScope::Class);
+//! assert_eq!(DecoratorKind::from_name("UnknownDecorator"), None);
+//! ```
+
+#![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::todo)]
+
+/// Where in the AST a decorator can appear.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DecoratorScope {
+    /// Class-level: `@Controller`, `@Injectable`, `@Module`, `@UseGuards`.
+    Class,
+    /// Method-level: `@Get`, `@Post`, `@HttpCode`, etc.
+    Method,
+    /// Parameter-level: `@Body`, `@Param`, `@Query`, `@Headers`.
+    Param,
+}
+
+/// Every NestJS decorator the transpiler currently recognizes.
+///
+/// Adding a new decorator means adding ONE variant here plus mapping its name
+/// in [`DecoratorKind::from_name`]. The handler that emits Rust for it lives
+/// in `tyrus_codegen::decorators`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DecoratorKind {
+    // Class-level
+    Module,
+    Injectable,
+    Controller,
+    UseGuards,
+
+    // Method-level
+    HttpGet,
+    HttpPost,
+    HttpPut,
+    HttpDelete,
+    HttpPatch,
+    HttpCode,
+
+    // Param-level
+    Body,
+    Param,
+    Query,
+}
+
+impl DecoratorKind {
+    /// Maps a decorator identifier (the bare name as written in TypeScript) to
+    /// its kind. Returns `None` for unknown decorators — callers are expected
+    /// to fall through to a generic translation, never to error out.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "Module" => Some(Self::Module),
+            "Injectable" => Some(Self::Injectable),
+            "Controller" => Some(Self::Controller),
+            "UseGuards" => Some(Self::UseGuards),
+            "Get" => Some(Self::HttpGet),
+            "Post" => Some(Self::HttpPost),
+            "Put" => Some(Self::HttpPut),
+            "Delete" => Some(Self::HttpDelete),
+            "Patch" => Some(Self::HttpPatch),
+            "HttpCode" => Some(Self::HttpCode),
+            "Body" => Some(Self::Body),
+            "Param" => Some(Self::Param),
+            "Query" => Some(Self::Query),
+            _ => None,
+        }
+    }
+
+    /// Where this decorator is allowed to appear in the AST.
+    pub fn scope(self) -> DecoratorScope {
+        match self {
+            Self::Module | Self::Injectable | Self::Controller | Self::UseGuards => {
+                DecoratorScope::Class
+            }
+            Self::HttpGet
+            | Self::HttpPost
+            | Self::HttpPut
+            | Self::HttpDelete
+            | Self::HttpPatch
+            | Self::HttpCode => DecoratorScope::Method,
+            Self::Body | Self::Param | Self::Query => DecoratorScope::Param,
+        }
+    }
+
+    /// True iff this decorator selects an HTTP verb (Get/Post/Put/Delete/Patch).
+    /// Used by routing to dispatch to the right `axum::routing::*` constructor.
+    pub fn is_http_method(self) -> bool {
+        matches!(
+            self,
+            Self::HttpGet | Self::HttpPost | Self::HttpPut | Self::HttpDelete | Self::HttpPatch
+        )
+    }
+
+    /// The original TypeScript name, for diagnostics.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Module => "Module",
+            Self::Injectable => "Injectable",
+            Self::Controller => "Controller",
+            Self::UseGuards => "UseGuards",
+            Self::HttpGet => "Get",
+            Self::HttpPost => "Post",
+            Self::HttpPut => "Put",
+            Self::HttpDelete => "Delete",
+            Self::HttpPatch => "Patch",
+            Self::HttpCode => "HttpCode",
+            Self::Body => "Body",
+            Self::Param => "Param",
+            Self::Query => "Query",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_name_known_decorators() {
+        assert_eq!(
+            DecoratorKind::from_name("Controller"),
+            Some(DecoratorKind::Controller)
+        );
+        assert_eq!(
+            DecoratorKind::from_name("Get"),
+            Some(DecoratorKind::HttpGet)
+        );
+        assert_eq!(DecoratorKind::from_name("Body"), Some(DecoratorKind::Body));
+        assert_eq!(
+            DecoratorKind::from_name("UseGuards"),
+            Some(DecoratorKind::UseGuards)
+        );
+    }
+
+    #[test]
+    fn from_name_unknown_returns_none() {
+        assert_eq!(DecoratorKind::from_name("IsEmail"), None);
+        assert_eq!(DecoratorKind::from_name(""), None);
+        assert_eq!(DecoratorKind::from_name("controller"), None); // case-sensitive
+    }
+
+    #[test]
+    fn scope_classification() {
+        assert_eq!(DecoratorKind::Controller.scope(), DecoratorScope::Class);
+        assert_eq!(DecoratorKind::HttpGet.scope(), DecoratorScope::Method);
+        assert_eq!(DecoratorKind::Body.scope(), DecoratorScope::Param);
+    }
+
+    #[test]
+    fn http_method_classification() {
+        assert!(DecoratorKind::HttpGet.is_http_method());
+        assert!(DecoratorKind::HttpPost.is_http_method());
+        assert!(!DecoratorKind::HttpCode.is_http_method());
+        assert!(!DecoratorKind::Controller.is_http_method());
+    }
+
+    #[test]
+    fn name_roundtrip() {
+        for kind in [
+            DecoratorKind::Module,
+            DecoratorKind::Injectable,
+            DecoratorKind::Controller,
+            DecoratorKind::UseGuards,
+            DecoratorKind::HttpGet,
+            DecoratorKind::HttpPost,
+            DecoratorKind::HttpPut,
+            DecoratorKind::HttpDelete,
+            DecoratorKind::HttpPatch,
+            DecoratorKind::HttpCode,
+            DecoratorKind::Body,
+            DecoratorKind::Param,
+            DecoratorKind::Query,
+        ] {
+            assert_eq!(DecoratorKind::from_name(kind.name()), Some(kind));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Establishes the architectural foundation for replacing the hardcoded decorator match arms scattered across `class/method.rs`, `class/routing.rs`, `class/mod.rs` and `analyzer/decorators.rs` with a single trait-based registry.

This is **PR #1 of 5** in the Caminho C migration approved via `/ultraplan` (full plan in `.claude/plan/ultraplan-decorator-registry.md`). It migrates **only class-level decorators** (`@Controller`, `@UseGuards`); method- and param-level handlers land in PR #2 and PR #3.

## Why this comes before Phase 9.1

Phase 9.1 (`class-validator` → `garde`) introduces 11 new validation decorators. Without this refactor, each new decorator costs ~3 file edits in hot paths. With this refactor, each new decorator = one new file in `decorators/`. The refactor is intentionally cheaper to do **now** (200 tests + HTTP E2E green) than after 11 more match arms have been sedimented.

## What changed

- **New crate `tyrus_decorator_kinds`** (zero deps): single source of truth for decorator name → `DecoratorKind` classification. Shared by analyzer + codegen without dragging `proc_macro2` into the analyzer.
- **New module `crates/tyrus_codegen/src/decorators/`** with:
  - `ClassDecoratorHandler`, `MethodDecoratorHandler`, `ParamDecoratorHandler` traits
  - `DecoratorRegistry` (HashMap-backed, O(1) lookup)
  - `default_registry()` + process-wide singleton via `OnceLock`
- **`ControllerHandler`** and **`UseGuardsHandler`** implement the class-level half.
- `extract_controller_info` now dispatches via the registry — implementation collapsed from ~50 lines to ~10.
- **DELETED heuristic** `class_name.ends_with("Controller")` in `class/mod.rs:26-30` — replaced by `ControllerInfo.is_controller` from the registry.
- `analyzer/decorators.rs` uses `DecoratorKind::from_name()` instead of string-compare match arms; `@Module` parsing extracted into focused helpers (`parse_module_metadata`, `collect_ident_array`, `values_to_providers`).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] **217/217 tests passing** (1 skipped) — +6 vs main (5 unit + 1 doc in `tyrus_decorator_kinds`; 1 unit in `decorators/mod.rs`)
- [x] `test_http_equivalence_rust_server` green (NestJS → Rust HTTP equivalence gate held)
- [x] `test_reference_nestjs_transpiles_and_compiles` green
- [x] No new `unwrap`/`expect`/`panic`/`todo`
- [x] Files <400 lines, functions <50 lines

## What's next

- **PR #2:** method-level handlers (`@Get`/`@Post`/`@Put`/`@Delete`/`@Patch` + `@HttpCode`) — eliminates duplication between `method.rs:61` and `routing.rs:131-138`.
- **PR #3:** param-level handlers (`@Body`/`@Param`/`@Query`) — eliminates `Option<String>` round-trip in `convert_single_param`.
- **PR #4:** ADR + docs + unit tests.
- **PR #5:** empirical validation — implement `@Headers` entirely via the registry, no legacy file touched.

Closes #108