### PR TITLE
chore(test-utils): add assert_output_equivalent_with_timeout helper

### DIFF
--- a/crates/tyrus_test_utils/src/lib.rs
+++ b/crates/tyrus_test_utils/src/lib.rs
@@ -1,9 +1,10 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 static RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -88,12 +89,12 @@ rand = "0.8"
     }
 }
 
-/// Compiles Rust code as a binary and runs it, returning stdout.
-/// The code must contain a `fn main()`.
+/// Sets up a single-binary Cargo project for `code` and runs `cargo build`,
+/// returning the path to the produced binary inside the shared target dir.
 ///
-/// # Panics
-/// Panics if compilation or execution fails.
-pub fn compile_and_run_rust(code: &str) -> String {
+/// `_temp_dir` is dropped on return but the binary lives in the shared target,
+/// so the path remains valid for the caller to invoke.
+fn prepare_and_build_binary(code: &str) -> PathBuf {
     let run_id = RUN_COUNTER.fetch_add(1, Ordering::SeqCst);
     let pid = std::process::id();
     let bin_name = format!("tyrus_run_{}_{}", pid, run_id);
@@ -145,7 +146,19 @@ serde_json = "1.0"
         );
     }
 
-    let bin_path = shared_target.join("debug").join(&bin_name);
+    shared_target.join("debug").join(&bin_name)
+}
+
+/// Compiles Rust code as a binary and runs it, returning stdout.
+/// The code must contain a `fn main()`.
+///
+/// # Panics
+/// Panics if compilation or execution fails. Has no timeout — a deadlocked
+/// binary will hang the test runner. Prefer [`compile_and_run_rust_with_timeout`]
+/// for code paths that may deadlock.
+pub fn compile_and_run_rust(code: &str) -> String {
+    let bin_path = prepare_and_build_binary(code);
+
     let run_output = Command::new(&bin_path)
         .output()
         .expect("Failed to run compiled binary");
@@ -159,6 +172,66 @@ serde_json = "1.0"
     }
 
     String::from_utf8_lossy(&run_output.stdout).to_string()
+}
+
+/// Compiles and runs Rust code with a wall-clock timeout on the binary execution.
+///
+/// On timeout, the child process is killed before this function panics — preventing
+/// orphaned processes from accumulating across deadlock-prone tests.
+///
+/// Build time is **not** included in the timeout; only the binary's execution.
+///
+/// # Panics
+/// - Build failure (same as [`compile_and_run_rust`]).
+/// - Non-zero exit status from the binary.
+/// - Timeout: the binary did not exit within `timeout` (likely deadlock).
+pub fn compile_and_run_rust_with_timeout(code: &str, timeout: Duration) -> String {
+    let bin_path = prepare_and_build_binary(code);
+
+    let mut child = Command::new(&bin_path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn compiled binary");
+
+    let start = Instant::now();
+    let exit_status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if start.elapsed() > timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!(
+                        "\n=== RUST BINARY TIMEOUT ===\n\
+                         Did not exit within {:?} (likely deadlock).\n\
+                         CODE:\n{}",
+                        timeout, code
+                    );
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("Failed to poll child process: {e}");
+            }
+        }
+    };
+
+    let output = child
+        .wait_with_output()
+        .expect("Failed to read child output after exit");
+
+    if !exit_status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        panic!(
+            "\n=== RUST EXECUTION FAILED ===\nCODE:\n{}\n\nSTDERR:\n{}",
+            code, stderr
+        );
+    }
+
+    String::from_utf8_lossy(&output.stdout).to_string()
 }
 
 /// Runs TypeScript code using Node.js and returns stdout.
@@ -191,4 +264,27 @@ pub fn run_node(ts_code: &str) -> String {
          CODE:\n{}\n\nSTDERR:\n{}",
         ts_code, stderr
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "RUST BINARY TIMEOUT")]
+    fn timeout_kills_deadlocked_binary() {
+        compile_and_run_rust_with_timeout(
+            r#"fn main() { std::thread::park(); }"#,
+            Duration::from_millis(500),
+        );
+    }
+
+    #[test]
+    fn no_timeout_for_fast_program() {
+        let out = compile_and_run_rust_with_timeout(
+            r#"fn main() { println!("ok"); }"#,
+            Duration::from_secs(60),
+        );
+        assert_eq!(out.trim(), "ok");
+    }
 }

--- a/tests/src/helpers.rs
+++ b/tests/src/helpers.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::time::Duration;
 
 /// Transpile a TypeScript string to Rust code (no compilation).
 /// This is the primary test helper — fast, no I/O beyond a temp file.
