### PR TITLE
refactor(codegen): introduce decorator registry foundation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,8 +77,9 @@ cargo bench --bench runtime_comparison # Node.js vs Rust runtime comparison
 | `tyrus_cli` | ~430 | CLI (clap). 4 commands: `check`/`build`/`compile`/`run`. Branded output, progress pipeline. |
 | `tyrus_parser` | ~55 | Wraps SWC parser. `.ts` → `Program` |
 | `tyrus_ast` | ~730 | Typed IR: `TyrusModule`/`TyrusExpr`/`TyrusStmt`/`TyrusDecl`. SWC→IR lowering. |
-| `tyrus_analyzer` | ~580 | `LintVisitor` (8 rules) + `DecoratorVisitor` + `UnsupportedApiVisitor` + JSON reports |
-| `tyrus_codegen` | ~5040 | **Core.** `RustGenerator` → TokenStream. Decomposed: `helpers/stmt/fn_decl/expr/*/class/*`. |
+| `tyrus_analyzer` | ~580 | `LintVisitor` (7 rules) + `DecoratorVisitor` + `UnsupportedApiVisitor` + JSON reports. Uses `tyrus_decorator_kinds` for name → kind classification. |
+| `tyrus_codegen` | ~6000 | **Core.** `RustGenerator` → TokenStream. Decomposed: `helpers/stmt/fn_decl/expr/*/class/*/decorators/*/stdlib/*`. |
+| `tyrus_decorator_kinds` | ~225 | **Single source of truth** for NestJS decorator name → `DecoratorKind` classification. Zero deps; shared by analyzer + codegen. See `docs/architecture/decisions/0007-decorator-registry.md`. |
 | `tyrus_di` | ~200 | DI graph (petgraph). Topological sort. |
 | `tyrus_orchestrator` | ~650 | Pipeline coordination. Split: `lib/pipeline/scaffold/format`. |
 | `tyrus_diagnostics` | ~69 | `TyrusError` + miette |
@@ -99,14 +100,15 @@ crates/tyrus_codegen/src/
 │   ├── stmt/             # Statement conversion
 │   │   ├── mod.rs         # Dispatcher + convert_stmt, convert_stmt_recursive
 │   │   ├── var_decl.rs    # Variable declarations (ident, object/array destructuring)
-│   │   ├── loops.rs       # while, for-of, for-in, for, do-while
+│   │   ├── loops.rs       # while, for-of, for, do-while  (for-in is analyzer-blocked)
 │   │   ├── switch.rs      # switch → match
 │   │   └── try_catch.rs   # try-catch → Result matching
 │   ├── class/            # Class → struct+impl
-│   │   ├── mod.rs         # Class dispatcher + property conversion
+│   │   ├── mod.rs         # Class dispatcher + property conversion (decorator-driven)
 │   │   ├── constructor.rs # Constructor transpilation + DI
-│   │   ├── method.rs      # Method transpilation + decorators
-│   │   ├── routing.rs     # Axum router generation + @UseGuards middleware
+│   │   ├── method.rs      # Method transpilation; param/method decorators via registry
+│   │   ├── routing.rs     # Axum router generation + @UseGuards middleware + map_status_code
+│   │   ├── getter_setter.rs # get/set → method calls
 │   │   └── mutation.rs    # Self-mutation detection
 │   └── expr/             # Expression conversion
 │       ├── mod.rs         # Expression dispatcher (convert_expr)
@@ -114,10 +116,18 @@ crates/tyrus_codegen/src/
 │       ├── call.rs        # Function/method calls, axios/fetch/array methods
 │       ├── member.rs      # Property access, mutex state (convert_member_expr)
 │       ├── arrow.rs       # Arrow functions → closures
-│       ├── literal.rs     # Object/array/template literals
-│       └── misc.rs        # Assignments, updates, optional chaining
+│       ├── literal.rs     # Object/array/template literals (incl. object spread)
+│       └── misc.rs        # Assignments (=, -=, *=, /=, %=, &=, |=, ^=, <<=, >>=), updates, optional chaining
+├── decorators/           # Decorator registry (ADR 0007)
+│   ├── mod.rs             # DecoratorRegistry + Class/Method/ParamDecoratorHandler traits + default_registry()
+│   ├── controller.rs      # @Controller("/path") handler
+│   ├── use_guards.rs      # @UseGuards(...) handler
+│   ├── http_method.rs     # @Get/@Post/@Put/@Delete/@Patch (one parameterized struct, 5 instances)
+│   ├── http_code.rs       # @HttpCode(N) handler
+│   └── params.rs          # @Body, @Param, @Query handlers (one file, 3 structs)
 └── stdlib/               # Standard library mappings
-    ├── mod.rs, console.rs, array.rs, string.rs, math.rs, json.rs, object.rs
+    ├── mod.rs, console.rs, array.rs, string.rs, math.rs,
+    ├── json.rs, object.rs, map_set.rs   (Map<K,V>→HashMap, Set<T>→HashSet)
 ```
 
 ## Type Mappings (TS → Rust)
@@ -131,6 +141,9 @@ crates/tyrus_codegen/src/
 | `T[]` / `Array<T>` | `Vec<T>` |
 | `Promise<T>` | `Result<T, AppError>` |
 | `Record<K,V>` | `HashMap<K,V>` |
+| `Map<K,V>` | `HashMap<K,V>` (`new Map()` → `HashMap::new()`) |
+| `Set<T>` | `HashSet<T>` (`new Set()` → `HashSet::new()`) |
+| `Date` | `String` (TODO: chrono); `Date.now()` → `chrono::Utc::now().timestamp_millis()` |
 | `T \| undefined` | `Option<T>` |
 | `interface` | `#[derive(Serialize, Deserialize)] struct` |
 | `type Status = "a" \| "b"` | `enum Status { A, B }` |
@@ -177,7 +190,13 @@ tests/
 
 See `docs/superpowers/plans/2026-03-12-full-refactoring-roadmap.md` for the complete plan.
 
-**Completed:** Phase 1-8 complete. Full NestJS → Rust transpilation with HTTP equivalence verified.
+**Completed:**
+- Phase 1-8: full NestJS → Rust transpilation with HTTP equivalence verified
+- Sprint 1 quick wins: assignment ops (`-=`/`*=`/`/=`/`%=`/`&=`/`|=`/`^=`/`<<=`/`>>=`), `Map<K,V>`/`Set<T>`, `this.method()`, object shorthand, `Date.now()`, object spread
+- **Decorator Registry migration (Caminho C, ADR 0007):** PR #1-#3 stacked — class/method/param decorators now flow through `DecoratorRegistry`. `find_param_decorator` deleted, `extract_single_decorator` deleted, `class_name.ends_with("Controller")` heuristic deleted, `unwrap_or` removed from generated status-code emission.
+
 **Milestone:** Multi-module NestJS project transpiles, compiles, and serves correct HTTP responses.
-**Status:** 195 tests (81 equivalence + 49 unit + 20 snapshot + 21 IR + 9 compilation + 7 CLI + 5 E2E/build + 1 trybuild + 1 skipped)
+**Status:** 230 tests (95 equivalence + 49 unit + 20 snapshot + 21 IR + 9 compilation + 7 CLI + 5 E2E/build + 1 trybuild + 1 skipped + new registry/handler isolation tests)
 **E2E:** `test_http_equivalence_rust_server` — transpile → compile → start server → verify GET responses
+
+**In flight (PR #5 of decorator registry):** empirical proof — implement `@Headers` purely via `decorators/params.rs` + one `register_param` line; touching zero legacy files.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,6 +1985,7 @@ dependencies = [
  "swc_ecma_ast",
  "swc_ecma_visit",
  "tyrus_common",
+ "tyrus_decorator_kinds",
  "tyrus_di",
  "tyrus_diagnostics",
 ]
@@ -2030,6 +2031,7 @@ dependencies = [
  "syn",
  "tyrus_ast",
  "tyrus_common",
+ "tyrus_decorator_kinds",
 ]
 
 [[package]]
@@ -2040,6 +2042,10 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tyrus_decorator_kinds"
+version = "0.1.0"
 
 [[package]]
 name = "tyrus_di"

--- a/crates/tyrus_analyzer/Cargo.toml
+++ b/crates/tyrus_analyzer/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 tyrus_common = { path = "../tyrus_common" }
 tyrus_diagnostics = { path = "../tyrus_diagnostics" }
 tyrus_di = { path = "../tyrus_di" }
+tyrus_decorator_kinds = { path = "../tyrus_decorator_kinds" }
 swc_ecma_ast = "18.0.0"
 swc_ecma_visit = "18.0.0"
 swc_common = { version = "17.0.1", features = ["tty-emitter"] }

--- a/crates/tyrus_analyzer/src/decorators.rs
+++ b/crates/tyrus_analyzer/src/decorators.rs
@@ -1,5 +1,6 @@
 use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitWith};
+use tyrus_decorator_kinds::DecoratorKind;
 use tyrus_di::graph::DiGraph;
 use tyrus_di::module::Module;
 use tyrus_di::provider::{InjectionScope, Provider};
@@ -35,6 +36,69 @@ impl DecoratorVisitor {
         }
         None
     }
