### PR TITLE
refactor(codegen): extract resolve_assign_lhs and emit_assign_op helpers

### DIFF
--- a/crates/tyrus_codegen/src/convert/expr/misc.rs
+++ b/crates/tyrus_codegen/src/convert/expr/misc.rs
@@ -3,98 +3,136 @@
 //! Handles: assignment expressions, update expressions (++/--),
 //! and optional chaining (?.).
 
-use proc_macro2::TokenStream;
+use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 use swc_ecma_ast::*;
 
 use crate::convert::helpers::to_snake_case;
 use crate::convert::interface::RustGenerator;
 
+/// Resolved shape of an assignment LHS, decoupled from operator dispatch.
+enum AssignLhs {
+    /// `this.field = …` where the field is a tracked state field — the emitter
+    /// must split read/write to avoid double-locking the same `Mutex`.
+    StateField { receiver: TokenStream, field: Ident },
+    /// `obj.prop = v` where `prop` has a setter — emit `obj.set_prop(v)`.
+    /// Compound assigns never reach this variant.
+    Setter { obj: TokenStream, setter: Ident },
+    /// Regular LHS expression that can be combined with any operator verbatim.
+    Plain(TokenStream),
+    /// Unsupported pattern — `compile_error!` token stream.
+    Invalid(TokenStream),
+}
+
 impl RustGenerator {
-    pub(crate) fn convert_assign_expr(&self, assign: &swc_ecma_ast::AssignExpr) -> TokenStream {
+    pub(crate) fn convert_assign_expr(&self, assign: &AssignExpr) -> TokenStream {
         let right = self.convert_expr(&assign.right);
-        let left = match &assign.left {
-            swc_ecma_ast::AssignTarget::Simple(simple) => match simple {
-                swc_ecma_ast::SimpleAssignTarget::Member(member) => {
-                    if member.obj.is_this() {
-                        if let Some(prop_ident) = member.prop.as_ident() {
-                            let prop_name = to_snake_case(prop_ident.sym.as_ref());
-                            let field = format_ident!("{}", prop_name);
-
-                            let receiver = if self.use_state_for_this.get() {
-                                quote! { state }
-                            } else {
-                                quote! { self }
-                            };
-
-                            if self
-                                .current_class_state_fields
-                                .contains_key(prop_ident.sym.as_ref())
-                            {
-                                // Avoid deadlock: read value first, then write
-                                // This prevents double-locking the same Mutex
-                                return quote! {
-                                    {
-                                        let __new_val = #right;
-                                        *#receiver.#field.lock().unwrap_or_else(|e| e.into_inner()) = __new_val;
-                                    }
-                                };
-                            } else {
-                                quote! { #receiver.#field }
-                            }
-                        } else {
-                            quote! { compile_error!("Tyrus: unsupported self member assignment") }
-                        }
-                    } else if let Some(prop_ident) = member.prop.as_ident() {
-                        let prop_name = to_snake_case(prop_ident.sym.as_ref());
-                        let obj = self.convert_expr(&member.obj);
-
-                        // Setter call-site: obj.prop = v → obj.set_prop(v)
-                        if assign.op == swc_ecma_ast::AssignOp::Assign
-                            && self.setter_names.contains(prop_ident.sym.as_ref())
-                        {
-                            let setter = format_ident!("set_{}", prop_name);
-                            return quote! { #obj.#setter(#right) };
-                        }
-
-                        let field = format_ident!("{}", prop_name);
-                        quote! { #obj.#field }
-                    } else {
-                        quote! { compile_error!("Tyrus: unsupported member assignment pattern") }
-                    }
+        match self.resolve_assign_lhs(&assign.left, assign.op) {
+            AssignLhs::StateField { receiver, field } => quote! {
+                {
+                    let __new_val = #right;
+                    *#receiver.#field.lock().unwrap_or_else(|e| e.into_inner()) = __new_val;
                 }
-                swc_ecma_ast::SimpleAssignTarget::Ident(ident) => {
-                    let name = format_ident!("{}", to_snake_case(ident.sym.as_ref()));
-                    quote! { #name }
-                }
-                _ => quote! { compile_error!("Tyrus: unsupported assignment target") },
             },
-            _ => quote! { compile_error!("Tyrus: unsupported assignment pattern") },
-        };
+            AssignLhs::Setter { obj, setter } => quote! { #obj.#setter(#right) },
+            AssignLhs::Plain(lhs) => self.emit_assign_op(assign.op, &lhs, &right),
+            AssignLhs::Invalid(err) => err,
+        }
+    }
 
-        match assign.op {
-            swc_ecma_ast::AssignOp::Assign => quote! { #left = #right },
-            swc_ecma_ast::AssignOp::AddAssign => quote! { #left += #right },
-            swc_ecma_ast::AssignOp::SubAssign => quote! { #left -= #right },
-            swc_ecma_ast::AssignOp::MulAssign => quote! { #left *= #right },
-            swc_ecma_ast::AssignOp::DivAssign => quote! { #left /= #right },
-            swc_ecma_ast::AssignOp::ModAssign => quote! { #left %= #right },
+    fn resolve_assign_lhs(&self, target: &AssignTarget, op: AssignOp) -> AssignLhs {
+        let simple = match target {
+            AssignTarget::Simple(simple) => simple,
+            _ => {
+                return AssignLhs::Invalid(
+                    quote! { compile_error!("Tyrus: unsupported assignment pattern") },
+                );
+            }
+        };
+        match simple {
+            SimpleAssignTarget::Member(member) => self.resolve_member_lhs(member, op),
+            SimpleAssignTarget::Ident(ident) => {
+                let name = format_ident!("{}", to_snake_case(ident.sym.as_ref()));
+                AssignLhs::Plain(quote! { #name })
+            }
+            _ => AssignLhs::Invalid(
+                quote! { compile_error!("Tyrus: unsupported assignment target") },
+            ),
+        }
+    }
+
+    fn resolve_member_lhs(&self, member: &MemberExpr, op: AssignOp) -> AssignLhs {
+        if member.obj.is_this() {
+            return self.resolve_this_member_lhs(member);
+        }
+        let prop_ident = match member.prop.as_ident() {
+            Some(ident) => ident,
+            None => {
+                return AssignLhs::Invalid(
+                    quote! { compile_error!("Tyrus: unsupported member assignment pattern") },
+                );
+            }
+        };
+        let prop_name = to_snake_case(prop_ident.sym.as_ref());
+        let obj = self.convert_expr(&member.obj);
+        if op == AssignOp::Assign && self.setter_names.contains(prop_ident.sym.as_ref()) {
+            let setter = format_ident!("set_{}", prop_name);
+            return AssignLhs::Setter { obj, setter };
+        }
+        let field = format_ident!("{}", prop_name);
+        AssignLhs::Plain(quote! { #obj.#field })
+    }
+
+    fn resolve_this_member_lhs(&self, member: &MemberExpr) -> AssignLhs {
+        let prop_ident = match member.prop.as_ident() {
+            Some(ident) => ident,
+            None => {
+                return AssignLhs::Invalid(
+                    quote! { compile_error!("Tyrus: unsupported self member assignment") },
+                );
+            }
+        };
+        let prop_name = to_snake_case(prop_ident.sym.as_ref());
+        let field = format_ident!("{}", prop_name);
+        let receiver = if self.use_state_for_this.get() {
+            quote! { state }
+        } else {
+            quote! { self }
+        };
+        if self
+            .current_class_state_fields
+            .contains_key(prop_ident.sym.as_ref())
+        {
+            AssignLhs::StateField { receiver, field }
+        } else {
+            AssignLhs::Plain(quote! { #receiver.#field })
+        }
+    }
+
+    fn emit_assign_op(&self, op: AssignOp, lhs: &TokenStream, rhs: &TokenStream) -> TokenStream {
+        match op {
+            AssignOp::Assign => quote! { #lhs = #rhs },
+            AssignOp::AddAssign => quote! { #lhs += #rhs },
+            AssignOp::SubAssign => quote! { #lhs -= #rhs },
+            AssignOp::MulAssign => quote! { #lhs *= #rhs },
+            AssignOp::DivAssign => quote! { #lhs /= #rhs },
+            AssignOp::ModAssign => quote! { #lhs %= #rhs },
             // Bitwise ops: TS numbers are f64 but bitwise truncates to i32.
             // Rust f64 doesn't implement BitAnd/BitOr/etc, so cast through i64.
-            swc_ecma_ast::AssignOp::BitAndAssign => {
-                quote! { #left = ((#left as i64) & (#right as i64)) as f64 }
+            AssignOp::BitAndAssign => {
+                quote! { #lhs = ((#lhs as i64) & (#rhs as i64)) as f64 }
             }
-            swc_ecma_ast::AssignOp::BitOrAssign => {
-                quote! { #left = ((#left as i64) | (#right as i64)) as f64 }
+            AssignOp::BitOrAssign => {
+                quote! { #lhs = ((#lhs as i64) | (#rhs as i64)) as f64 }
             }
-            swc_ecma_ast::AssignOp::BitXorAssign => {
-                quote! { #left = ((#left as i64) ^ (#right as i64)) as f64 }
+            AssignOp::BitXorAssign => {
+                quote! { #lhs = ((#lhs as i64) ^ (#rhs as i64)) as f64 }
             }
-            swc_ecma_ast::AssignOp::LShiftAssign => {
-                quote! { #left = ((#left as i64) << (#right as i64)) as f64 }
+            AssignOp::LShiftAssign => {
+                quote! { #lhs = ((#lhs as i64) << (#rhs as i64)) as f64 }
             }
-            swc_ecma_ast::AssignOp::RShiftAssign => {
-                quote! { #left = ((#left as i64) >> (#right as i64)) as f64 }
+            AssignOp::RShiftAssign => {
+                quote! { #lhs = ((#lhs as i64) >> (#rhs as i64)) as f64 }
             }
             _ => quote! { compile_error!("Tyrus: unsupported assignment operator") },
         }


### PR DESCRIPTION
## Resumo

Extract `resolve_assign_lhs` + `emit_assign_op` (and the LHS sub-helpers `resolve_member_lhs` / `resolve_this_member_lhs`) from `convert_assign_expr`. Pure refactor — no behavioral change. All 235 tests pass bit-for-bit.

## Motivação

`convert_assign_expr` was **88 lines**, well over the project's 50-line `clippy::too_many_lines` limit. #129 PR1 (the actual deadlock fix) needs to add ~30 LOC for compound-assign read-then-write splitting + guarded-block reads. Without this refactor, PR1 would hard-fail CI on `-D warnings`.

This is **Ordem 0b** of the plan in `.claude/plan/critical-issues-roadmap-2026-05-03.md` — a prerequisite identified by the audit pass (tyrus-reviewer C1 finding).

## Mudanças

- `crates/tyrus_codegen/src/convert/expr/misc.rs`:
  - New `enum AssignLhs { StateField, Setter, Plain, Invalid }` capturing LHS shapes that need different emission paths.
  - `convert_assign_expr` reduced from 88 → **14 lines** of glue.
  - 4 new private helpers, each under the 50-line limit: `resolve_assign_lhs` (20), `resolve_member_lhs` (21), `resolve_this_member_lhs` (25), `emit_assign_op` (28).
  - `emit_assign_op` takes `&TokenStream` refs (clippy `needless_pass_by_value` compliant); `quote!` interpolation works through `ToTokens` blanket impl.

## Testes

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo nextest run --workspace` — **235/235 pass** (1 skipped, same as main)
- [x] No new tests required — refactor is byte-for-byte semantic-equivalent; existing assignment + state-mutation tests already cover all branches.

**Pre-existing infrastructure issues** (not caused by this PR, tracked separately):
- `cargo deny check` fails locally with schema error in `deny.toml:8` (`unmaintained = "warn"` invalid in schema v2). Not run by CI.
- `cargo audit --deny warnings` reports 2 advisories in transitive deps. Not run by CI.

## Rollback

Single-file change. `git revert 50a50b5` is safe — reverts cleanly to the prior 88-line implementation. Behavior identical either way.

## Linked Issues

Refs #129 — prerequisite refactor that unblocks the actual deadlock fix in subsequent PR1.

## Documentation Sync

- [ ] CHANGELOG.md — N/A (auto via `release-plz` from this `refactor:` commit; will land in PR #127)
- [ ] CLAUDE.md test count — N/A (still 235)
- [ ] README.md — N/A (no user-visible change)
- [ ] MASTER_PLAN.md — N/A (refactor is internal)
- [ ] NestJS roadmap — N/A
- [ ] ADR — N/A (no architectural decision)
- [ ] Codemap — N/A (helper additions only, dispatcher unchanged)

## Checklist

- [x] One branch = one concern (refactor only)
- [x] Conventional Commits format (`refactor(codegen): …`)
- [x] Local validation: fmt + clippy + nextest all pass
- [x] No `unwrap`/`expect`/`panic`/`todo`
- [x] All functions under 50 lines (max: 28)
- [x] File under 400 lines (184)
- [x] `pub(crate)` for the public entry point; new helpers are `fn` (private)