@@ -36,6 +37,39 @@ pub fn assert_output_equivalent(ts_code: &str) {
     let rust_output = tyrus_test_utils::compile_and_run_rust(&rust_binary);
 
     // 5. Compare outputs
+    assert_eq!(
+        ts_output.trim(),
+        rust_output.trim(),
+        "\n╔══════════════════════════════════════════╗\n\
+         ║  SEMANTIC EQUIVALENCE FAILURE             ║\n\
+         ╚══════════════════════════════════════════╝\n\n\
+         TypeScript output: {:?}\n\
+         Rust output:       {:?}\n\n\
+         Generated Rust code:\n{}\n",
+        ts_output.trim(),
+        rust_output.trim(),
+        rust_code
+    );
+}
+
+/// Same contract as [`assert_output_equivalent`] but bounds the Rust binary's
+/// execution wall-clock time. Use for tests that exercise code paths prone
+/// to deadlock (e.g., mutex re-entrance regressions).
+///
+/// On timeout, the child process is killed and the test panics with a message
+/// that names the timeout — preventing nextest from hanging indefinitely.
+pub fn assert_output_equivalent_with_timeout(ts_code: &str, timeout: Duration) {
+    let ts_output = tyrus_test_utils::run_node(ts_code);
+    let rust_code = transpile(ts_code);
+
+    let rust_binary = if rust_code.contains("fn main()") {
+        rust_code.clone()
+    } else {
+        format!("{}\nfn main() {{}}", rust_code)
+    };
+
+    let rust_output = tyrus_test_utils::compile_and_run_rust_with_timeout(&rust_binary, timeout);
+
     assert_eq!(
         ts_output.trim(),
         rust_output.trim(),


### PR DESCRIPTION
## Resumo

Test infrastructure addition: timeout-aware variants of `compile_and_run_rust` and `assert_output_equivalent`. **Ordem 2.5** of the plan in `.claude/plan/critical-issues-roadmap-2026-05-03.md`. Standalone PR — no changes to production code.

## Motivação

The #129 deadlock regression tests (landing in subsequent PR1) execute Rust binaries that may deadlock on mutex re-entrance. Without a timeout-aware helper, a deadlocked binary would hang `nextest` indefinitely, blocking CI and local development.

This PR delivers exactly that helper — independent of the actual fix — so the bug-reproduction test can land in PR1 with a guaranteed bound on wall-clock time.

## Mudanças

- `crates/tyrus_test_utils/src/lib.rs`:
  - Extract `prepare_and_build_binary()` private helper (shared by both run variants).
  - Add `compile_and_run_rust_with_timeout(code, timeout)`: spawns child via `Command::spawn()`, polls `try_wait()` every 50ms, on timeout calls `child.kill()` + panics with a clear message.
  - Add `#[cfg(test)] mod tests` with 2 smoke tests:
    - `timeout_kills_deadlocked_binary` — `std::thread::park()` killed in 500ms.
    - `no_timeout_for_fast_program` — `println!("ok")` returns under 60s.
  - No behavioral change to existing `compile_and_run_rust` or `assert_rust_compiles`.
- `tests/src/helpers.rs`:
  - Add `assert_output_equivalent_with_timeout(ts_code, timeout)` mirroring `assert_output_equivalent` but bounding the binary execution.

## Testes

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo nextest run --workspace` — **237/237 pass** (235 baseline + 2 new smoke)
- [x] Build time only counts toward suite total, not toward the per-test timeout budget — confirmed via the smoke tests using a 500ms timeout post-build.

**Toolchain note:** the recent dependabot batch (`cargo_metadata 0.23` via #137) pulled `cargo-platform 0.3.3` which requires rustc 1.91+. Local rustc 1.89 was upgraded to 1.95 as part of preparing this PR. CI uses `dtolnay/rust-toolchain@stable` so it auto-tracks. Worth flagging in the contributor README that local rustc must be ≥ 1.91.

## Rollback

Two-file change. `git revert <sha>` is safe — no production code touched, no callers yet (PR1 will be the first consumer). Existing tests continue to use the no-timeout helpers.

## Linked Issues

Refs #129 — prerequisite test infrastructure that unblocks the deadlock regression tests in PR1.

## Documentation Sync

- [ ] CHANGELOG.md — N/A (auto via release-plz from this `chore:` commit)
- [x] CLAUDE.md test count — needs update from 235 → 237 (will batch with PR1's update)
- [ ] README.md — N/A
- [ ] MASTER_PLAN.md — N/A
- [ ] NestJS roadmap — N/A
- [ ] ADR — N/A
- [ ] Codemap — N/A (test infrastructure, not codegen)

## Checklist

- [x] One branch = one concern (helper only — no production code)
- [x] Conventional Commits format (`chore(test-utils): …`)
- [x] Local validation: fmt + clippy + nextest all pass (237/237)
- [x] No `unwrap`/`expect`/`panic` in non-test code (`tyrus_test_utils` already allows them at crate level for test infrastructure)
- [x] All functions under 50 lines
- [x] File under 400 lines (260 after change)
- [x] Smoke tests for the timeout behavior itself