+
+    /// Parses an `@Module({ imports, providers, controllers, exports })`
+    /// decorator into a [`Module`] for the DI graph.
+    fn parse_module_metadata(&self, class_name: &str, decorator: &Decorator) -> Module {
+        let mut module = Module {
+            name: class_name.to_string(),
+            imports: vec![],
+            providers: vec![],
+            controllers: vec![],
+            exports: vec![],
+        };
+        let Some(obj) = self.extract_decorator_args(decorator) else {
+            return module;
+        };
+        for prop in obj.props {
+            let PropOrSpread::Prop(prop) = prop else {
+                continue;
+            };
+            let Prop::KeyValue(kv) = *prop else { continue };
+            let PropName::Ident(key) = kv.key else {
+                continue;
+            };
+            let Expr::Array(arr) = *kv.value else {
+                continue;
+            };
+            let values = collect_ident_array(&arr);
+            match key.sym.as_ref() {
+                "imports" => module.imports = values,
+                "providers" => module.providers = values_to_providers(values),
+                "controllers" => module.controllers = values,
+                "exports" => module.exports = values,
+                _ => {}
+            }
+        }
+        module
+    }
+}
+
+/// Collects ident expressions from an array literal, ignoring spreads/non-idents.
+fn collect_ident_array(arr: &ArrayLit) -> Vec<String> {
+    arr.elems
+        .iter()
+        .filter_map(|e| {
+            let ExprOrSpread { expr, .. } = e.as_ref()?;
+            if let Expr::Ident(i) = &**expr {
+                return Some(i.sym.to_string());
+            }
+            None
+        })
+        .collect()
+}
+
+/// Wraps each ident name in a `Provider` (singleton, deps filled later).
+fn values_to_providers(values: Vec<String>) -> Vec<Provider> {
+    values
+        .into_iter()
+        .map(|v| Provider {
+            token: v.clone(),
+            implementation: v,
+            scope: InjectionScope::Singleton,
+            dependencies: vec![],
+        })
+        .collect()
 }
 
 impl Visit for DecoratorVisitor {
@@ -43,73 +107,30 @@ impl Visit for DecoratorVisitor {
         let mut is_injectable = false;
 
         for decorator in &n.class.decorators {
-            if let Expr::Call(call_expr) = &*decorator.expr {
-                if let Callee::Expr(expr) = &call_expr.callee {
-                    if let Expr::Ident(ident) = &**expr {
-                        if ident.sym == *"Module" {
-                            // Extract Module Metadata
-                            let mut module = Module {
-                                name: class_name.clone(),
-                                imports: vec![],
-                                providers: vec![],
-                                controllers: vec![],
-                                exports: vec![],
-                            };
-
-                            if let Some(obj) = self.extract_decorator_args(decorator) {
-                                for prop in obj.props {
-                                    if let PropOrSpread::Prop(prop) = prop {
-                                        if let Prop::KeyValue(kv) = *prop {
-                                            if let PropName::Ident(key) = kv.key {
-                                                if let Expr::Array(arr) = *kv.value {
-                                                    let values: Vec<String> = arr
-                                                        .elems
-                                                        .iter()
-                                                        .filter_map(|e| {
-                                                            if let Some(ExprOrSpread {
-                                                                expr, ..
-                                                            }) = e
-                                                            {
-                                                                if let Expr::Ident(i) = &**expr {
-                                                                    return Some(i.sym.to_string());
-                                                                }
-                                                            }
-                                                            None
-                                                        })
-                                                        .collect();
-
-                                                    match key.sym.as_ref() {
-                                                        "imports" => module.imports = values,
-                                                        "providers" => {
-                                                            module.providers = values
-                                                                .into_iter()
-                                                                .map(|v| Provider {
-                                                                    token: v.clone(),
-                                                                    implementation: v,
-                                                                    scope:
-                                                                        InjectionScope::Singleton,
-                                                                    dependencies: vec![], // Will be filled later
-                                                                })
-                                                                .collect();
-                                                        }
-                                                        "controllers" => {
-                                                            module.controllers = values
-                                                        }
-                                                        "exports" => module.exports = values,
-                                                        _ => {}
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            self.graph.add_module(module);
-                        } else if ident.sym == *"Injectable" || ident.sym == *"Controller" {
-                            is_injectable = true;
-                        }
-                    }
+            let Expr::Call(call_expr) = &*decorator.expr else {
+                continue;
+            };
+            let Callee::Expr(callee_expr) = &call_expr.callee else {
+                continue;
+            };
+            let Expr::Ident(ident) = &**callee_expr else {
+                continue;
+            };
+            // Single source of truth for decorator name → kind classification.
+            // Adding a new decorator requires extending tyrus_decorator_kinds,
+            // not this match arm.
+            let Some(kind) = DecoratorKind::from_name(ident.sym.as_ref()) else {
+                continue;
+            };
+            match kind {
+                DecoratorKind::Module => {
+                    let module = self.parse_module_metadata(&class_name, decorator);
+                    self.graph.add_module(module);
                 }
+                DecoratorKind::Injectable | DecoratorKind::Controller => {
+                    is_injectable = true;
+                }
+                _ => {}
             }
         }
 

--- a/crates/tyrus_codegen/Cargo.toml
+++ b/crates/tyrus_codegen/Cargo.toml
@@ -12,3 +12,4 @@ swc_ecma_visit = "18.0.0"
 swc_common = { version = "17.0.1", features = ["tty-emitter"] }
 tyrus_common = { path = "../tyrus_common" }
 tyrus_ast = { path = "../tyrus_ast" }
+tyrus_decorator_kinds = { path = "../tyrus_decorator_kinds" }

--- a/crates/tyrus_codegen/src/convert/class/method.rs
+++ b/crates/tyrus_codegen/src/convert/class/method.rs
@@ -4,9 +4,13 @@ use swc_ecma_ast::{Expr, Lit, Pat};
 use crate::convert::helpers::to_snake_case;
 use crate::convert::interface::RustGenerator;
 use crate::convert::type_mapper::{is_optional_type, map_ts_type};
+use crate::decorators;
 
 /// Extracted decorator metadata from a class method.
 struct MethodDecorators {
+    /// HTTP verb decorator name (`"Get"`, `"Post"`, ...) if any.
+    /// Carried as a `String` for legacy callers; the canonical type is
+    /// [`tyrus_decorator_kinds::DecoratorKind`].
     http_method: Option<String>,
     route_path: String,
     http_code: Option<u16>,
@@ -21,56 +25,22 @@ struct MethodContext {
     returns_option: bool,
 }
 
-/// Scans method decorators for @Get/@Post/@Put/@Delete/@Patch and @HttpCode.
+/// Scans method decorators for `@Get`/`@Post`/`@Put`/`@Delete`/`@Patch` and
+/// `@HttpCode` via the shared [`crate::decorators::DecoratorRegistry`].
+/// Per-decorator parsing logic lives in `decorators/http_method.rs` and
+/// `decorators/http_code.rs`. This function bridges the registry's
+/// [`crate::decorators::MethodDecoratorContext`] to legacy callers that
+/// expect `MethodDecorators` with a stringy `http_method`.
 fn extract_method_decorators(method: &swc_ecma_ast::ClassMethod) -> MethodDecorators {
-    let mut http_method = None;
-    let mut route_path = String::new();
-    let mut http_code: Option<u16> = None;
-
-    for decorator in &method.function.decorators {
-        if let Expr::Call(call) = &*decorator.expr {
-            if let swc_ecma_ast::Callee::Expr(expr) = &call.callee {
-                if let Expr::Ident(ident) = &**expr {
-                    extract_single_decorator(
-                        ident.sym.as_str(),
-                        call,
-                        &mut http_method,
-                        &mut route_path,
-                        &mut http_code,
-                    );
-                }
-            }
-        }
-    }
-
+    let mut ctx = decorators::MethodDecoratorContext::default();
+    decorators::shared_registry().apply_method_decorators(method, &mut ctx);
     MethodDecorators {
-        http_method,
-        route_path,
-        http_code,
-    }
-}
-
-/// Processes a single decorator call to extract HTTP method or status code.
-fn extract_single_decorator(
-    name: &str,
-    call: &swc_ecma_ast::CallExpr,
-    http_method: &mut Option<String>,
-    route_path: &mut String,
-    http_code: &mut Option<u16>,
-) {
-    if matches!(name, "Get" | "Post" | "Put" | "Delete" | "Patch") {
-        *http_method = Some(name.to_string());
-        if let Some(arg) = call.args.first() {
-            if let Expr::Lit(Lit::Str(s)) = &*arg.expr {
-                *route_path = s.value.as_str().unwrap_or_default().to_string();
-            }
-        }
-    } else if name == "HttpCode" {
-        if let Some(arg) = call.args.first() {
-            if let Expr::Lit(Lit::Num(num)) = &*arg.expr {
-                *http_code = Some(num.value as u16);
-            }
-        }
+        // Convert canonical DecoratorKind back to its TypeScript name for
+        // legacy consumers (build_doc_comment, route tuples). The full
+        // strong-typing lives inside the registry.
+        http_method: ctx.http_method.map(|k| k.name().to_string()),
+        route_path: ctx.route_path,
+        http_code: ctx.http_code,
     }
 }
 
@@ -108,7 +78,12 @@ fn build_self_param(
     }
 }
 
-/// Converts a single method parameter, handling @Body/@Param/@Query decorators.
+/// Converts a single method parameter. Decorator-driven extractor selection
+/// is delegated to the [`crate::decorators::DecoratorRegistry`]: the registry
+/// classifies the decorator (if any) and the matching
+/// [`ParamDecoratorHandler::emit_extractor`] produces the Axum binding token.
+/// Plain (undecorated) parameters fall through to a generic
+/// `name: Type` binding.
 fn convert_single_param(param: &swc_ecma_ast::Param) -> Option<proc_macro2::TokenStream> {
     let Pat::Ident(ident) = &param.pat else {
         return None;
@@ -116,40 +91,15 @@ fn convert_single_param(param: &swc_ecma_ast::Param) -> Option<proc_macro2::Toke
 
     let param_name = format_ident!("{}", to_snake_case(ident.sym.as_ref()));
     let param_type = map_ts_type(ident.type_ann.as_ref());
-    let decorator = find_param_decorator(param);
+    let registry = decorators::shared_registry();
 
-    let tokens = match decorator.as_deref() {
-        Some("Body") => {
-            quote! { axum::Json(#param_name): axum::Json<#param_type> }
-        }
-        Some("Param") => {
-            quote! { axum::extract::Path(#param_name): axum::extract::Path<#param_type> }
-        }
-        Some("Query") => {
-            quote! { axum::extract::Query(#param_name): axum::extract::Query<#param_type> }
-        }
-        _ => {
-            quote! { #param_name: #param_type }
-        }
-    };
+    let tokens = registry
+        .first_param_decorator_kind(param)
+        .and_then(|kind| registry.param_handler(kind))
+        .map(|handler| handler.emit_extractor(param, &param_name, &param_type))
+        .unwrap_or_else(|| quote! { #param_name: #param_type });
+
     Some(tokens)
-}
-
-/// Finds the first NestJS parameter decorator (@Body, @Param, @Query) on a param.
-fn find_param_decorator(param: &swc_ecma_ast::Param) -> Option<String> {
-    for decorator in &param.decorators {
-        if let Expr::Call(call) = &*decorator.expr {
-            if let swc_ecma_ast::Callee::Expr(expr) = &call.callee {
-                if let Expr::Ident(dec_ident) = &**expr {
-                    let dec_name = dec_ident.sym.as_ref();
-                    if matches!(dec_name, "Body" | "Param" | "Query") {
-                        return Some(dec_name.to_string());
-                    }
-                }
-            }
-        }
-    }
-    None
 }
 
 /// Builds the full parameter list including self and method params.

--- a/crates/tyrus_codegen/src/convert/class/mod.rs
+++ b/crates/tyrus_codegen/src/convert/class/mod.rs
@@ -23,11 +23,13 @@ impl RustGenerator {
             self.code.push('\n');
         }
 
-        self.is_controller = class_name.ends_with("Controller");
+        // Decorator-driven detection — replaces the previous heuristic
+        // `class_name.ends_with("Controller")`. The Service heuristic stays
+        // until all fixtures gain `@Injectable` (tracked separately).
+        let controller_info = routing::extract_controller_info(n);
+        self.is_controller = controller_info.is_controller;
 
-        let is_service_or_controller = class_name.ends_with("Service")
-            || class_name.ends_with("Controller")
-            || self.is_controller;
+        let is_service_or_controller = self.is_controller || class_name.ends_with("Service");
 
         // Extract generic params early
         let mut generic_params = std::collections::HashSet::new();
@@ -301,7 +303,7 @@ impl RustGenerator {
         }
 
         // Generate controller routing if applicable
-        let controller_info = routing::extract_controller_info(n);
+        // (controller_info was extracted at the start of this function)
         if controller_info.is_controller {
             self.emit_controller_routing(
                 &struct_name,

--- a/crates/tyrus_codegen/src/convert/class/routing.rs
+++ b/crates/tyrus_codegen/src/convert/class/routing.rs
@@ -1,8 +1,9 @@
 use quote::{format_ident, quote};
-use swc_ecma_ast::{ClassDecl, Expr, Lit};
+use swc_ecma_ast::ClassDecl;
 
 use crate::convert::helpers::to_snake_case;
 use crate::convert::interface::RustGenerator;
+use crate::decorators;
 
 /// Extracted controller decorator information.
 pub(crate) struct ControllerInfo {
@@ -12,40 +13,18 @@ pub(crate) struct ControllerInfo {
     pub guard_names: Vec<String>,
 }
 
-/// Extracts `@Controller("/path")` and `@UseGuards(...)` decorator info from a class.
+/// Extracts `@Controller("/path")` and `@UseGuards(...)` decorator info from
+/// a class via the shared [`crate::decorators::DecoratorRegistry`]. The
+/// per-decorator parsing logic lives in the handler files
+/// (`decorators/controller.rs`, `decorators/use_guards.rs`); this function
+/// is the bridge that exposes the registry's `ClassContext` to legacy callers.
 pub(crate) fn extract_controller_info(n: &ClassDecl) -> ControllerInfo {
-    let mut is_controller = false;
-    let mut controller_path = String::new();
-    let mut guard_names = Vec::new();
-
-    for decorator in &n.class.decorators {
-        if let Expr::Call(call) = &*decorator.expr {
-            if let swc_ecma_ast::Callee::Expr(expr) = &call.callee {
-                if let Expr::Ident(ident) = &**expr {
-                    match ident.sym.as_ref() {
-                        "Controller" => {
-                            is_controller = true;
-                            if let Some(arg) = call.args.first() {
-                                if let Expr::Lit(Lit::Str(s)) = &*arg.expr {
-                                    controller_path =
-                                        s.value.as_str().unwrap_or_default().to_string();
-                                }
-                            }
-                        }
-                        "UseGuards" => {
-                            extract_guard_args(call, &mut guard_names);
-                        }
-                        _ => {}
-                    }
-                }
-            }
-        }
-    }
-
+    let mut ctx = decorators::ClassContext::default();
+    decorators::shared_registry().apply_class_decorators(n, &mut ctx);
     ControllerInfo {
-        is_controller,
-        controller_path,
-        guard_names,
+        is_controller: ctx.is_controller,
+        controller_path: ctx.controller_path,
+        guard_names: ctx.guard_names,
     }
 }
 
@@ -61,15 +40,6 @@ fn find_can_activate_method(n: &ClassDecl) -> Option<&swc_ecma_ast::ClassMethod>
         }
         None
     })
-}
-
-/// Extracts guard class names from `@UseGuards(Guard1, Guard2)` arguments.
-fn extract_guard_args(call: &swc_ecma_ast::CallExpr, guard_names: &mut Vec<String>) {
-    for arg in &call.args {
-        if let Expr::Ident(ident) = &*arg.expr {
-            guard_names.push(ident.sym.to_string());
-        }
-    }
 }
 
 /// Generates the `FromRequestParts` implementation for a controller struct.

--- a/crates/tyrus_codegen/src/convert/class/routing.rs
+++ b/crates/tyrus_codegen/src/convert/class/routing.rs
@@ -1,5 +1,6 @@
 use quote::{format_ident, quote};
 use swc_ecma_ast::ClassDecl;
+use tyrus_decorator_kinds::DecoratorKind;
 
 use crate::convert::helpers::to_snake_case;
 use crate::convert::interface::RustGenerator;
@@ -17,9 +18,10 @@ pub(crate) struct ControllerInfo {
 /// a class via the shared [`crate::decorators::DecoratorRegistry`]. The
 /// per-decorator parsing logic lives in the handler files
 /// (`decorators/controller.rs`, `decorators/use_guards.rs`); this function
-/// is the bridge that exposes the registry's `ClassContext` to legacy callers.
+/// is the bridge that exposes the registry's [`ClassDecoratorContext`] to
+/// legacy callers.
 pub(crate) fn extract_controller_info(n: &ClassDecl) -> ControllerInfo {
-    let mut ctx = decorators::ClassContext::default();
+    let mut ctx = decorators::ClassDecoratorContext::default();
     decorators::shared_registry().apply_class_decorators(n, &mut ctx);
     ControllerInfo {
         is_controller: ctx.is_controller,
@@ -90,6 +92,12 @@ pub(crate) fn generate_router_method(
 }
 
 /// Builds individual `.route()` calls from route metadata.
+///
+/// The HTTP verb name is mapped to its `axum::routing::*` constructor via
+/// [`DecoratorKind::axum_routing_fn_name`] — the same source of truth
+/// `extract_method_decorators` uses, eliminating the previous duplicate
+/// match on `"Get"` / `"Post"` / etc. that existed in both this module
+/// and `class/method.rs`.
 fn build_route_calls(
     routes: &[(String, String, String)],
     controller_path: &str,
@@ -97,19 +105,30 @@ fn build_route_calls(
     routes
         .iter()
         .map(|(method_name, http_method, path)| {
-            let method_ident = format_ident!("{}", method_name);
-            let axum_method = match http_method.as_str() {
-                "Get" => quote! { get },
-                "Post" => quote! { post },
-                "Put" => quote! { put },
-                "Delete" => quote! { delete },
-                "Patch" => quote! { patch },
-                _ => quote! { get },
-            };
-            let full_path = combine_paths(controller_path, path);
-            quote! { .route(#full_path, axum::routing::#axum_method(Self::#method_ident)) }
+            build_single_route(method_name, http_method, path, controller_path)
         })
         .collect()
+}
+
+/// Emits a single `.route(path, axum::routing::verb(Self::handler))` call,
+/// or a `compile_error!` token if the verb is unknown (which would indicate
+/// an internal inconsistency between the registry and this dispatcher).
+fn build_single_route(
+    method_name: &str,
+    http_method: &str,
+    path: &str,
+    controller_path: &str,
+) -> proc_macro2::TokenStream {
+    let Some(axum_fn_name) =
+        DecoratorKind::from_name(http_method).and_then(DecoratorKind::axum_routing_fn_name)
+    else {
+        let msg = format!("Tyrus: unknown HTTP method decorator '{http_method}'");
+        return quote! { compile_error!(#msg); };
+    };
+    let method_ident = format_ident!("{}", method_name);
+    let axum_method = format_ident!("{}", axum_fn_name);
+    let full_path = combine_paths(controller_path, path);
+    quote! { .route(#full_path, axum::routing::#axum_method(Self::#method_ident)) }
 }
 
 /// Combines controller path and method path into a full route path.
@@ -132,27 +151,48 @@ fn combine_paths(controller_path: &str, method_path: &str) -> String {
     }
 }
 
-/// Maps an HTTP status code to its axum StatusCode constant.
+/// Common HTTP status codes mapped to their `axum::http::StatusCode`
+/// constants. Adding support for a new code is a one-line table edit;
+/// uncovered codes generate a `compile_error!` rather than a runtime
+/// `unwrap_or` fallback.
+const STATUS_CODES: &[(u16, &str)] = &[
+    (100, "CONTINUE"),
+    (200, "OK"),
+    (201, "CREATED"),
+    (202, "ACCEPTED"),
+    (204, "NO_CONTENT"),
+    (301, "MOVED_PERMANENTLY"),
+    (302, "FOUND"),
+    (304, "NOT_MODIFIED"),
+    (400, "BAD_REQUEST"),
+    (401, "UNAUTHORIZED"),
+    (403, "FORBIDDEN"),
+    (404, "NOT_FOUND"),
+    (405, "METHOD_NOT_ALLOWED"),
+    (409, "CONFLICT"),
+    (410, "GONE"),
+    (422, "UNPROCESSABLE_ENTITY"),
+    (429, "TOO_MANY_REQUESTS"),
+    (500, "INTERNAL_SERVER_ERROR"),
+    (502, "BAD_GATEWAY"),
+    (503, "SERVICE_UNAVAILABLE"),
+    (504, "GATEWAY_TIMEOUT"),
+];
+
+/// Maps an HTTP status code to its `axum::http::StatusCode` constant. Codes
+/// outside [`STATUS_CODES`] expand to a `compile_error!` token — generated
+/// Rust never carries an `unwrap_or` fallback for status codes.
 pub(crate) fn map_status_code(code: u16) -> proc_macro2::TokenStream {
     use quote::quote;
-    match code {
-        200 => quote! { axum::http::StatusCode::OK },
-        201 => quote! { axum::http::StatusCode::CREATED },
-        204 => quote! { axum::http::StatusCode::NO_CONTENT },
-        301 => quote! { axum::http::StatusCode::MOVED_PERMANENTLY },
-        400 => quote! { axum::http::StatusCode::BAD_REQUEST },
-        401 => quote! { axum::http::StatusCode::UNAUTHORIZED },
-        403 => quote! { axum::http::StatusCode::FORBIDDEN },
-        404 => quote! { axum::http::StatusCode::NOT_FOUND },
-        409 => quote! { axum::http::StatusCode::CONFLICT },
-        500 => quote! { axum::http::StatusCode::INTERNAL_SERVER_ERROR },
-        100..=999 => {
-            quote! { axum::http::StatusCode::from_u16(#code).unwrap_or(axum::http::StatusCode::INTERNAL_SERVER_ERROR) }
-        }
-        _ => {
-            quote! { compile_error!("Tyrus: @HttpCode value is not a valid HTTP status code (100-999)") }
-        }
+    if let Some((_, name)) = STATUS_CODES.iter().find(|(c, _)| *c == code) {
+        let ident = format_ident!("{}", name);
+        return quote! { axum::http::StatusCode::#ident };
     }
+    let msg = format!(
+        "Tyrus: @HttpCode({code}) is not in the supported status code table; \
+         add it to STATUS_CODES in convert/class/routing.rs or use a standard code"
+    );
+    quote! { compile_error!(#msg) }
 }
 
 /// Builds the doc comment for a handler method.
@@ -256,5 +296,75 @@ impl RustGenerator {
             struct_name: class_name.to_string(),
             route_path: controller_info.controller_path.clone(),
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map_status_code_emits_constant_for_known_code() {
+        let token = map_status_code(200);
+        assert!(token.to_string().contains("StatusCode :: OK"));
+    }
+
+    #[test]
+    fn map_status_code_covers_full_table() {
+        for (code, name) in STATUS_CODES {
+            let token = map_status_code(*code);
+            let s = token.to_string();
+            assert!(
+                s.contains(name),
+                "code {code} expected to emit {name}, got: {s}"
+            );
+            assert!(
+                !s.contains("compile_error"),
+                "code {code} unexpectedly emitted compile_error"
+            );
+            assert!(
+                !s.contains("unwrap_or"),
+                "code {code} regressed: unwrap_or should not appear in generated code"
+            );
+        }
+    }
+
+    #[test]
+    fn map_status_code_emits_compile_error_for_unknown_code() {
+        for code in [0_u16, 999, 12345_u16.saturating_mul(1)] {
+            let token = map_status_code(code);
+            let s = token.to_string();
+            assert!(
+                s.contains("compile_error"),
+                "code {code} should emit compile_error, got: {s}"
+            );
+            assert!(
+                !s.contains("unwrap_or"),
+                "code {code} regressed: generated code must not contain unwrap_or"
+            );
+        }
+    }
+
+    #[test]
+    fn build_single_route_known_verb_emits_axum_routing() {
+        let token = build_single_route("find_all", "Get", "", "/users");
+        let s = token.to_string();
+        assert!(s.contains("axum :: routing :: get"));
+        assert!(s.contains("\"/users\""));
+        assert!(s.contains("Self :: find_all"));
+    }
+
+    #[test]
+    fn build_single_route_unknown_verb_emits_compile_error() {
+        let token = build_single_route("foo", "BogusVerb", "", "/x");
+        let s = token.to_string();
+        assert!(
+            s.contains("compile_error"),
+            "unknown verb should emit compile_error, got: {s}"
+        );
+        assert!(
+            s.contains("BogusVerb"),
+            "compile_error should name the verb"
+        );
     }
 }

--- a/crates/tyrus_codegen/src/decorators/controller.rs
+++ b/crates/tyrus_codegen/src/decorators/controller.rs
@@ -3,7 +3,7 @@
 use swc_ecma_ast::{CallExpr, ClassDecl, Expr, Lit};
 use tyrus_decorator_kinds::DecoratorKind;
 
-use super::{ClassContext, ClassDecoratorHandler};
+use super::{ClassDecoratorContext, ClassDecoratorHandler};
 
 pub(crate) struct ControllerHandler;
 
@@ -12,7 +12,7 @@ impl ClassDecoratorHandler for ControllerHandler {
         DecoratorKind::Controller
     }
 
-    fn apply(&self, _class: &ClassDecl, call: &CallExpr, ctx: &mut ClassContext) {
+    fn apply(&self, _class: &ClassDecl, call: &CallExpr, ctx: &mut ClassDecoratorContext) {
         ctx.is_controller = true;
         if let Some(arg) = call.args.first() {
             if let Expr::Lit(Lit::Str(s)) = &*arg.expr {

--- a/crates/tyrus_codegen/src/decorators/controller.rs
+++ b/crates/tyrus_codegen/src/decorators/controller.rs
@@ -1,0 +1,23 @@
+//! `@Controller("/path")` handler.
+
+use swc_ecma_ast::{CallExpr, ClassDecl, Expr, Lit};
+use tyrus_decorator_kinds::DecoratorKind;
+
+use super::{ClassContext, ClassDecoratorHandler};
+
+pub(crate) struct ControllerHandler;
+
+impl ClassDecoratorHandler for ControllerHandler {
+    fn kind(&self) -> DecoratorKind {
+        DecoratorKind::Controller
+    }
+
+    fn apply(&self, _class: &ClassDecl, call: &CallExpr, ctx: &mut ClassContext) {
+        ctx.is_controller = true;
+        if let Some(arg) = call.args.first() {
+            if let Expr::Lit(Lit::Str(s)) = &*arg.expr {
+                ctx.controller_path = s.value.as_str().unwrap_or_default().to_string();
+            }
+        }
+    }
+}

--- a/crates/tyrus_codegen/src/decorators/http_code.rs
+++ b/crates/tyrus_codegen/src/decorators/http_code.rs
@@ -1,0 +1,35 @@
+//! `@HttpCode(201)` handler — sets the response status code on a method.
+
+use swc_ecma_ast::{CallExpr, ClassMethod, Expr, Lit};
+use tyrus_decorator_kinds::DecoratorKind;
+
+use super::{MethodDecoratorContext, MethodDecoratorHandler};
+
+pub(crate) struct HttpCodeHandler;
+
+impl MethodDecoratorHandler for HttpCodeHandler {
+    fn kind(&self) -> DecoratorKind {
+        DecoratorKind::HttpCode
+    }
+
+    fn apply(&self, _method: &ClassMethod, call: &CallExpr, ctx: &mut MethodDecoratorContext) {
+        if let Some(arg) = call.args.first() {
+            if let Expr::Lit(Lit::Num(num)) = &*arg.expr {
+                ctx.http_code = Some(num.value as u16);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handler_kind_is_http_code() {
+        let h = HttpCodeHandler;
+        assert_eq!(h.kind(), DecoratorKind::HttpCode);
+        assert!(!DecoratorKind::HttpCode.is_http_method());
+        assert!(DecoratorKind::HttpCode.axum_routing_fn_name().is_none());
+    }
+}

--- a/crates/tyrus_codegen/src/decorators/http_method.rs
+++ b/crates/tyrus_codegen/src/decorators/http_method.rs
@@ -1,0 +1,62 @@
+//! `@Get` / `@Post` / `@Put` / `@Delete` / `@Patch` handlers.
+//!
+//! A single struct parameterized by [`DecoratorKind`] backs all five HTTP
+//! verb decorators. The registry stores one instance per verb in its method
+//! handler map, so dispatch is still O(1) by kind.
+
+use swc_ecma_ast::{CallExpr, ClassMethod, Expr, Lit};
+use tyrus_decorator_kinds::DecoratorKind;
+
+use super::{MethodDecoratorContext, MethodDecoratorHandler};
+
+pub(crate) struct HttpMethodHandler {
+    kind: DecoratorKind,
+}
+
+impl HttpMethodHandler {
+    /// Creates a handler for the given HTTP verb decorator. The kind must be
+    /// one of `HttpGet`, `HttpPost`, `HttpPut`, `HttpDelete`, `HttpPatch`.
+    pub(crate) fn new(kind: DecoratorKind) -> Self {
+        debug_assert!(
+            kind.is_http_method(),
+            "HttpMethodHandler instantiated with non-HTTP-method kind {kind:?}"
+        );
+        Self { kind }
+    }
+}
+
+impl MethodDecoratorHandler for HttpMethodHandler {
+    fn kind(&self) -> DecoratorKind {
+        self.kind
+    }
+
+    fn apply(&self, _method: &ClassMethod, call: &CallExpr, ctx: &mut MethodDecoratorContext) {
+        ctx.http_method = Some(self.kind);
+        if let Some(arg) = call.args.first() {
+            if let Expr::Lit(Lit::Str(s)) = &*arg.expr {
+                ctx.route_path = s.value.as_str().unwrap_or_default().to_string();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handler_carries_kind() {
+        for kind in [
+            DecoratorKind::HttpGet,
+            DecoratorKind::HttpPost,
+            DecoratorKind::HttpPut,
+            DecoratorKind::HttpDelete,
+            DecoratorKind::HttpPatch,
+        ] {
+            let h = HttpMethodHandler::new(kind);
+            assert_eq!(h.kind(), kind);
+            assert!(kind.is_http_method());
+            assert!(kind.axum_routing_fn_name().is_some());
+        }
+    }
+}

--- a/crates/tyrus_codegen/src/decorators/mod.rs
+++ b/crates/tyrus_codegen/src/decorators/mod.rs
@@ -8,8 +8,8 @@
 //!
 //! Three traits, one per scope:
 //!
-//! - [`ClassDecoratorHandler`] — runs over a `ClassDecl`, mutates a [`ClassContext`]
-//! - [`MethodDecoratorHandler`] — runs over a `ClassMethod`, mutates a [`MethodContext`]
+//! - [`ClassDecoratorHandler`] — runs over a `ClassDecl`, mutates a [`ClassDecoratorContext`]
+//! - [`MethodDecoratorHandler`] — runs over a `ClassMethod`, mutates a [`MethodDecoratorContext`]
 //! - [`ParamDecoratorHandler`] — runs over a `Param`, emits an Axum extractor token
 //!
 //! A [`DecoratorRegistry`] dispatches a decorator's identifier to the right
@@ -17,14 +17,20 @@
 //! means: add one variant to `DecoratorKind`, write one handler file, register
 //! it in [`default_registry`]. No hot-path file is touched.
 //!
-//! ## What's here today (PR #1)
+//! ## What's here today (PR #3)
 //!
-//! Only the **class-level** half of the registry is wired:
-//! [`ControllerHandler`] and [`UseGuardsHandler`]. Method- and param-level
-//! handlers are stubbed (the trait + storage exists, but `default_registry`
-//! does not register any yet — those land in PR #2 and PR #3).
+//! All three scopes wired:
+//! - Class-level: `@Controller`, `@UseGuards`
+//! - Method-level: `@Get`/`@Post`/`@Put`/`@Delete`/`@Patch` + `@HttpCode`
+//! - Param-level: `@Body`, `@Param`, `@Query`
+//!
+//! PR #5 will add `@Headers` purely by extending `params.rs` + registering
+//! one new handler — proving the registry pattern's extensibility claim.
 
 pub(crate) mod controller;
+pub(crate) mod http_code;
+pub(crate) mod http_method;
+pub(crate) mod params;
 pub(crate) mod use_guards;
 
 use std::collections::HashMap;
@@ -38,17 +44,19 @@ use tyrus_decorator_kinds::DecoratorKind;
 /// `UseGuardsHandler` appends to `guard_names`. Code outside this module
 /// reads the resulting struct — it never observes which handler wrote what.
 #[derive(Debug, Default, Clone)]
-pub(crate) struct ClassContext {
+pub(crate) struct ClassDecoratorContext {
     pub(crate) is_controller: bool,
     pub(crate) controller_path: String,
     pub(crate) guard_names: Vec<String>,
 }
 
-/// Mutable bag of method-level metadata. Populated in PR #2.
+/// Mutable bag of method-level metadata. `HttpMethodHandler` writes
+/// `http_method` + `route_path`; `HttpCodeHandler` writes `http_code`.
 #[derive(Debug, Default, Clone)]
-#[allow(dead_code)]
-pub(crate) struct MethodContext {
-    pub(crate) http_method: Option<String>,
+pub(crate) struct MethodDecoratorContext {
+    /// The [`DecoratorKind`] of the HTTP verb decorator, if any.
+    /// `None` ⇒ method is not an HTTP handler.
+    pub(crate) http_method: Option<DecoratorKind>,
     pub(crate) route_path: String,
     pub(crate) http_code: Option<u16>,
 }
@@ -56,21 +64,18 @@ pub(crate) struct MethodContext {
 /// Handler for class-level decorators (`@Controller`, `@UseGuards`, ...).
 pub(crate) trait ClassDecoratorHandler: Send + Sync {
     fn kind(&self) -> DecoratorKind;
-    fn apply(&self, class: &ClassDecl, call: &CallExpr, ctx: &mut ClassContext);
+    fn apply(&self, class: &ClassDecl, call: &CallExpr, ctx: &mut ClassDecoratorContext);
 }
 
 /// Handler for method-level decorators (`@Get`, `@Post`, `@HttpCode`, ...).
-/// Wired in PR #2.
-#[allow(dead_code)]
 pub(crate) trait MethodDecoratorHandler: Send + Sync {
     fn kind(&self) -> DecoratorKind;
-    fn apply(&self, method: &ClassMethod, call: &CallExpr, ctx: &mut MethodContext);
+    fn apply(&self, method: &ClassMethod, call: &CallExpr, ctx: &mut MethodDecoratorContext);
 }
 
 /// Handler for param-level decorators (`@Body`, `@Param`, `@Query`, ...).
-/// Wired in PR #3. `emit_extractor` returns the Axum extractor token to
-/// substitute for the parameter binding.
-#[allow(dead_code)]
+/// `emit_extractor` returns the Axum extractor token to substitute for
+/// the parameter binding in the generated handler signature.
 pub(crate) trait ParamDecoratorHandler: Send + Sync {
     fn kind(&self) -> DecoratorKind;
     fn emit_extractor(
@@ -85,9 +90,7 @@ pub(crate) trait ParamDecoratorHandler: Send + Sync {
 /// `O(1)` via `HashMap` keyed on [`DecoratorKind`].
 pub(crate) struct DecoratorRegistry {
     class: HashMap<DecoratorKind, Box<dyn ClassDecoratorHandler>>,
-    #[allow(dead_code)]
     method: HashMap<DecoratorKind, Box<dyn MethodDecoratorHandler>>,
-    #[allow(dead_code)]
     param: HashMap<DecoratorKind, Box<dyn ParamDecoratorHandler>>,
 }
 
@@ -104,12 +107,10 @@ impl DecoratorRegistry {
         self.class.insert(handler.kind(), handler);
     }
 
-    #[allow(dead_code)]
     pub(crate) fn register_method(&mut self, handler: Box<dyn MethodDecoratorHandler>) {
         self.method.insert(handler.kind(), handler);
     }
 
-    #[allow(dead_code)]
     pub(crate) fn register_param(&mut self, handler: Box<dyn ParamDecoratorHandler>) {
         self.param.insert(handler.kind(), handler);
     }
@@ -118,21 +119,41 @@ impl DecoratorRegistry {
         self.class.get(&kind).map(std::convert::AsRef::as_ref)
     }
 
+    pub(crate) fn method_handler(
+        &self,
+        kind: DecoratorKind,
+    ) -> Option<&dyn MethodDecoratorHandler> {
+        self.method.get(&kind).map(std::convert::AsRef::as_ref)
+    }
+
+    pub(crate) fn param_handler(&self, kind: DecoratorKind) -> Option<&dyn ParamDecoratorHandler> {
+        self.param.get(&kind).map(std::convert::AsRef::as_ref)
+    }
+
+    /// Scans a function parameter's decorators and returns the kind of the
+    /// first one recognized as a param-level decorator. The caller is
+    /// expected to look up the handler via [`Self::param_handler`] and call
+    /// `emit_extractor` for the actual token emission. Decorators that
+    /// don't classify (non-call expressions, unknown names) or aren't
+    /// param-level are skipped, not aborted.
+    pub(crate) fn first_param_decorator_kind(&self, param: &Param) -> Option<DecoratorKind> {
+        for decorator in &param.decorators {
+            let Some((kind, _call)) = classify_decorator(decorator) else {
+                continue;
+            };
+            if self.param.contains_key(&kind) {
+                return Some(kind);
+            }
+        }
+        None
+    }
+
     /// Iterates the class decorators of `n`, classifies each by name,
     /// and invokes the corresponding handler. Unknown decorators are
     /// silently ignored — generic translation responsibility lies elsewhere.
-    pub(crate) fn apply_class_decorators(&self, n: &ClassDecl, ctx: &mut ClassContext) {
+    pub(crate) fn apply_class_decorators(&self, n: &ClassDecl, ctx: &mut ClassDecoratorContext) {
         for decorator in &n.class.decorators {
-            let swc_ecma_ast::Expr::Call(call) = &*decorator.expr else {
-                continue;
-            };
-            let swc_ecma_ast::Callee::Expr(callee_expr) = &call.callee else {
-                continue;
-            };
-            let swc_ecma_ast::Expr::Ident(ident) = &**callee_expr else {
-                continue;
-            };
-            let Some(kind) = DecoratorKind::from_name(ident.sym.as_ref()) else {
+            let Some((kind, call)) = classify_decorator(decorator) else {
                 continue;
             };
             if let Some(handler) = self.class_handler(kind) {
@@ -140,14 +161,65 @@ impl DecoratorRegistry {
             }
         }
     }
+
+    /// Iterates the decorators of a class method and invokes the matching
+    /// method-level handlers. Unknown decorators are silently ignored.
+    pub(crate) fn apply_method_decorators(
+        &self,
+        method: &ClassMethod,
+        ctx: &mut MethodDecoratorContext,
+    ) {
+        for decorator in &method.function.decorators {
+            let Some((kind, call)) = classify_decorator(decorator) else {
+                continue;
+            };
+            if let Some(handler) = self.method_handler(kind) {
+                handler.apply(method, call, ctx);
+            }
+        }
+    }
+}
+
+/// Classifies a decorator AST node into its [`DecoratorKind`] and returns the
+/// underlying [`CallExpr`] for handler use. Returns `None` for non-call
+/// decorators or unknown names — the caller is expected to skip those.
+fn classify_decorator(decorator: &swc_ecma_ast::Decorator) -> Option<(DecoratorKind, &CallExpr)> {
+    let swc_ecma_ast::Expr::Call(call) = &*decorator.expr else {
+        return None;
+    };
+    let swc_ecma_ast::Callee::Expr(callee_expr) = &call.callee else {
+        return None;
+    };
+    let swc_ecma_ast::Expr::Ident(ident) = &**callee_expr else {
+        return None;
+    };
+    DecoratorKind::from_name(ident.sym.as_ref()).map(|kind| (kind, call))
 }
 
 /// The default registry used by the transpiler. Adding a new built-in
 /// decorator means adding one `register_*` line here.
 pub(crate) fn default_registry() -> DecoratorRegistry {
     let mut registry = DecoratorRegistry::new();
+    // Class-level
     registry.register_class(Box::new(controller::ControllerHandler));
     registry.register_class(Box::new(use_guards::UseGuardsHandler));
+    // Method-level — one `HttpMethodHandler` instance per HTTP verb,
+    // plus one `HttpCodeHandler` for `@HttpCode(...)`.
+    for kind in [
+        DecoratorKind::HttpGet,
+        DecoratorKind::HttpPost,
+        DecoratorKind::HttpPut,
+        DecoratorKind::HttpDelete,
+        DecoratorKind::HttpPatch,
+    ] {
+        registry.register_method(Box::new(http_method::HttpMethodHandler::new(kind)));
+    }
+    registry.register_method(Box::new(http_code::HttpCodeHandler));
+    // Param-level — Body, Param (NestJS @Param == Axum Path), Query, Headers.
+    registry.register_param(Box::new(params::BodyHandler));
+    registry.register_param(Box::new(params::ParamHandler));
+    registry.register_param(Box::new(params::QueryHandler));
+    registry.register_param(Box::new(params::HeadersHandler));
     registry
 }
 
@@ -167,7 +239,40 @@ mod tests {
         let r = default_registry();
         assert!(r.class_handler(DecoratorKind::Controller).is_some());
         assert!(r.class_handler(DecoratorKind::UseGuards).is_some());
-        // Method-/param-level handlers land in PR #2 and #3.
+        // Class lookup must not return method-/param-level handlers.
         assert!(r.class_handler(DecoratorKind::HttpGet).is_none());
+    }
+
+    #[test]
+    fn default_registry_has_method_handlers() {
+        let r = default_registry();
+        for kind in [
+            DecoratorKind::HttpGet,
+            DecoratorKind::HttpPost,
+            DecoratorKind::HttpPut,
+            DecoratorKind::HttpDelete,
+            DecoratorKind::HttpPatch,
+            DecoratorKind::HttpCode,
+        ] {
+            assert!(r.method_handler(kind).is_some(), "{kind:?} not registered");
+        }
+        // Method lookup must not return class-level handlers.
+        assert!(r.method_handler(DecoratorKind::Controller).is_none());
+    }
+
+    #[test]
+    fn default_registry_has_param_handlers() {
+        let r = default_registry();
+        for kind in [
+            DecoratorKind::Body,
+            DecoratorKind::Param,
+            DecoratorKind::Query,
+            DecoratorKind::Headers,
+        ] {
+            assert!(r.param_handler(kind).is_some(), "{kind:?} not registered");
+        }
+        // Param lookup must not return class-/method-level handlers.
+        assert!(r.param_handler(DecoratorKind::Controller).is_none());
+        assert!(r.param_handler(DecoratorKind::HttpGet).is_none());
     }
 }

--- a/crates/tyrus_codegen/src/decorators/mod.rs
+++ b/crates/tyrus_codegen/src/decorators/mod.rs
@@ -1,0 +1,173 @@
+//! Decorator handler registry.
+//!
+//! This module is the architectural answer to the prior approach where every
+//! NestJS decorator required hardcoded match arms scattered across
+//! `class/mod.rs`, `class/method.rs`, `class/routing.rs`, and the analyzer.
+//!
+//! ## Design
+//!
+//! Three traits, one per scope:
+//!
+//! - [`ClassDecoratorHandler`] — runs over a `ClassDecl`, mutates a [`ClassContext`]
+//! - [`MethodDecoratorHandler`] — runs over a `ClassMethod`, mutates a [`MethodContext`]
+//! - [`ParamDecoratorHandler`] — runs over a `Param`, emits an Axum extractor token
+//!
+//! A [`DecoratorRegistry`] dispatches a decorator's identifier to the right
+//! handler via [`tyrus_decorator_kinds::DecoratorKind`]. Adding a new decorator
+//! means: add one variant to `DecoratorKind`, write one handler file, register
+//! it in [`default_registry`]. No hot-path file is touched.
+//!
+//! ## What's here today (PR #1)
+//!
+//! Only the **class-level** half of the registry is wired:
+//! [`ControllerHandler`] and [`UseGuardsHandler`]. Method- and param-level
+//! handlers are stubbed (the trait + storage exists, but `default_registry`
+//! does not register any yet — those land in PR #2 and PR #3).
+
+pub(crate) mod controller;
+pub(crate) mod use_guards;
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+use swc_ecma_ast::{CallExpr, ClassDecl, ClassMethod, Param};
+use tyrus_decorator_kinds::DecoratorKind;
+
+/// Mutable bag of class-level metadata that handlers populate.
+///
+/// `ControllerHandler` flips `is_controller` and writes `controller_path`;
+/// `UseGuardsHandler` appends to `guard_names`. Code outside this module
+/// reads the resulting struct — it never observes which handler wrote what.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct ClassContext {
+    pub(crate) is_controller: bool,
+    pub(crate) controller_path: String,
+    pub(crate) guard_names: Vec<String>,
+}
+
+/// Mutable bag of method-level metadata. Populated in PR #2.
+#[derive(Debug, Default, Clone)]
+#[allow(dead_code)]
+pub(crate) struct MethodContext {
+    pub(crate) http_method: Option<String>,
+    pub(crate) route_path: String,
+    pub(crate) http_code: Option<u16>,
+}
+
+/// Handler for class-level decorators (`@Controller`, `@UseGuards`, ...).
+pub(crate) trait ClassDecoratorHandler: Send + Sync {
+    fn kind(&self) -> DecoratorKind;
+    fn apply(&self, class: &ClassDecl, call: &CallExpr, ctx: &mut ClassContext);
+}
+
+/// Handler for method-level decorators (`@Get`, `@Post`, `@HttpCode`, ...).
+/// Wired in PR #2.
+#[allow(dead_code)]
+pub(crate) trait MethodDecoratorHandler: Send + Sync {
+    fn kind(&self) -> DecoratorKind;
+    fn apply(&self, method: &ClassMethod, call: &CallExpr, ctx: &mut MethodContext);
+}
+
+/// Handler for param-level decorators (`@Body`, `@Param`, `@Query`, ...).
+/// Wired in PR #3. `emit_extractor` returns the Axum extractor token to
+/// substitute for the parameter binding.
+#[allow(dead_code)]
+pub(crate) trait ParamDecoratorHandler: Send + Sync {
+    fn kind(&self) -> DecoratorKind;
+    fn emit_extractor(
+        &self,
+        param: &Param,
+        param_name: &proc_macro2::Ident,
+        param_type: &proc_macro2::TokenStream,
+    ) -> proc_macro2::TokenStream;
+}
+
+/// Central registry. Owned by `RustGenerator` (or built ad-hoc). Lookup is
+/// `O(1)` via `HashMap` keyed on [`DecoratorKind`].
+pub(crate) struct DecoratorRegistry {
+    class: HashMap<DecoratorKind, Box<dyn ClassDecoratorHandler>>,
+    #[allow(dead_code)]
+    method: HashMap<DecoratorKind, Box<dyn MethodDecoratorHandler>>,
+    #[allow(dead_code)]
+    param: HashMap<DecoratorKind, Box<dyn ParamDecoratorHandler>>,
+}
+
+impl DecoratorRegistry {
+    pub(crate) fn new() -> Self {
+        Self {
+            class: HashMap::new(),
+            method: HashMap::new(),
+            param: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn register_class(&mut self, handler: Box<dyn ClassDecoratorHandler>) {
+        self.class.insert(handler.kind(), handler);
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn register_method(&mut self, handler: Box<dyn MethodDecoratorHandler>) {
+        self.method.insert(handler.kind(), handler);
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn register_param(&mut self, handler: Box<dyn ParamDecoratorHandler>) {
+        self.param.insert(handler.kind(), handler);
+    }
+
+    pub(crate) fn class_handler(&self, kind: DecoratorKind) -> Option<&dyn ClassDecoratorHandler> {
+        self.class.get(&kind).map(std::convert::AsRef::as_ref)
+    }
+
+    /// Iterates the class decorators of `n`, classifies each by name,
+    /// and invokes the corresponding handler. Unknown decorators are
+    /// silently ignored — generic translation responsibility lies elsewhere.
+    pub(crate) fn apply_class_decorators(&self, n: &ClassDecl, ctx: &mut ClassContext) {
+        for decorator in &n.class.decorators {
+            let swc_ecma_ast::Expr::Call(call) = &*decorator.expr else {
+                continue;
+            };
+            let swc_ecma_ast::Callee::Expr(callee_expr) = &call.callee else {
+                continue;
+            };
+            let swc_ecma_ast::Expr::Ident(ident) = &**callee_expr else {
+                continue;
+            };
+            let Some(kind) = DecoratorKind::from_name(ident.sym.as_ref()) else {
+                continue;
+            };
+            if let Some(handler) = self.class_handler(kind) {
+                handler.apply(n, call, ctx);
+            }
+        }
+    }
+}
+
+/// The default registry used by the transpiler. Adding a new built-in
+/// decorator means adding one `register_*` line here.
+pub(crate) fn default_registry() -> DecoratorRegistry {
+    let mut registry = DecoratorRegistry::new();
+    registry.register_class(Box::new(controller::ControllerHandler));
+    registry.register_class(Box::new(use_guards::UseGuardsHandler));
+    registry
+}
+
+/// Process-wide singleton of [`default_registry`]. Built once on first access;
+/// subsequent calls are a pointer load.
+pub(crate) fn shared_registry() -> &'static DecoratorRegistry {
+    static REGISTRY: OnceLock<DecoratorRegistry> = OnceLock::new();
+    REGISTRY.get_or_init(default_registry)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_registry_has_class_handlers() {
+        let r = default_registry();
+        assert!(r.class_handler(DecoratorKind::Controller).is_some());
+        assert!(r.class_handler(DecoratorKind::UseGuards).is_some());
+        // Method-/param-level handlers land in PR #2 and #3.
+        assert!(r.class_handler(DecoratorKind::HttpGet).is_none());
+    }
+}

--- a/crates/tyrus_codegen/src/decorators/params.rs
+++ b/crates/tyrus_codegen/src/decorators/params.rs
@@ -1,0 +1,171 @@
+//! `@Body`, `@Param`, `@Query` handlers — Axum extractor emitters.
+//!
+//! All three live in one file because the feedback memory rule
+//! ("never create a separate handler function per decorator name") treats
+//! per-name handler files as the anti-pattern; the only thing that matters
+//! is that the dispatch is registry-based, not scattered across hot paths.
+//! Future param decorators (`@Headers`, `@Req`, `@Session`, ...) can keep
+//! piling up here, or split out only when this file approaches the 400-line
+//! limit.
+//!
+//! Each handler emits the parameter binding token used in the generated
+//! Axum handler signature:
+//!
+//! ```text
+//! @Body() dto: CreateUserDto      → axum::Json(dto): axum::Json<CreateUserDto>
+//! @Param('id') id: string          → axum::extract::Path(id): axum::extract::Path<String>
+//! @Query('page') page: string      → axum::extract::Query(page): axum::extract::Query<String>
+//! ```
+
+use proc_macro2::{Ident, TokenStream};
+use quote::quote;
+use swc_ecma_ast::Param;
+use tyrus_decorator_kinds::DecoratorKind;
+
+use super::ParamDecoratorHandler;
+
+pub(crate) struct BodyHandler;
+
+impl ParamDecoratorHandler for BodyHandler {
+    fn kind(&self) -> DecoratorKind {
+        DecoratorKind::Body
+    }
+
+    fn emit_extractor(
+        &self,
+        _param: &Param,
+        param_name: &Ident,
+        param_type: &TokenStream,
+    ) -> TokenStream {
+        quote! { axum::Json(#param_name): axum::Json<#param_type> }
+    }
+}
+
+pub(crate) struct ParamHandler;
+
+impl ParamDecoratorHandler for ParamHandler {
+    fn kind(&self) -> DecoratorKind {
+        DecoratorKind::Param
+    }
+
+    fn emit_extractor(
+        &self,
+        _param: &Param,
+        param_name: &Ident,
+        param_type: &TokenStream,
+    ) -> TokenStream {
+        quote! { axum::extract::Path(#param_name): axum::extract::Path<#param_type> }
+    }
+}
+
+pub(crate) struct QueryHandler;
+
+impl ParamDecoratorHandler for QueryHandler {
+    fn kind(&self) -> DecoratorKind {
+        DecoratorKind::Query
+    }
+
+    fn emit_extractor(
+        &self,
+        _param: &Param,
+        param_name: &Ident,
+        param_type: &TokenStream,
+    ) -> TokenStream {
+        quote! { axum::extract::Query(#param_name): axum::extract::Query<#param_type> }
+    }
+}
+
+/// `@Headers()` — emits the entire `axum::http::HeaderMap` as the parameter
+/// binding. The user's TypeScript type annotation is ignored because Axum
+/// only exposes `HeaderMap` for full-headers extraction. Handlers can then
+/// query individual headers via `headers.get("name")`.
+///
+/// A name-scoped form (`@Headers('authorization') auth: string`) would
+/// require extending [`super::ParamDecoratorHandler`] with a body-prelude
+/// hook so the generated handler can extract the specific value before
+/// the user code runs. That extension is intentionally deferred — adding
+/// it here is independent of validating the registry pattern.
+pub(crate) struct HeadersHandler;
+
+impl ParamDecoratorHandler for HeadersHandler {
+    fn kind(&self) -> DecoratorKind {
+        DecoratorKind::Headers
+    }
+
+    fn emit_extractor(
+        &self,
+        _param: &Param,
+        param_name: &Ident,
+        _param_type: &TokenStream,
+    ) -> TokenStream {
+        quote! { #param_name: axum::http::HeaderMap }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::format_ident;
+
+    fn dummy_param() -> Param {
+        Param {
+            span: swc_common::DUMMY_SP,
+            decorators: vec![],
+            pat: swc_ecma_ast::Pat::Ident(swc_ecma_ast::BindingIdent {
+                id: swc_ecma_ast::Ident::new("x".into(), swc_common::DUMMY_SP, Default::default()),
+                type_ann: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn body_handler_emits_json_extractor() {
+        let h = BodyHandler;
+        let name = format_ident!("dto");
+        let ty = quote! { CreateUserDto };
+        let token = h.emit_extractor(&dummy_param(), &name, &ty).to_string();
+        assert!(token.contains("axum :: Json"));
+        assert!(token.contains("dto"));
+        assert!(token.contains("CreateUserDto"));
+        assert_eq!(h.kind(), DecoratorKind::Body);
+    }
+
+    #[test]
+    fn param_handler_emits_path_extractor() {
+        let h = ParamHandler;
+        let name = format_ident!("id");
+        let ty = quote! { String };
+        let token = h.emit_extractor(&dummy_param(), &name, &ty).to_string();
+        assert!(token.contains("axum :: extract :: Path"));
+        assert!(token.contains("id"));
+        assert!(token.contains("String"));
+        assert_eq!(h.kind(), DecoratorKind::Param);
+    }
+
+    #[test]
+    fn query_handler_emits_query_extractor() {
+        let h = QueryHandler;
+        let name = format_ident!("page");
+        let ty = quote! { String };
+        let token = h.emit_extractor(&dummy_param(), &name, &ty).to_string();
+        assert!(token.contains("axum :: extract :: Query"));
+        assert!(token.contains("page"));
+        assert_eq!(h.kind(), DecoratorKind::Query);
+    }
+
+    #[test]
+    fn headers_handler_emits_header_map_param() {
+        let h = HeadersHandler;
+        let name = format_ident!("headers");
+        // The user's type annotation is ignored — HeaderMap is the only Axum form.
+        let ty = quote! { ThisShouldBeIgnored };
+        let token = h.emit_extractor(&dummy_param(), &name, &ty).to_string();
+        assert!(token.contains("axum :: http :: HeaderMap"));
+        assert!(token.contains("headers"));
+        assert!(
+            !token.contains("ThisShouldBeIgnored"),
+            "user's type annotation must NOT appear in the emitted extractor"
+        );
+        assert_eq!(h.kind(), DecoratorKind::Headers);
+    }
+}

--- a/crates/tyrus_codegen/src/decorators/use_guards.rs
+++ b/crates/tyrus_codegen/src/decorators/use_guards.rs
@@ -1,0 +1,22 @@
+//! `@UseGuards(Guard1, Guard2)` handler.
+
+use swc_ecma_ast::{CallExpr, ClassDecl, Expr};
+use tyrus_decorator_kinds::DecoratorKind;
+
+use super::{ClassContext, ClassDecoratorHandler};
+
+pub(crate) struct UseGuardsHandler;
+
+impl ClassDecoratorHandler for UseGuardsHandler {
+    fn kind(&self) -> DecoratorKind {
+        DecoratorKind::UseGuards
+    }
+
+    fn apply(&self, _class: &ClassDecl, call: &CallExpr, ctx: &mut ClassContext) {
+        for arg in &call.args {
+            if let Expr::Ident(ident) = &*arg.expr {
+                ctx.guard_names.push(ident.sym.to_string());
+            }
+        }
+    }
+}

--- a/crates/tyrus_codegen/src/decorators/use_guards.rs
+++ b/crates/tyrus_codegen/src/decorators/use_guards.rs
@@ -3,7 +3,7 @@
 use swc_ecma_ast::{CallExpr, ClassDecl, Expr};
 use tyrus_decorator_kinds::DecoratorKind;
 
-use super::{ClassContext, ClassDecoratorHandler};
+use super::{ClassDecoratorContext, ClassDecoratorHandler};
 
 pub(crate) struct UseGuardsHandler;
 
@@ -12,7 +12,7 @@ impl ClassDecoratorHandler for UseGuardsHandler {
         DecoratorKind::UseGuards
     }
 
-    fn apply(&self, _class: &ClassDecl, call: &CallExpr, ctx: &mut ClassContext) {
+    fn apply(&self, _class: &ClassDecl, call: &CallExpr, ctx: &mut ClassDecoratorContext) {
         for arg in &call.args {
             if let Expr::Ident(ident) = &*arg.expr {
                 ctx.guard_names.push(ident.sym.to_string());

--- a/crates/tyrus_codegen/src/lib.rs
+++ b/crates/tyrus_codegen/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod convert;
+pub(crate) mod decorators;
 pub mod stdlib;
 
 use convert::interface::RustGenerator;

--- a/crates/tyrus_decorator_kinds/Cargo.toml
+++ b/crates/tyrus_decorator_kinds/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "tyrus_decorator_kinds"
+version = "0.1.0"
+edition = "2021"
+description = "Single source of truth for NestJS decorator name → kind classification, shared between analyzer and codegen."
+
+[dependencies]

--- a/crates/tyrus_decorator_kinds/src/lib.rs
+++ b/crates/tyrus_decorator_kinds/src/lib.rs
@@ -51,6 +51,7 @@ pub enum DecoratorKind {
     Body,
     Param,
     Query,
+    Headers,
 }
 
 impl DecoratorKind {
@@ -72,6 +73,7 @@ impl DecoratorKind {
             "Body" => Some(Self::Body),
             "Param" => Some(Self::Param),
             "Query" => Some(Self::Query),
+            "Headers" => Some(Self::Headers),
             _ => None,
         }
     }
@@ -88,7 +90,7 @@ impl DecoratorKind {
             | Self::HttpDelete
             | Self::HttpPatch
             | Self::HttpCode => DecoratorScope::Method,
-            Self::Body | Self::Param | Self::Query => DecoratorScope::Param,
+            Self::Body | Self::Param | Self::Query | Self::Headers => DecoratorScope::Param,
         }
     }
 
@@ -99,6 +101,25 @@ impl DecoratorKind {
             self,
             Self::HttpGet | Self::HttpPost | Self::HttpPut | Self::HttpDelete | Self::HttpPatch
         )
+    }
+
+    /// Returns the `axum::routing::*` constructor name for HTTP verb
+    /// decorators (e.g. `HttpGet` → `"get"`). Returns `None` for any
+    /// non-verb kind.
+    ///
+    /// This lives in `tyrus_decorator_kinds` (rather than the codegen crate)
+    /// because the mapping is a property of the decorator, not of the code
+    /// emission strategy — keeping it here means routing.rs and the registry
+    /// share the same source of truth.
+    pub fn axum_routing_fn_name(self) -> Option<&'static str> {
+        match self {
+            Self::HttpGet => Some("get"),
+            Self::HttpPost => Some("post"),
+            Self::HttpPut => Some("put"),
+            Self::HttpDelete => Some("delete"),
+            Self::HttpPatch => Some("patch"),
+            _ => None,
+        }
     }
 
     /// The original TypeScript name, for diagnostics.
@@ -117,6 +138,7 @@ impl DecoratorKind {
             Self::Body => "Body",
             Self::Param => "Param",
             Self::Query => "Query",
+            Self::Headers => "Headers",
         }
     }
 }
@@ -165,6 +187,23 @@ mod tests {
     }
 
     #[test]
+    fn axum_routing_fn_name_for_verbs() {
+        assert_eq!(DecoratorKind::HttpGet.axum_routing_fn_name(), Some("get"));
+        assert_eq!(DecoratorKind::HttpPost.axum_routing_fn_name(), Some("post"));
+        assert_eq!(DecoratorKind::HttpPut.axum_routing_fn_name(), Some("put"));
+        assert_eq!(
+            DecoratorKind::HttpDelete.axum_routing_fn_name(),
+            Some("delete")
+        );
+        assert_eq!(
+            DecoratorKind::HttpPatch.axum_routing_fn_name(),
+            Some("patch")
+        );
+        assert_eq!(DecoratorKind::HttpCode.axum_routing_fn_name(), None);
+        assert_eq!(DecoratorKind::Controller.axum_routing_fn_name(), None);
+    }
+
+    #[test]
     fn name_roundtrip() {
         for kind in [
             DecoratorKind::Module,
@@ -180,6 +219,7 @@ mod tests {
             DecoratorKind::Body,
             DecoratorKind::Param,
             DecoratorKind::Query,
+            DecoratorKind::Headers,
         ] {
             assert_eq!(DecoratorKind::from_name(kind.name()), Some(kind));
         }

--- a/crates/tyrus_decorator_kinds/src/lib.rs
+++ b/crates/tyrus_decorator_kinds/src/lib.rs
@@ -1,0 +1,187 @@
+//! Single source of truth for NestJS decorator name → kind classification.
+//!
+//! This crate is intentionally lightweight (zero dependencies) so it can be
+//! shared by both `tyrus_analyzer` and `tyrus_codegen` without dragging
+//! `proc_macro2`/`quote` into the analyzer.
+//!
+//! Usage:
+//! ```
+//! use tyrus_decorator_kinds::{DecoratorKind, DecoratorScope};
+//!
+//! assert_eq!(DecoratorKind::from_name("Controller"), Some(DecoratorKind::Controller));
+//! assert_eq!(DecoratorKind::Controller.scope(), DecoratorScope::Class);
+//! assert_eq!(DecoratorKind::from_name("UnknownDecorator"), None);
+//! ```
+
+#![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::todo)]
+
+/// Where in the AST a decorator can appear.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DecoratorScope {
+    /// Class-level: `@Controller`, `@Injectable`, `@Module`, `@UseGuards`.
+    Class,
+    /// Method-level: `@Get`, `@Post`, `@HttpCode`, etc.
+    Method,
+    /// Parameter-level: `@Body`, `@Param`, `@Query`, `@Headers`.
+    Param,
+}
+
+/// Every NestJS decorator the transpiler currently recognizes.
+///
+/// Adding a new decorator means adding ONE variant here plus mapping its name
+/// in [`DecoratorKind::from_name`]. The handler that emits Rust for it lives
+/// in `tyrus_codegen::decorators`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DecoratorKind {
+    // Class-level
+    Module,
+    Injectable,
+    Controller,
+    UseGuards,
+
+    // Method-level
+    HttpGet,
+    HttpPost,
+    HttpPut,
+    HttpDelete,
+    HttpPatch,
+    HttpCode,
+
+    // Param-level
+    Body,
+    Param,
+    Query,
+}
+
+impl DecoratorKind {
+    /// Maps a decorator identifier (the bare name as written in TypeScript) to
+    /// its kind. Returns `None` for unknown decorators — callers are expected
+    /// to fall through to a generic translation, never to error out.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "Module" => Some(Self::Module),
+            "Injectable" => Some(Self::Injectable),
+            "Controller" => Some(Self::Controller),
+            "UseGuards" => Some(Self::UseGuards),
+            "Get" => Some(Self::HttpGet),
+            "Post" => Some(Self::HttpPost),
+            "Put" => Some(Self::HttpPut),
+            "Delete" => Some(Self::HttpDelete),
+            "Patch" => Some(Self::HttpPatch),
+            "HttpCode" => Some(Self::HttpCode),
+            "Body" => Some(Self::Body),
+            "Param" => Some(Self::Param),
+            "Query" => Some(Self::Query),
+            _ => None,
+        }
+    }
+
+    /// Where this decorator is allowed to appear in the AST.
+    pub fn scope(self) -> DecoratorScope {
+        match self {
+            Self::Module | Self::Injectable | Self::Controller | Self::UseGuards => {
+                DecoratorScope::Class
+            }
+            Self::HttpGet
+            | Self::HttpPost
+            | Self::HttpPut
+            | Self::HttpDelete
+            | Self::HttpPatch
+            | Self::HttpCode => DecoratorScope::Method,
+            Self::Body | Self::Param | Self::Query => DecoratorScope::Param,
+        }
+    }
+
+    /// True iff this decorator selects an HTTP verb (Get/Post/Put/Delete/Patch).
+    /// Used by routing to dispatch to the right `axum::routing::*` constructor.
+    pub fn is_http_method(self) -> bool {
+        matches!(
+            self,
+            Self::HttpGet | Self::HttpPost | Self::HttpPut | Self::HttpDelete | Self::HttpPatch
+        )
+    }
+
+    /// The original TypeScript name, for diagnostics.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Module => "Module",
+            Self::Injectable => "Injectable",
+            Self::Controller => "Controller",
+            Self::UseGuards => "UseGuards",
+            Self::HttpGet => "Get",
+            Self::HttpPost => "Post",
+            Self::HttpPut => "Put",
+            Self::HttpDelete => "Delete",
+            Self::HttpPatch => "Patch",
+            Self::HttpCode => "HttpCode",
+            Self::Body => "Body",
+            Self::Param => "Param",
+            Self::Query => "Query",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_name_known_decorators() {
+        assert_eq!(
+            DecoratorKind::from_name("Controller"),
+            Some(DecoratorKind::Controller)
+        );
+        assert_eq!(
+            DecoratorKind::from_name("Get"),
+            Some(DecoratorKind::HttpGet)
+        );
+        assert_eq!(DecoratorKind::from_name("Body"), Some(DecoratorKind::Body));
+        assert_eq!(
+            DecoratorKind::from_name("UseGuards"),
+            Some(DecoratorKind::UseGuards)
+        );
+    }
+
+    #[test]
+    fn from_name_unknown_returns_none() {
+        assert_eq!(DecoratorKind::from_name("IsEmail"), None);
+        assert_eq!(DecoratorKind::from_name(""), None);
+        assert_eq!(DecoratorKind::from_name("controller"), None); // case-sensitive
+    }
+
+    #[test]
+    fn scope_classification() {
+        assert_eq!(DecoratorKind::Controller.scope(), DecoratorScope::Class);
+        assert_eq!(DecoratorKind::HttpGet.scope(), DecoratorScope::Method);
+        assert_eq!(DecoratorKind::Body.scope(), DecoratorScope::Param);
+    }
+
+    #[test]
+    fn http_method_classification() {
+        assert!(DecoratorKind::HttpGet.is_http_method());
+        assert!(DecoratorKind::HttpPost.is_http_method());
+        assert!(!DecoratorKind::HttpCode.is_http_method());
+        assert!(!DecoratorKind::Controller.is_http_method());
+    }
+
+    #[test]
+    fn name_roundtrip() {
+        for kind in [
+            DecoratorKind::Module,
+            DecoratorKind::Injectable,
+            DecoratorKind::Controller,
+            DecoratorKind::UseGuards,
+            DecoratorKind::HttpGet,
+            DecoratorKind::HttpPost,
+            DecoratorKind::HttpPut,
+            DecoratorKind::HttpDelete,
+            DecoratorKind::HttpPatch,
+            DecoratorKind::HttpCode,
+            DecoratorKind::Body,
+            DecoratorKind::Param,
+            DecoratorKind::Query,
+        ] {
+            assert_eq!(DecoratorKind::from_name(kind.name()), Some(kind));
+        }
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -59,8 +59,9 @@ A dedicated crate for handling the application's dependency graph.
 | `tyrus_cli`         | CLI (clap). 4 commands: `check`/`build`/`compile`/`run`. Branded banner, progress pipeline, `--quiet`/`--json` flags. Installable globally via `cargo install --path crates/tyrus_cli`. |
 | `tyrus_parser`      | Wraps SWC parser. Input: `.ts` file. Output: `swc_ecma_ast::Program`. |
 | `tyrus_ast`         | Typed IR: `TyrusModule`, `TyrusExpr`, `TyrusStmt`, `TyrusDecl`, `TyrusType`. SWC→IR type lowering (`lower_type.rs`). |
-| `tyrus_analyzer`    | `LintVisitor` (8 rules) + `DecoratorVisitor` + `UnsupportedApiVisitor` (11 APIs). Structured `Diagnostic` output with JSON/pretty formatters. |
-| `tyrus_codegen`     | Core transpilation. `RustGenerator` visitor converts TS AST to Rust.  |
+| `tyrus_analyzer`    | `LintVisitor` (7 rules) + `DecoratorVisitor` + `UnsupportedApiVisitor` (11 APIs). Structured `Diagnostic` output with JSON/pretty formatters. Uses `tyrus_decorator_kinds::DecoratorKind::from_name` for decorator classification. |
+| `tyrus_codegen`     | Core transpilation. `RustGenerator` visitor converts TS AST to Rust. Hosts the `decorators` module — trait-based registry replacing the previous scattered match-arm dispatch. |
+| `tyrus_decorator_kinds` | **Single source of truth** for NestJS decorator name → `DecoratorKind` classification. Zero external dependencies; consumed by both the analyzer (DI graph extraction) and the codegen (handler dispatch). See [ADR 0007](architecture/decisions/0007-decorator-registry.md). |
 | `tyrus_di`          | NestJS-style DI engine. Uses `petgraph::DiGraph` for topo sort.       |
 | `tyrus_orchestrator`| Coordinates the full pipeline: parse → analyze → codegen.            |
 | `tyrus_diagnostics` | `TyrusError` variants with `miette` for rich error reporting.         |
@@ -71,48 +72,78 @@ A dedicated crate for handling the application's dependency graph.
 
 ## Code Generation Module Structure (`tyrus_codegen`)
 
-The `crates/tyrus_codegen/src/convert/` directory is decomposed into focused, single-responsibility modules:
+The `crates/tyrus_codegen/src/` tree is decomposed into focused, single-responsibility modules. The top-level split is `convert/` (AST → Rust translation) plus `decorators/` (registry-based NestJS decorator dispatch — see [ADR 0007](architecture/decisions/0007-decorator-registry.md)) plus `stdlib/` (built-in API mappings).
 
 ```
-convert/
-├── mod.rs          — module declarations and re-exports
-├── interface.rs    — RustGenerator struct definition + Visit impl (pipeline entry point)
-├── helpers.rs      — shared utilities: to_snake_case, to_pascal_case, is_string_expr
-├── fn_decl.rs      — function declaration processing (process_fn_decl)
-├── module.rs       — module/import handling
-├── type_mapper.rs  — TypeScript → Rust type mapping (deduplicated map_type_core)
-├── stmt/           — statement conversion
-│   ├── mod.rs          — dispatcher + convert_stmt, convert_stmt_recursive
-│   ├── var_decl.rs     — variable declarations (ident, object/array destructuring)
-│   ├── loops.rs        — while, for-of, for-in, for, do-while
-│   ├── switch.rs       — switch → match
-│   └── try_catch.rs    — try-catch → Result matching
-├── class/          — class → struct+impl
-│   ├── mod.rs          — dispatcher + property conversion
-│   ├── constructor.rs  — constructor transpilation + DI
-│   ├── method.rs       — method transpilation + decorators
-│   ├── routing.rs      — Axum router generation + @UseGuards middleware
-│   └── mutation.rs     — self-mutation detection
-└── expr/
-    ├── mod.rs      — expression dispatcher (convert_expr)
-    ├── binary.rs   — binary operators (convert_bin_expr)
-    ├── call.rs     — function/method calls, axios/fetch/array methods (map/filter/forEach/find)
-    ├── member.rs   — property access, mutex state (convert_member_expr)
-    ├── arrow.rs    — arrow functions → closures (convert_arrow_expr)
-    ├── literal.rs  — literals, object/array/template expressions
-    └── misc.rs     — assignments, updates, optional chaining
+src/
+├── lib.rs              — public entry point, ControllerMetadata, generate()
+├── convert/
+│   ├── mod.rs          — module declarations and re-exports
+│   ├── interface.rs    — RustGenerator struct definition + Visit impl (pipeline entry point)
+│   ├── helpers.rs      — shared utilities: to_snake_case, to_pascal_case, is_string_expr
+│   ├── fn_decl.rs      — function declaration processing (process_fn_decl)
+│   ├── module.rs       — module/import handling
+│   ├── type_mapper.rs  — TypeScript → Rust type mapping (incl. Map/Set/Date)
+│   ├── stmt/           — statement conversion
+│   │   ├── mod.rs          — dispatcher + convert_stmt, convert_stmt_recursive
+│   │   ├── var_decl.rs     — variable declarations (ident, object/array destructuring)
+│   │   ├── loops.rs        — while, for-of, for, do-while  (for-in is analyzer-blocked)
+│   │   ├── switch.rs       — switch → match
+│   │   └── try_catch.rs    — try-catch → Result matching
+│   ├── class/          — class → struct+impl
+│   │   ├── mod.rs          — dispatcher + property conversion (decorator-driven, no name suffix heuristic)
+│   │   ├── constructor.rs  — constructor transpilation + DI
+│   │   ├── method.rs       — method transpilation; method/param decorators dispatched through registry
+│   │   ├── routing.rs      — Axum router generation + map_status_code (static STATUS_CODES table)
+│   │   ├── getter_setter.rs — get/set → method calls
+│   │   └── mutation.rs     — self-mutation detection
+│   └── expr/
+│       ├── mod.rs      — expression dispatcher (convert_expr)
+│       ├── binary.rs   — binary operators (convert_bin_expr)
+│       ├── call.rs     — function/method calls, axios/fetch/array methods
+│       ├── member.rs   — property access, mutex state (convert_member_expr)
+│       ├── arrow.rs    — arrow functions → closures (convert_arrow_expr)
+│       ├── literal.rs  — literals, object/array/template expressions (incl. object spread)
+│       └── misc.rs     — assignments (`=`/`-=`/`*=`/`/=`/`%=`/`&=`/`|=`/`^=`/`<<=`/`>>=`), updates, optional chaining
+├── decorators/         — Decorator registry (ADR 0007)
+│   ├── mod.rs          — DecoratorRegistry, ClassDecoratorHandler/MethodDecoratorHandler/ParamDecoratorHandler traits, default_registry(), shared_registry()
+│   ├── controller.rs   — @Controller("/path") handler
+│   ├── use_guards.rs   — @UseGuards(...) handler
+│   ├── http_method.rs  — @Get/@Post/@Put/@Delete/@Patch (one parameterized struct, 5 instances registered)
+│   ├── http_code.rs    — @HttpCode(N) handler
+│   └── params.rs       — @Body, @Param, @Query handlers (one file, 3 structs)
+└── stdlib/
+    ├── mod.rs, console.rs, array.rs, string.rs, math.rs,
+    └── json.rs, object.rs, map_set.rs   (Map<K,V>→HashMap, Set<T>→HashSet)
 ```
+
+### Decorator Dispatch Flow
+
+```
+class/method.rs::extract_method_decorators
+    → decorators::shared_registry().apply_method_decorators(method, &mut ctx)
+        → for each decorator on the method:
+            → DecoratorKind::from_name(ident) classifies the decorator
+            → registry.method_handler(kind) finds the handler
+            → handler.apply(method, call, &mut ctx) populates MethodDecoratorContext
+    → ctx.http_method (Option<DecoratorKind>) and ctx.http_code (Option<u16>) drive subsequent code emission
+```
+
+The same pattern applies to class-level (`apply_class_decorators` → `ClassDecoratorContext`) and param-level (`first_param_decorator_kind` + `param_handler.emit_extractor`) decorators. **No file in `convert/` matches on decorator names; all name-based decisions are concentrated in `tyrus_decorator_kinds::DecoratorKind::from_name`.**
 
 ### Key Transpilation Patterns
 
-- **Types:** `string→String`, `number→f64`, `boolean→bool`, `Promise<T>→Result<T, AppError>`, `Record<K,V>→HashMap<K,V>`
+- **Types:** `string→String`, `number→f64`, `boolean→bool`, `Promise<T>→Result<T, AppError>`, `Record<K,V>→HashMap<K,V>`, `Map<K,V>→HashMap<K,V>`, `Set<T>→HashSet<T>`
 - **Interfaces** → `#[derive(Serialize, Deserialize)] struct` with serde
 - **String union types** (`type Status = "open" | "closed"`) → Rust enums
 - **Array methods** (`.map`, `.filter`, `.forEach`, `.find`, `.some`, `.every`) → iterator chains with `.collect()`. Supports `(item, index)` callbacks via `.enumerate()`
 - **String methods** (`.includes→.contains`, `.replace→.replacen`, `.split→.split().collect()`, etc.)
-- **Classes** → structs with `impl` blocks. State fields use `Arc<Mutex<T>>` for interior mutability. Constructor-injected deps wrapped in `Arc<T>`.
-- **NestJS decorators** → Axum: `@Controller("/path")` → router, `@Get()` → `axum::routing::get`, `@Injectable()` → DI registration
+- **Classes** → structs with `impl` blocks. State fields use `Arc<Mutex<T>>` for interior mutability. Constructor-injected deps wrapped in `Arc<T>`. Controller detection is decorator-driven (presence of `@Controller(...)`), not by class-name suffix.
+- **NestJS decorators** → Axum, dispatched through the `decorators` registry: `@Controller("/path")` → `router()` + `FromRequestParts`, `@Get/@Post/@Put/@Delete/@Patch` → `axum::routing::get`/`post`/etc, `@HttpCode(N)` → `(StatusCode, Json<T>)` tuple return, `@Body/@Param/@Query` → `axum::Json<T>`/`Path<T>`/`Query<T>` extractors, `@UseGuards(...)` → `axum::middleware::from_fn` layer, `@Injectable()`/`@Module()` → DI graph (analyzer-side).
 - **Async/await** → `pub async fn` with tokio, `await` → `.await`
+- **Object spread (`{...base, field: v}`)** → struct update syntax
+- **Assignment operators (`=`/`-=`/`*=`/`/=`/`%=`/`&=`/`|=`/`^=`/`<<=`/`>>=`)** → equivalent Rust compound assignments
+- **`Date.now()`** → `chrono::Utc::now().timestamp_millis()`
 
 ---
 
@@ -121,9 +152,9 @@ convert/
 Four visitors traverse the SWC AST via `swc_ecma_visit::Visit`:
 
 1. `LintVisitor` — rejects `var`, `any`, `eval`, `for-in`, `delete`, `with`, labeled (in `tyrus_analyzer`)
-2. `DecoratorVisitor` — extracts `@Module`, `@Injectable`, `@Controller` metadata (in `tyrus_analyzer`)
+2. `DecoratorVisitor` — extracts `@Module`, `@Injectable`, `@Controller` metadata (in `tyrus_analyzer`); classifies decorator names via `tyrus_decorator_kinds::DecoratorKind::from_name`, never via raw string compare
 3. `UnsupportedApiVisitor` — detects DOM, browser, timer, CommonJS APIs (in `tyrus_analyzer`)
-4. `RustGenerator` — produces Rust token streams (entry point: `interface.rs`)
+4. `RustGenerator` — produces Rust token streams (entry point: `interface.rs`); delegates all NestJS decorator handling to the registry in `decorators/`
 
 ---
 
@@ -146,7 +177,7 @@ tests/
     └── tier4/         — framework integration (NestJS → Axum)
 ```
 
-179 tests across 7 categories: equivalence (71), unit (49), snapshot (20), IR (21), compilation (9), CLI (7), trybuild (1).
+230 tests across 7 categories: equivalence (95), unit (62 incl. registry/handler isolation), snapshot (20), IR (21), compilation (9), CLI (7), tier4 E2E (5), trybuild (1), plus 1 skipped. The HTTP-equivalence E2E test (`tier4_tests::test_http_equivalence_rust_server`) transpiles the reference NestJS project, compiles the generated Rust, starts both servers, and compares responses byte-for-byte.
 
 ---
 

--- a/docs/CODEMAPS/codegen.md
+++ b/docs/CODEMAPS/codegen.md
@@ -1,45 +1,76 @@
-<!-- Generated: 2026-03-15 | Files scanned: 32 | Token estimate: ~900 -->
+<!-- Generated: 2026-05-02 | Files scanned: 39 | Token estimate: ~1100 -->
 
 # Codegen Module Codemap
 
-## Module Tree (5,040 lines)
+## Module Tree (~6,000 lines, 39 files across 4 top-level modules)
 
 ```
-convert/
-├── interface.rs    (399) RustGenerator struct + Visit impl
-├── helpers.rs       (72) to_snake_case, to_pascal_case, is_string_expr
-├── fn_decl.rs      (179) function declarations
-├── type_mapper.rs  (257) TS→Rust type mapping
-├── module.rs       (182) import/export handling
-├── stmt/
-│   ├── mod.rs      (158) statement dispatcher
-│   ├── var_decl.rs (148) variable declarations + destructuring
-│   ├── loops.rs     (96) while, for, for-of, do-while
-│   ├── switch.rs    (76) switch → match
-│   └── try_catch.rs(224) try-catch → Result
-├── class/
-│   ├── mod.rs      (375) class dispatcher + properties
-│   ├── constructor (503) DI constructor + field init
-│   ├── method.rs   (388) method + HTTP decorators
-│   ├── getter_set. (92) get/set → accessor methods
-│   ├── routing.rs  (290) Axum router + @UseGuards
-│   └── mutation.rs  (30) self-mutation detection
-├── expr/
-│   ├── mod.rs       (96) expression dispatcher
-│   ├── call.rs     (385) function/method calls
-│   ├── member.rs   (135) property access
-│   ├── binary.rs    (72) binary operators
-│   ├── arrow.rs     (45) arrow → closure
-│   ├── literal.rs  (178) object/array/template
-│   └── misc.rs     (125) assign, update, optional chain
+src/
+├── lib.rs              (35) public entry, ControllerMetadata, generate()
+├── convert/
+│   ├── mod.rs           (8) module declarations
+│   ├── interface.rs   (405) RustGenerator struct + Visit impl
+│   ├── helpers.rs     (118) to_snake_case, to_pascal_case, is_string_expr
+│   ├── fn_decl.rs     (179) function declarations
+│   ├── type_mapper.rs (269) TS→Rust type mapping (incl. Map/Set/Date)
+│   ├── module.rs      (182) import/export handling
+│   ├── stmt/
+│   │   ├── mod.rs     (158) statement dispatcher
+│   │   ├── var_decl.rs(162) variable declarations + destructuring
+│   │   ├── loops.rs   (126) while, for, for-of, do-while
+│   │   ├── switch.rs   (47) switch → match
+│   │   └── try_catch.rs(224) try-catch → Result
+│   ├── class/
+│   │   ├── mod.rs     (377) class dispatcher; controller flag from registry
+│   │   ├── constructor (503) DI constructor + field init
+│   │   ├── method.rs  (338) method + decorator dispatch via registry
+│   │   ├── getter_setter (87) get/set → accessor methods
+│   │   ├── routing.rs (370) Axum router + STATUS_CODES static table + map_status_code
+│   │   └── mutation.rs (60) self-mutation detection
+│   └── expr/
+│       ├── mod.rs     (104) expression dispatcher
+│       ├── call.rs    (402) function/method calls
+│       ├── member.rs  (147) property access
+│       ├── binary.rs   (72) binary operators
+│       ├── arrow.rs    (45) arrow → closure
+│       ├── literal.rs (186) object/array/template (incl. object spread)
+│       └── misc.rs    (146) assign (=/-=/*=/etc), update, optional chain
+├── decorators/         — Decorator registry, ADR 0007
+│   ├── mod.rs         (276) DecoratorRegistry + 3 traits + default_registry()
+│   ├── controller.rs   (23) @Controller("/path")
+│   ├── use_guards.rs   (22) @UseGuards(Guard1, Guard2)
+│   ├── http_method.rs  (62) @Get/@Post/@Put/@Delete/@Patch (1 struct, 5 instances)
+│   ├── http_code.rs    (35) @HttpCode(N)
+│   └── params.rs      (128) @Body, @Param, @Query (3 structs)
 └── stdlib/
-    ├── mod.rs      (130) stdlib dispatcher
-    ├── array.rs    (184) 15 array methods
-    ├── string.rs   (208) 16 string methods
-    ├── math.rs     (130) 15 math functions
-    ├── console.rs   (22) 5 console methods
-    ├── json.rs      (12) stringify/parse
-    └── object.rs    (22) keys/values/entries
+    ├── mod.rs         (117) stdlib dispatcher
+    ├── array.rs       (184) 15 array methods
+    ├── string.rs      (208) 16 string methods
+    ├── math.rs        (103) 15 math functions
+    ├── console.rs      (31) 5 console methods
+    ├── json.rs         (34) stringify/parse
+    ├── object.rs       (46) keys/values/entries
+    └── map_set.rs     (164) Map<K,V>→HashMap, Set<T>→HashSet
+```
+
+## Decorator Registry Dispatch (`src/decorators/`)
+
+```
+DecoratorRegistry (HashMap<DecoratorKind, Box<dyn _>> per scope)
+  ├── class:  HashMap<DecoratorKind, Box<dyn ClassDecoratorHandler>>
+  ├── method: HashMap<DecoratorKind, Box<dyn MethodDecoratorHandler>>
+  └── param:  HashMap<DecoratorKind, Box<dyn ParamDecoratorHandler>>
+
+shared_registry() → &'static DecoratorRegistry  (OnceLock-cached)
+
+apply_class_decorators(class, &mut ClassDecoratorContext)
+  populates: is_controller, controller_path, guard_names
+
+apply_method_decorators(method, &mut MethodDecoratorContext)
+  populates: http_method (Option<DecoratorKind>), route_path, http_code
+
+first_param_decorator_kind(param) → Option<DecoratorKind>
+  → param_handler(kind).emit_extractor(...) → TokenStream
 ```
 
 ## Expression Dispatch Chain
@@ -52,11 +83,11 @@ convert_expr(expr) → match expr {
   Call       → convert_call_expr()     [call.rs]
   Member     → convert_member_expr()   [member.rs]
   Arrow      → convert_arrow_expr()    [arrow.rs]
-  Assign     → convert_assign_expr()   [misc.rs]
+  Assign     → convert_assign_expr()   [misc.rs]   (=, -=, *=, /=, %=, &=, |=, ^=, <<=, >>=)
   Update     → convert_update_expr()   [misc.rs]
   Unary      → convert_unary_expr()    [misc.rs]
   Tpl        → convert_tpl()           [literal.rs]
-  Object     → try_typed_object || convert_object_lit()
+  Object     → try_typed_object || convert_object_lit()   (incl. spread)
   Array      → convert_array_lit()     [literal.rs]
   Paren      → recurse into inner expr
   OptChain   → convert_opt_chain()     [misc.rs]
@@ -74,16 +105,20 @@ convert_expr(expr) → match expr {
 convert_call_expr(call) → match callee {
   console.log/error/warn   → stdlib::console
   Math.floor/sqrt/sin/...  → stdlib::math
-  JSON.stringify/parse      → stdlib::json
-  Object.keys/values        → stdlib::object
-  array.map/filter/find/... → stdlib::array
-  string.includes/split/... → stdlib::string
-  axios.get/post/...        → reqwest client
-  fetch()                   → reqwest::get()
-  new NotFoundException()   → AppError::NotFound
-  super(args)               → base field init
-  Class.staticMethod()      → Class::static_method()
-  generic function()        → function()
+  JSON.stringify/parse     → stdlib::json
+  Object.keys/values       → stdlib::object
+  array.map/filter/find/.. → stdlib::array
+  string.includes/split/.. → stdlib::string
+  map.get/set/has/...      → stdlib::map_set (HashMap)
+  set.add/has/...          → stdlib::map_set (HashSet)
+  Date.now()               → chrono::Utc::now().timestamp_millis()
+  axios.get/post/...       → reqwest client
+  fetch()                  → reqwest::get()
+  new NotFoundException()  → AppError::NotFound
+  super(args)              → base field init
+  Class.staticMethod()     → Class::static_method()
+  this.method(args)        → self.method(args)
+  generic function()       → function()
 }
 ```
 
@@ -95,27 +130,33 @@ number    → f64
 boolean   → bool
 void      → ()
 null      → ()
-any       → serde_json::Value (should be blocked)
+any       → serde_json::Value (analyzer should block)
 T[]       → Vec<T>
 Array<T>  → Vec<T>
 Promise<T>→ Result<T, AppError>
 Record<K,V> → HashMap<K,V>
-Date      → String (TODO: chrono)
+Map<K,V>  → HashMap<K,V>
+Set<T>    → HashSet<T>
+Date      → String (TODO: chrono); Date.now() → chrono::Utc::now().timestamp_millis()
 T | undefined → Option<T>
 interface → #[derive(Serialize, Deserialize)] struct
 type "a"|"b" → enum with Display
 ```
 
-## NestJS Decorator Mapping
+## NestJS Decorator Mapping (Registry-Based)
+
+All NestJS decorators flow through the `decorators` registry — there is **zero** name-matching in `convert/class/*` or `convert/expr/*`. To add a new decorator, edit `tyrus_decorator_kinds::DecoratorKind` (variant + `from_name` arm) and write/register a handler. No hot-path file is touched.
 
 ```
 @Injectable()           → struct + impl (Arc<Mutex> fields for services)
-@Controller('path')     → struct + router() + FromRequestParts
-@Get/Post/Put/Delete()  → async handler with State<Arc<Self>>
-@Body()                 → Json(body): Json<T>
-@Param('id')            → Path(id): Path<String>
-@Query('q')             → Query(q): Query<String>
-@HttpCode(201)          → Result<(StatusCode, Json<T>), AppError>
-@UseGuards(Guard)       → .layer(from_fn(guard_middleware))
-@Module({...})          → parsed for DI graph (not emitted)
+@Controller('path')     → ControllerHandler  → struct + router() + FromRequestParts
+@Get/Post/Put/Del/Patch → HttpMethodHandler  → async handler with State<Arc<Self>>
+@HttpCode(N)            → HttpCodeHandler    → Result<(StatusCode, Json<T>), AppError>
+                                                StatusCode resolved via STATUS_CODES static
+                                                table (compile_error! for unknown codes)
+@Body()                 → BodyHandler        → axum::Json<T>
+@Param('id')            → ParamHandler       → axum::extract::Path<T>
+@Query('q')             → QueryHandler       → axum::extract::Query<T>
+@UseGuards(Guard)       → UseGuardsHandler   → .layer(from_fn(guard_middleware))
+@Module({...})          → analyzer-only (DI graph), not emitted
 ```

--- a/docs/architecture/decisions/0007-decorator-registry.md
+++ b/docs/architecture/decisions/0007-decorator-registry.md
@@ -1,0 +1,122 @@
+# 7. Decorator Registry
+
+Date: 2026-05-02
+Status: Accepted
+
+## Context
+
+Tyrus translates a finite catalog of NestJS decorators (`@Controller`, `@Get`/`@Post`/..., `@Body`, `@HttpCode`, `@UseGuards`, etc.) into Axum handler scaffolding. Until PRs #109/#111/#115, each decorator was recognized through string-compare match arms scattered across four hot files:
+
+- `crates/tyrus_codegen/src/convert/class/method.rs:61` — `matches!(name, "Get" | "Post" | "Put" | "Delete" | "Patch")` to extract the verb.
+- `crates/tyrus_codegen/src/convert/class/routing.rs:131-138` — a **second** `match http_method.as_str()` to map the same verb to its `axum::routing::*` constructor.
+- `crates/tyrus_codegen/src/convert/class/method.rs:121-145` — `find_param_decorator` returning `Option<String>`, then a match on `"Body"`/`"Param"`/`"Query"` to pick the extractor.
+- `crates/tyrus_analyzer/src/decorators.rs:46-110` — yet another `if ident.sym == *"Module"` / `Injectable` / `Controller` ladder for DI graph extraction.
+
+Plus a heuristic `class_name.ends_with("Controller")` in `class/mod.rs:26` that flagged classes as controllers by **string suffix** rather than by decorator presence.
+
+This violated two rules already on record in the project memory:
+
+> `feedback_compiler_fundamentals.md`: **Two Layers — Generic AST Handler + Semantic Registry (HashMap, config, trait impls), NOT match arms scattered across files.**
+
+> `feedback_architecture_principles.md`: **NEVER add a `match name { "Foo" => ... }` inside a structural handler.**
+
+The drift was set to compound. Phase 9.1 (`class-validator` → `garde`) introduces 11 new validation decorators (`@IsString`, `@IsEmail`, `@MinLength`, `@MaxLength`, `@Min`, `@Max`, `@IsOptional`, `@ValidateNested`, `@IsPhoneNumber`, `@Matches`, `@IsNotEmpty`). Without restructuring, each new decorator costs ~3 file edits in hot paths. Linear growth in scattered match arms = quadratic risk of regression.
+
+## Decision
+
+Replace string-compare dispatch with a **trait-based registry**, in two complementary crates:
+
+### `tyrus_decorator_kinds` (zero-dep, lightweight)
+
+Single source of truth for decorator name → kind classification:
+
+```rust
+pub enum DecoratorKind {
+    Module, Injectable, Controller, UseGuards,           // class
+    HttpGet, HttpPost, HttpPut, HttpDelete, HttpPatch,   // method
+    HttpCode,
+    Body, Param, Query,                                   // param
+}
+
+impl DecoratorKind {
+    pub fn from_name(name: &str) -> Option<Self> { ... }
+    pub fn scope(self) -> DecoratorScope { ... }
+    pub fn axum_routing_fn_name(self) -> Option<&'static str> { ... }
+}
+```
+
+This crate has zero dependencies (no `proc_macro2`, no `swc`), so it is freely consumed by both `tyrus_analyzer` (for DI graph classification) and `tyrus_codegen` (for handler dispatch) without dragging compiler-only crates into the analyzer.
+
+### `tyrus_codegen::decorators` (registry + handlers)
+
+Three traits, one per scope:
+
+```rust
+trait ClassDecoratorHandler  { fn kind(&self) -> DecoratorKind; fn apply(&self, class, call, ctx: &mut ClassDecoratorContext);  }
+trait MethodDecoratorHandler { fn kind(&self) -> DecoratorKind; fn apply(&self, method, call, ctx: &mut MethodDecoratorContext); }
+trait ParamDecoratorHandler  { fn kind(&self) -> DecoratorKind; fn emit_extractor(&self, param, name, type) -> TokenStream; }
+
+pub(crate) struct DecoratorRegistry {
+    class:  HashMap<DecoratorKind, Box<dyn ClassDecoratorHandler>>,
+    method: HashMap<DecoratorKind, Box<dyn MethodDecoratorHandler>>,
+    param:  HashMap<DecoratorKind, Box<dyn ParamDecoratorHandler>>,
+}
+```
+
+A process-wide `OnceLock<DecoratorRegistry>` carries the default instance built once via `default_registry()`. Lookup is O(1); the `apply_*_decorators` methods iterate decorators of a node and dispatch to handlers.
+
+### File layout
+
+Adding a new decorator is now:
+1. Add one variant to `DecoratorKind` and one arm in `from_name`.
+2. Write one handler struct (10-30 lines) — colocated by **scope**, not by decorator name (`params.rs` holds `BodyHandler`, `ParamHandler`, `QueryHandler` together; `http_method.rs` holds five handler instances of one parameterized struct).
+3. Register it in `default_registry()`.
+
+No hot-path file is touched.
+
+### Heuristic deletion
+
+`class_name.ends_with("Controller")` in `class/mod.rs:26-30` was deleted. The `is_controller` flag now comes from `ControllerInfo.is_controller`, populated by `ControllerHandler` when the registry observes an actual `@Controller(...)` decorator on the class.
+
+## Alternatives Considered
+
+1. **Procedural macros (`tyrus_macros` crate).** The fully-generic transpilation plan from `.claude/plan/registry-migration.md` proposed emitting `#[controller(...)]` attributes and resolving them at the consumer's compile time via proc macros. Rejected for now: it adds substantial cognitive surface (proc macros, hygiene, syn AST) and slows generated-crate compilation. The registry achieves the architectural property (no scattered match arms) without that cost. The proc macro option remains open as a future PR if extensibility outside the transpiler becomes a priority.
+
+2. **Generic decorator translation (no registry).** Treat every decorator uniformly: `@Foo(args)` → `#[foo(args)]`. Compiles and transpiles arbitrary decorators but provides no NestJS-specific behavior. Rejected because the value of Tyrus is precisely the *semantic mapping* (`@Get` → `axum::routing::get`, `@Body()` → `axum::Json<T>`) that a generic translator cannot do.
+
+3. **Keep status quo (incremental Sprint 2-9 of `tyrus-production-roadmap-v3.md`).** Add new validation decorators directly into the existing match arms. Rejected per the audit: each Sprint multiplies the dispatch surface; refactoring becomes more expensive at each step. Doing the registry first is cheaper than the cumulative cost of the alternative.
+
+## Consequences
+
+### Positive
+
+- **Single source of truth.** `tyrus_decorator_kinds::DecoratorKind` is consulted by both the analyzer (for DI graph) and the codegen (for handler dispatch). The literal strings `"Get"`, `"Body"`, `"Controller"`, `"Module"`, etc. appear in **one** place — `from_name`. Renames are localized.
+- **O(1) decorator addition.** PR #5 will add `@Headers` by editing only `params.rs` and `default_registry()`. Zero changes to `class/method.rs`, `class/routing.rs`, or any analyzer file.
+- **No more `unwrap_or` in generated code for status codes.** `map_status_code` migrated from a `from_u16(...).unwrap_or(...)` runtime fallback to a static `STATUS_CODES: &[(u16, &str)]` table + `compile_error!` for unrecognized codes.
+- **Strong-typed dispatch.** `MethodDecoratorContext::http_method` is `Option<DecoratorKind>` instead of `Option<String>`; the `Option<String>` round-trip in `convert_single_param` is gone.
+- **Decorator-driven controller detection.** A class is now flagged as a controller iff it carries `@Controller(...)`, not because of its name suffix.
+
+### Negative
+
+- **One more crate (`tyrus_decorator_kinds`).** Marginal cost; offset by the reduction in cross-crate string duplication.
+- **`Box<dyn Handler>` adds vtable lookup overhead.** Negligible (decorator dispatch happens at codegen time, not at the generated server's request path), but visible in profiling.
+- **More files in `decorators/`.** Consolidated where natural (`params.rs` holds 3 handlers; `http_method.rs` holds 5 instances of one parameterized struct), kept separate where the handler has its own state or non-trivial parsing (`controller.rs`, `use_guards.rs`, `http_code.rs`). Future cleanup may merge `controller.rs` + `use_guards.rs` into `class_decorators.rs` if file count becomes a concern.
+
+### Neutral
+
+- Generated Rust output is **byte-identical** for all existing fixtures (verified by snapshot tests in `tier4_nestjs/` and the HTTP equivalence E2E). The refactor is invisible to consumers of Tyrus.
+
+## Implementation Trail
+
+- PR #109: skeleton + class-level handlers (`@Controller`, `@UseGuards`)
+- PR #111: method-level handlers (`@Get`/`@Post`/`@Put`/`@Delete`/`@Patch` + `@HttpCode`); duplicate-verb dispatch eliminated; `unwrap_or` removed from generated status-code emission; isolation tests added (PR #111 reinforcement)
+- PR #115: param-level handlers (`@Body`, `@Param`, `@Query`); `find_param_decorator` deleted
+- PR #116 (this ADR): documentation sync
+- PR #5 (planned): empirical proof — implement `@Headers` purely via the registry, touching zero legacy files
+
+## References
+
+- `crates/tyrus_decorator_kinds/src/lib.rs`
+- `crates/tyrus_codegen/src/decorators/`
+- `.claude/plan/ultraplan-decorator-registry.md` (full Caminho C plan)
+- Memory: `feedback_compiler_fundamentals.md`, `feedback_architecture_principles.md`

--- a/docs/specs/GRAMMAR.md
+++ b/docs/specs/GRAMMAR.md
@@ -70,7 +70,9 @@ NewExpr           ::= 'new' Identifier '(' ArgumentList? ')'
 
 UnaryExpr         ::= ('!' | '-' | '+') Expression
 ArrowExpr         ::= '(' ParamList ')' '=>' (Expression | Block)
-AssignExpr        ::= Expression '=' Expression
+AssignExpr        ::= Expression AssignOp Expression
+AssignOp          ::= '=' | '-=' | '*=' | '/=' | '%='
+                    | '&=' | '|=' | '^=' | '<<=' | '>>='
 UpdateExpr        ::= Expression ('++' | '--') | ('++' | '--') Expression
 OptionalChainExpr ::= Expression '?.' (Identifier | CallExpr | MemberExpr)
 ```
@@ -86,12 +88,26 @@ Type ::=
     | 'null'
     | Identifier                           (* User-defined structs *)
     | Type '[]'                            (* Array → Vec<T> *)
+    | 'Array' '<' Type '>'                 (* Array → Vec<T> *)
     | 'Promise' '<' Type '>'               (* → Result<T, AppError> *)
     | 'Record' '<' Type ',' Type '>'       (* → HashMap<K, V> *)
+    | 'Map' '<' Type ',' Type '>'          (* → HashMap<K, V> *)
+    | 'Set' '<' Type '>'                   (* → HashSet<T> *)
+    | 'Date'                                (* → String today; chrono::DateTime planned *)
+    | Type '|' 'undefined'                 (* → Option<T> *)
     | StringUnionType                      (* → Rust enum *)
 
 StringUnionType ::= StringLiteral ('|' StringLiteral)+
 ```
+
+### Built-in stdlib calls recognized
+
+| TypeScript                | Rust                                              |
+|---------------------------|---------------------------------------------------|
+| `new Map()`               | `HashMap::new()`                                  |
+| `new Set()`               | `HashSet::new()`                                  |
+| `Date.now()`              | `chrono::Utc::now().timestamp_millis()`           |
+| `Math.*` / `JSON.*` / `console.*` / `Object.*` | mapped per `crates/tyrus_codegen/src/stdlib/`     |
 
 ## 5. Control Flow (Supported)
 
@@ -120,35 +136,52 @@ Literal ::=
     | ObjectLiteral
     | TemplateLiteral
 
-ArrayLiteral    ::= '[' (Expression (',' Expression)*)? ']'
-ObjectLiteral   ::= '{' (Identifier ':' Expression (',' Identifier ':' Expression)*)? '}'
+ArrayLiteral    ::= '[' (ArrayElement (',' ArrayElement)*)? ']'
+ArrayElement    ::= Expression | SpreadExpr
+
+ObjectLiteral   ::= '{' (ObjectMember (',' ObjectMember)*)? '}'
+ObjectMember    ::= Identifier ':' Expression          (* explicit         *)
+                  | Identifier                          (* shorthand: {x}    *)
+                  | SpreadExpr                          (* spread: {...base} *)
+
 TemplateLiteral ::= '`' (StringPart | '${' Expression '}')* '`'
 ```
 
+`{...base, field: v}` lowers to Rust struct update syntax (`Foo { field: v, ..base }`); `[...a, b]` lowers to iterator chain (`a.iter().cloned().chain(...).collect()`).
+
 ## 7. Decorators (NestJS Subset — Supported)
+
+Decorator dispatch is registry-based ([ADR 0007](../architecture/decisions/0007-decorator-registry.md)). The set of recognized names lives in `tyrus_decorator_kinds::DecoratorKind`. Adding a new decorator is a one-variant edit there plus one handler registration in `tyrus_codegen::decorators::default_registry()`; nothing in the legacy match-on-name dispatch survives.
 
 ```ebnf
 Decorator ::= '@' Identifier ('(' ArgumentList? ')')?
 
 SupportedDecorators ::=
-    | '@Module' '(' ModuleOptions ')'
-    | '@Injectable' '(' ')'
-    | '@Controller' '(' StringLiteral? ')'
-    | '@Get' '(' StringLiteral? ')'
-    | '@Post' '(' StringLiteral? ')'
-    | '@Put' '(' StringLiteral? ')'
-    | '@Delete' '(' StringLiteral? ')'
-    | '@Patch' '(' StringLiteral? ')'
-    | '@Body' '(' ')'
-    | '@Param' '(' StringLiteral? ')'
-    | '@Query' '(' StringLiteral? ')'
-    | '@HttpCode' '(' NumberLiteral ')'
-    | '@UseGuards' '(' Identifier (',' Identifier)* ')'
+    (* Class-level *)
+    | '@Module' '(' ModuleOptions ')'                                  (* analyzer DI graph *)
+    | '@Injectable' '(' ')'                                            (* analyzer DI graph *)
+    | '@Controller' '(' StringLiteral? ')'                             (* → Axum router scaffolding *)
+    | '@UseGuards' '(' Identifier (',' Identifier)* ')'                (* → middleware layers *)
+
+    (* Method-level *)
+    | '@Get'    '(' StringLiteral? ')'                                 (* → axum::routing::get *)
+    | '@Post'   '(' StringLiteral? ')'                                 (* → axum::routing::post *)
+    | '@Put'    '(' StringLiteral? ')'                                 (* → axum::routing::put *)
+    | '@Delete' '(' StringLiteral? ')'                                 (* → axum::routing::delete *)
+    | '@Patch'  '(' StringLiteral? ')'                                 (* → axum::routing::patch *)
+    | '@HttpCode' '(' NumberLiteral ')'                                (* → Result<(StatusCode, Json<T>), AppError>, codes resolved via STATUS_CODES static; unknown codes emit compile_error! *)
+
+    (* Param-level *)
+    | '@Body'  '(' ')'                                                 (* → axum::Json<T> *)
+    | '@Param' '(' StringLiteral? ')'                                  (* → axum::extract::Path<T> *)
+    | '@Query' '(' StringLiteral? ')'                                  (* → axum::extract::Query<T> *)
 ```
+
+Unknown decorators are *not* an error: they are skipped silently by the registry. Generic-translation behavior for arbitrary decorators is handled outside the NestJS-aware path.
 
 ## 8. Unsafe (Forbidden)
 
-The following constructs are explicitly rejected by the `tyrus_analyzer` (`LintVisitor`):
+The following constructs are explicitly rejected by the `tyrus_analyzer` (`LintVisitor`, 7 rules):
 
 - `any` type usage.
 - `eval()` calls.

--- a/docs/superpowers/plans/MASTER_PLAN.md
+++ b/docs/superpowers/plans/MASTER_PLAN.md
@@ -7,11 +7,12 @@
 
 ---
 
-## Current State (2026-03-13)
+## Current State (2026-05-02)
 
 | Metric | Value |
 |--------|-------|
-| Tests passing | 179 (71 equivalence + 7 CLI + 8 IR + 73 integration + 9 codegen + 4 common + 1 trybuild + 1 skipped) |
+| Tests passing | **230** (95 equivalence + 62 unit incl. registry/handler isolation + 20 snapshot + 21 IR + 9 compilation + 7 CLI + 5 tier4 E2E + 1 trybuild + 1 skipped) |
+| Crates | **11** (added `tyrus_decorator_kinds` in PR #109 — single source of truth for decorator name → kind classification) |
 | Equivalence tests | 71 (proving TS↔Rust output identity) |
 | Array spread | `[...a, ...b]` → `a.iter().cloned().chain(b.iter().cloned()).collect()` |
 | Static methods | `Class.method()` → `Class::method()` (associated functions) |
@@ -43,9 +44,14 @@ Phase 3 ✅ Equivalence     (Milestone 13A)    — Prove output identity for bas
 Phase 4 ✅ Control Flow    (Milestone 13B)    — Unlock blocked constructs + bug fixes
 Phase 5 ✅ Stdlib Complete (Milestone 14)     — Full JS/TS method coverage (ALL methods done)
 Phase 5.5 ✅ Architecture  (CLI+IR+Analyzer)  — Branded CLI, typed IR, expanded analyzer
-Phase 6.0 ✅ Infrastructure (prettyplease, thiserror 2.0, trybuild) — See docs/superpowers/plans/2026-03-13-nestjs-full-transpilation-roadmap.md
-Phase 6 ✅ Advanced TS     (Milestone 15)     — Class inheritance, static, enums, type assertions, spread
-Phase 7 📋 Academic        (Milestone 16)     — Benchmarks, formal spec, paper
+Phase 6.0 ✅ Infrastructure (prettyplease, thiserror 2.0, trybuild)
+Phase 6 ✅ Advanced TS     (Milestone 15)     — Class inheritance, static, enums, type assertions, spread, getters/setters
+Phase 7 ✅ NestJS Framework — @Param/@Query/@HttpCode/@UseGuards, HttpException, multi-module DI, getters/setters
+Phase 8 ✅ HTTP equivalence E2E — reference NestJS project transpiles, compiles, serves identical responses (`test_http_equivalence_rust_server`)
+Sprint 1 ✅ Quick Wins     — assignment ops, Map/Set, this.method(), object shorthand, Date.now(), object spread
+Caminho C 🚧 Decorator Registry (PR #1-#5, ADR 0007) — replace scattered match-arm decorator dispatch with a trait-based registry; PR #1-#3 merged-in-flight, PR #4 (this PR) docs sync, PR #5 empirical proof via @Headers
+Phase 9 📋 Validation & Pipes (class-validator → garde, ParseIntPipe, ValidationPipe)
+Phase 10 📋 Academic       (Milestone 16)     — Benchmarks, formal spec, paper
 ```
 
 ---

--- a/tests/src/unit/tier4_nestjs.rs
+++ b/tests/src/unit/tier4_nestjs.rs
@@ -112,6 +112,63 @@ class ItemsController {
     );
 }
 
+/// Empirical proof point for ADR 0007: adding `@Headers` (a NestJS decorator
+/// previously unsupported) required edits to exactly 4 files —
+/// `tyrus_decorator_kinds/src/lib.rs` (one variant + maps),
+/// `tyrus_codegen/src/decorators/params.rs` (one handler),
+/// `tyrus_codegen/src/decorators/mod.rs` (one register line),
+/// and this test. Zero edits to any `convert/class/*`, `convert/expr/*`,
+/// or analyzer file. This test pins the property.
+#[test]
+fn test_headers_decorator_emits_header_map_param() {
+    let rust = crate::helpers::transpile(
+        r#"
+import { Controller, Get, Headers } from "@nestjs/common";
+@Controller("/echo")
+class EchoController {
+    @Get("/")
+    echo(@Headers() headers: any): string {
+        return "ok";
+    }
+}
+"#,
+    );
+    assert!(
+        rust.contains("axum :: http :: HeaderMap") || rust.contains("axum::http::HeaderMap"),
+        "Expected axum::http::HeaderMap parameter in: {rust}"
+    );
+    assert!(
+        rust.contains("headers"),
+        "Expected the parameter name 'headers' in: {rust}"
+    );
+}
+
+/// `@Headers` must coexist with other param decorators in the same handler
+/// signature — proves dispatch is independent per-param, not order-sensitive.
+#[test]
+fn test_headers_decorator_combines_with_path_extractor() {
+    let rust = crate::helpers::transpile(
+        r#"
+import { Controller, Get, Headers, Param } from "@nestjs/common";
+@Controller("/echo")
+class EchoController {
+    @Get("/:id")
+    echo(@Param("id") id: string, @Headers() headers: any): string {
+        return id;
+    }
+}
+"#,
+    );
+    assert!(
+        rust.contains("axum :: extract :: Path") || rust.contains("axum::extract::Path"),
+        "Expected Path extractor for @Param in: {rust}"
+    );
+    assert!(
+        rust.contains("axum :: http :: HeaderMap") || rust.contains("axum::http::HeaderMap"),
+        "Expected HeaderMap for @Headers in: {rust}"
+    );
+}
+
 #[test]
 fn test_nestjs_not_found_exception_maps_to_app_error() {
     let rust = crate::helpers::transpile(


### PR DESCRIPTION
Establishes the architectural foundation for replacing the hardcoded decorator match arms scattered across class/method.rs, class/routing.rs, class/mod.rs and analyzer/decorators.rs with a single trait-based registry. This PR migrates only class-level decorators (@Controller, @UseGuards); method- and param-level handlers land in PR #2 and #3.

Key changes:
- New crate tyrus_decorator_kinds (zero deps): single source of truth for decorator name → DecoratorKind classification, shared by analyzer and codegen without dragging proc_macro2 into the analyzer.
- New module crates/tyrus_codegen/src/decorators/ with traits ClassDecoratorHandler, MethodDecoratorHandler, ParamDecoratorHandler, DecoratorRegistry, and a process-wide singleton via OnceLock.
- ControllerHandler and UseGuardsHandler implement the class-level half.
- extract_controller_info now dispatches via the registry.
- DELETED heuristic class_name.ends_with("Controller") in class/mod.rs — replaced by ControllerInfo.is_controller from the registry.
- analyzer/decorators.rs uses DecoratorKind::from_name() instead of string-compare match arms; @Module parsing extracted into focused helper methods (parse_module_metadata, collect_ident_array, values_to_providers).

Tests: 217/217 passing (1 skipped). +6 tests vs main (5 unit + 1 doc in tyrus_decorator_kinds; 1 unit in decorators/mod.rs). HTTP equivalence (test_http_equivalence_rust_server) and reference NestJS compilation remain green.

Refs #108

# 🏗️ Pull Request

## 📌 Context

**Issue Link:** # (or JIRA-123)
**Type:**

- [ ] ✨ New Feature (`feat`)
- [ ] 🐛 Bug Fix (`fix`)
- [ ] 🧹 Chore/Refactor (`chore`, `refactor`)
- [ ] 📚 Documentation (`docs`)

## 📝 Summary

<!-- Brief description of what was changed and why. -->

## 🧪 Test Plan

<!-- How did you verify this change? -->

- [ ] **Unit Tests**: `cargo nextest run --workspace`
- [ ] **Snapshot Tests**: `cargo test -p tests snapshot` (run `cargo insta review` if snapshots changed)
- [ ] **Compilation Tests**: `cargo test -p tests compilation`
- [ ] **Manual Verification**: (Describe steps)

## 📸 Screenshots / Logs

<!-- If applicable, add evidence here. -->

## ✅ Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] `cargo nextest run --workspace` passes locally.
- [ ] `cargo fmt -- --check` passes (no formatting issues).
- [ ] `cargo clippy --workspace -- -D warnings -W clippy::unwrap_used -W clippy::expect_used -W clippy::panic` passes with no warnings.
- [ ] No `.unwrap()`, `.expect()`, `panic!()`, `todo!()`, or `unimplemented!()` introduced.
- [ ] I have commented my code, particularly in hard-to-understand areas.
