### PR TITLE
fix(codegen): prevent mutex re-entrance on compound assigns and dual reads (#129)

### DIFF
--- a/crates/tyrus_codegen/src/convert/expr/member.rs
+++ b/crates/tyrus_codegen/src/convert/expr/member.rs
@@ -47,10 +47,20 @@ impl RustGenerator {
             "f64" | "bool" | "i32" | "usize" | "u64" | "i64"
         );
 
+        // Wrap each read in a block so the MutexGuard temporary drops at the
+        // end of the block — not at the end of the enclosing statement (#129).
+        // Reading the same state field twice in one statement (e.g. struct
+        // literal `User { id: this.x, count: this.x }`, fn args
+        // `Math.max(this.x, this.x)`) would otherwise hold two guards and
+        // deadlock on the second `.lock()` call.
         if needs_deref {
-            quote! { *#receiver.#field_ident.lock().unwrap_or_else(|e| e.into_inner()) }
+            quote! {
+                { let __g = #receiver.#field_ident.lock().unwrap_or_else(|e| e.into_inner()); *__g }
+            }
         } else {
-            quote! { #receiver.#field_ident.lock().unwrap_or_else(|e| e.into_inner()).clone() }
+            quote! {
+                { let __g = #receiver.#field_ident.lock().unwrap_or_else(|e| e.into_inner()); __g.clone() }
+            }
         }
     }
 

--- a/crates/tyrus_codegen/src/convert/expr/misc.rs
+++ b/crates/tyrus_codegen/src/convert/expr/misc.rs
@@ -28,16 +28,93 @@ impl RustGenerator {
     pub(crate) fn convert_assign_expr(&self, assign: &AssignExpr) -> TokenStream {
         let right = self.convert_expr(&assign.right);
         match self.resolve_assign_lhs(&assign.left, assign.op) {
-            AssignLhs::StateField { receiver, field } => quote! {
-                {
-                    let __new_val = #right;
-                    *#receiver.#field.lock().unwrap_or_else(|e| e.into_inner()) = __new_val;
-                }
-            },
+            AssignLhs::StateField { receiver, field } => {
+                self.emit_state_field_assign(&receiver, &field, assign.op, &right)
+            }
             AssignLhs::Setter { obj, setter } => quote! { #obj.#setter(#right) },
             AssignLhs::Plain(lhs) => self.emit_assign_op(assign.op, &lhs, &right),
             AssignLhs::Invalid(err) => err,
         }
+    }
+
+    /// Emits a Mutex-safe write to a `this.field` state field (#129).
+    ///
+    /// All ops route through a read-then-write split using a separate
+    /// statement for each `.lock()` call. The `MutexGuard` from each lock
+    /// is dropped at its statement's `;`, so the two locks never coexist —
+    /// preventing `std::sync::Mutex` re-entrance deadlocks.
+    fn emit_state_field_assign(
+        &self,
+        receiver: &TokenStream,
+        field: &Ident,
+        op: AssignOp,
+        rhs: &TokenStream,
+    ) -> TokenStream {
+        // Guarded read: block-scoped guard, returns Copy value.
+        let guarded_read = quote! {
+            { let __g = #receiver.#field.lock().unwrap_or_else(|e| e.into_inner()); *__g }
+        };
+        let new_val = match op {
+            AssignOp::Assign => quote! { #rhs },
+            AssignOp::AddAssign => quote! { #guarded_read + #rhs },
+            AssignOp::SubAssign => quote! { #guarded_read - #rhs },
+            AssignOp::MulAssign => quote! { #guarded_read * #rhs },
+            AssignOp::DivAssign => quote! { #guarded_read / #rhs },
+            AssignOp::ModAssign => quote! { #guarded_read % #rhs },
+            AssignOp::BitAndAssign => {
+                quote! { ((#guarded_read as i64) & (#rhs as i64)) as f64 }
+            }
+            AssignOp::BitOrAssign => {
+                quote! { ((#guarded_read as i64) | (#rhs as i64)) as f64 }
+            }
+            AssignOp::BitXorAssign => {
+                quote! { ((#guarded_read as i64) ^ (#rhs as i64)) as f64 }
+            }
+            AssignOp::LShiftAssign => {
+                quote! { ((#guarded_read as i64) << (#rhs as i64)) as f64 }
+            }
+            AssignOp::RShiftAssign => {
+                quote! { ((#guarded_read as i64) >> (#rhs as i64)) as f64 }
+            }
+            _ => {
+                return quote! {
+                    compile_error!("Tyrus: unsupported assignment operator on state field")
+                }
+            }
+        };
+        quote! {
+            {
+                let __new_val = #new_val;
+                *#receiver.#field.lock().unwrap_or_else(|e| e.into_inner()) = __new_val;
+            }
+        }
+    }
+
+    /// Returns `(receiver, field_ident)` if `expr` is `this.<field>` and
+    /// `<field>` is a tracked state field of the current class. Used by
+    /// update-expr (`++`/`--`) to route through the same split-write path
+    /// as compound assigns.
+    fn try_resolve_this_state_field(&self, expr: &Expr) -> Option<(TokenStream, Ident)> {
+        let Expr::Member(member) = expr else {
+            return None;
+        };
+        if !member.obj.is_this() {
+            return None;
+        }
+        let prop_ident = member.prop.as_ident()?;
+        if !self
+            .current_class_state_fields
+            .contains_key(prop_ident.sym.as_ref())
+        {
+            return None;
+        }
+        let field = format_ident!("{}", to_snake_case(prop_ident.sym.as_ref()));
+        let receiver = if self.use_state_for_this.get() {
+            quote! { state }
+        } else {
+            quote! { self }
+        };
+        Some((receiver, field))
     }
 
     fn resolve_assign_lhs(&self, target: &AssignTarget, op: AssignOp) -> AssignLhs {
@@ -139,6 +216,14 @@ impl RustGenerator {
     }
 
     pub(crate) fn convert_update_expr(&self, update: &UpdateExpr) -> TokenStream {
+        if let Some((receiver, field)) = self.try_resolve_this_state_field(&update.arg) {
+            let op = match update.op {
+                UpdateOp::PlusPlus => AssignOp::AddAssign,
+                UpdateOp::MinusMinus => AssignOp::SubAssign,
+            };
+            return self.emit_state_field_assign(&receiver, &field, op, &quote! { 1.0 });
+        }
+
         let arg = self.convert_expr(&update.arg);
         match update.op {
             UpdateOp::PlusPlus => quote! { #arg += 1.0 },

--- a/tests/src/snapshot/snapshots/integration_tests__snapshot__tier4_nestjs__snapshot_controller.snap
+++ b/tests/src/snapshot/snapshots/integration_tests__snapshot__tier4_nestjs__snapshot_controller.snap
@@ -31,12 +31,18 @@ impl UsersService {
         }
     }
     pub fn find_all(&self) -> Vec<User> {
-        return self.users.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        return {
+            let __g = self.users.lock().unwrap_or_else(|e| e.into_inner());
+            __g.clone()
+        };
     }
     pub fn create(&self, dto: CreateUserDto) -> User {
         let user = User {
-            id: self.users.lock().unwrap_or_else(|e| e.into_inner()).clone().len() as f64
-                + 1f64,
+            id: {
+                let __g = self.users.lock().unwrap_or_else(|e| e.into_inner());
+                __g.clone()
+            }
+                .len() as f64 + 1f64,
             name: dto.name,
             email: dto.email,
         };

--- a/tests/src/snapshot/snapshots/integration_tests__snapshot__tier4_nestjs__snapshot_injectable_service.snap
+++ b/tests/src/snapshot/snapshots/integration_tests__snapshot__tier4_nestjs__snapshot_injectable_service.snap
@@ -25,22 +25,27 @@ impl UsersService {
         }
     }
     pub fn find_all(&self) -> Vec<User> {
-        return self.users.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        return {
+            let __g = self.users.lock().unwrap_or_else(|e| e.into_inner());
+            __g.clone()
+        };
     }
     pub fn find_by_id(&self, id: f64) -> User {
-        return self
-            .users
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone()
+        return {
+            let __g = self.users.lock().unwrap_or_else(|e| e.into_inner());
+            __g.clone()
+        }
             .iter()
             .find(|item| (|user| user.id == id)(**item))
             .cloned();
     }
     pub fn create(&self, name: String, email: String) -> User {
         let user = User {
-            id: self.users.lock().unwrap_or_else(|e| e.into_inner()).clone().len() as f64
-                + 1f64,
+            id: {
+                let __g = self.users.lock().unwrap_or_else(|e| e.into_inner());
+                __g.clone()
+            }
+                .len() as f64 + 1f64,
             name: name,
             email: email,
         };

--- a/tests/src/unit/mod.rs
+++ b/tests/src/unit/mod.rs
@@ -1,4 +1,5 @@
 mod expr;
+mod state_mutation;
 mod stdlib;
 mod stmt;
 mod tier3;

--- a/tests/src/unit/state_mutation.rs
+++ b/tests/src/unit/state_mutation.rs
@@ -1,0 +1,193 @@
+//! Regression tests for #129 — `std::sync::Mutex` re-entrance deadlocks
+//! when state fields are read or written multiple times in one statement.
+//!
+//! Two failure modes both rooted in `MutexGuard` temporary lifetime:
+//!   1. Compound assigns (`this.x += N`) silently miscompile to plain `=`
+//!      (the read-then-write split previously only handled `=`).
+//!   2. Reading the same state field twice in one statement (struct literal
+//!      arg, function call args) keeps two guards live → deadlock at runtime.
+//!
+//! These tests assert the generated Rust no longer contains the
+//! double-lock-in-one-statement pattern and that it compiles cleanly.
+
+use crate::helpers::transpile;
+use tyrus_test_utils::assert_rust_compiles;
+
+const SERVICE_TEMPLATE: &str = r#"
+import { Injectable } from "@nestjs/common";
+
+interface User {
+    id: number;
+    name: string;
+}
+
+@Injectable()
+class UsersService {
+    counter: number;
+    users: User[];
+
+    constructor() {
+        this.counter = 0;
+        this.users = [];
+    }
+
+    PLACEHOLDER_BODY
+}
+"#;
+
+fn render_service(method_body: &str) -> String {
+    SERVICE_TEMPLATE.replace("PLACEHOLDER_BODY", method_body)
+}
+
+/// `*self.counter.lock()...! += 1` is the broken inline pattern; if any
+/// generated method body contains it, the binary deadlocks at runtime.
+fn assert_no_inline_compound_on_lock(rust: &str) {
+    for op in ["+=", "-=", "*=", "/=", "%="] {
+        let pattern = format!(".lock().unwrap_or_else(|e| e.into_inner()) {op} ");
+        assert!(
+            !rust.contains(&pattern),
+            "Generated Rust contains broken inline compound on locked guard: {pattern}\n--- code ---\n{rust}"
+        );
+    }
+}
+
+#[test]
+fn compound_addassign_emits_read_then_write() {
+    let ts = render_service(
+        r#"
+    bumpCounter(): void {
+        this.counter += 7;
+    }"#,
+    );
+    let rust = transpile(&ts);
+
+    assert_no_inline_compound_on_lock(&rust);
+    assert!(
+        rust.contains("let __new_val")
+            || rust.contains("let __next")
+            || rust.contains("__new_val ="),
+        "Expected a temporary binding before the write-back, got: {rust}"
+    );
+    // Discriminator vs silent miscompile to plain `=`: the literal `7` must
+    // appear with an addition. Without the operator, `this.counter += 7`
+    // would compile to `*lock = 7f64` (effectively `=`), losing the bump.
+    assert!(
+        rust.contains("+ 7f64") || rust.contains("+ 7.0") || rust.contains("+ 7)"),
+        "Operator dropped — `+= 7` silently became `= 7`. Got:\n{rust}"
+    );
+}
+
+#[test]
+fn compound_subassign_emits_read_then_write() {
+    let ts = render_service(
+        r#"
+    drain(amount: number): void {
+        this.counter -= amount;
+    }"#,
+    );
+    let rust = transpile(&ts);
+    assert_no_inline_compound_on_lock(&rust);
+    assert!(
+        rust.contains("- amount") || rust.contains("- amount)"),
+        "Operator dropped — `-= amount` silently became `= amount`. Got:\n{rust}"
+    );
+}
+
+#[test]
+fn update_expr_postincrement_emits_safe_form() {
+    let ts = render_service(
+        r#"
+    next(): void {
+        this.counter++;
+    }"#,
+    );
+    let rust = transpile(&ts);
+    // The unsafe form would be `*self.counter.lock(...) += 1f64` (single statement,
+    // single guard, currently safe) — but for parity with compound assigns we
+    // also route this through the read-then-write split. Either way, the broken
+    // pattern from `assert_no_inline_compound_on_lock` must not appear.
+    assert_no_inline_compound_on_lock(&rust);
+}
+
+#[test]
+fn dual_read_in_struct_literal_uses_guarded_blocks() {
+    let ts = render_service(
+        r#"
+    snapshot(): User {
+        const u: User = { id: this.counter, name: "row-" + this.counter };
+        return u;
+    }"#,
+    );
+    let rust = transpile(&ts);
+
+    let lock_count = rust.matches(".lock()").count();
+    let guarded_block_count = rust.matches("let __g = ").count();
+
+    assert!(
+        guarded_block_count >= 2 || rust.contains("let __counter_read"),
+        "Expected guarded-block reads for state field appearing twice in one statement. \
+         Found {guarded_block_count} guarded block(s) and {lock_count} raw .lock() calls.\n--- code ---\n{rust}"
+    );
+}
+
+#[test]
+fn dual_read_in_call_args_uses_guarded_blocks() {
+    let ts = render_service(
+        r#"
+    range(): number {
+        return Math.max(this.counter, this.counter);
+    }"#,
+    );
+    let rust = transpile(&ts);
+
+    let lock_count = rust.matches(".lock()").count();
+    let guarded_block_count = rust.matches("let __g = ").count();
+
+    assert!(
+        guarded_block_count >= 2 || lock_count == 0,
+        "Expected guarded-block reads when state field is read twice in same statement. \
+         Found {guarded_block_count} guarded block(s).\n--- code ---\n{rust}"
+    );
+}
+
+#[test]
+fn state_compound_assign_compiles() {
+    let ts = render_service(
+        r#"
+    bumpCounter(): void {
+        this.counter += 1;
+        this.counter -= 1;
+        this.counter *= 2;
+    }"#,
+    );
+    let rust = transpile(&ts);
+    assert_rust_compiles(&rust);
+}
+
+#[test]
+fn state_dual_read_compiles() {
+    let ts = render_service(
+        r#"
+    snapshot(): User {
+        const u: User = { id: this.counter, name: "row-" + this.counter };
+        return u;
+    }"#,
+    );
+    let rust = transpile(&ts);
+    assert_rust_compiles(&rust);
+}
+
+#[test]
+fn state_update_expr_compiles() {
+    let ts = render_service(
+        r#"
+    next(): void {
+        this.counter++;
+    }
+    prev(): void {
+        this.counter--;
+    }"#,
+    );
+    let rust = transpile(&ts);
+    assert_rust_compiles(&rust);
+}


### PR DESCRIPTION
## Resumo

Closes #129 — the P0 deadlock bug. **Two distinct failure modes** rooted in `std::sync::Mutex` non-reentrance, both fixed:

1. **Compound assigns on state fields** silently miscompiled to plain `=` (the StateField branch ignored the operator).
2. **Reading the same state field twice in one statement** kept two `MutexGuard` temporaries alive until the enclosing `;`, deadlocking on the second `.lock()`.

This is **Ordem 1** of `.claude/plan/critical-issues-roadmap-2026-05-03.md`. Builds on PR #139 (refactor) and PR #140 (`_with_timeout` test helper).

## Motivação

The `examples/real_world_demo` POST `/users` handler called `this.idCounter = this.idCounter + 1` and was deadlocking at runtime — the most basic NestJS counter pattern. The fix had partial coverage for plain `=`; this PR closes the gap for compound assigns, update expressions (`++`/`--`), and dual-reads of the same state field within one statement.

## Mudanças

### Codegen (production)

- **`crates/tyrus_codegen/src/convert/expr/misc.rs`**:
  - `convert_assign_expr` StateField arm now delegates to a new `emit_state_field_assign(receiver, field, op, rhs)` helper that preserves the operator. Compound ops (`+=`/`-=`/`*=`/`/=`/`%=`/`&=`/`|=`/`^=`/`<<=`/`>>=`) all route through the read-then-write split.
  - `try_resolve_this_state_field(expr)` extracted as a shared helper.
  - `convert_update_expr` now detects `this.field++` / `this.field--` on state fields and routes through `emit_state_field_assign` with `AddAssign`/`SubAssign`. Non-state-field update exprs unchanged.

- **`crates/tyrus_codegen/src/convert/expr/member.rs`**:
  - `convert_this_member` wraps both branches (`needs_deref` + non-Copy clone) in `{ let __g = ...; *__g }` (or `__g.clone()`). The `MutexGuard` drops at the end of the inner block, **not** the enclosing statement — so the same field can be read multiple times per statement without deadlocking.

### Tests

- **`tests/src/unit/state_mutation.rs`** (new, 193 LOC, 8 tests):
  - `compound_addassign_emits_read_then_write` — operator survives (`+ 7` literal appears).
  - `compound_subassign_emits_read_then_write` — operator survives.
  - `update_expr_postincrement_emits_safe_form` — no inline `*lock += N` pattern.
  - `dual_read_in_struct_literal_uses_guarded_blocks` — two guarded blocks emitted.
  - `dual_read_in_call_args_uses_guarded_blocks` — same in fn args.
  - `state_compound_assign_compiles` — `assert_rust_compiles` for `+=`/`-=`/`*=`.
  - `state_dual_read_compiles` — compiles for struct literal dual read.
  - `state_update_expr_compiles` — compiles for `++`/`--`.

- **Snapshots updated** (intentional; reflect new guarded-block pattern):
  - `tier4_nestjs__snapshot_controller.snap`
  - `tier4_nestjs__snapshot_injectable_service.snap`

## Manual end-to-end verification

Re-transpiled `examples/real_world_demo/src` with the fix. Generated `users_service.rs::create()`:

```rust
pub fn create(&self, create_user_dto: CreateUserDto) -> User {
    let new_user = User {
        id: { let __g = self.id_counter.lock()...; *__g },  // guard drops
        // ...
    };
    {
        let __new_val = { let __g = self.id_counter.lock()...; *__g } + 1f64;
        // ↑ inner guard drops at end of inner block
        *self.id_counter.lock()... = __new_val;
        // ↑ second lock — first one already dropped
    };
    self.users.lock()...! .push(new_user.clone());
    return new_user;
}
```

Two `.lock()` calls but in two separate statements (each terminated by `;`), so guards never coexist.

## Testes

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo nextest run --workspace` — **245/245 pass** (237 baseline + 8 new state_mutation)
- [x] `test_http_equivalence_rust_server` continues passing (E2E POST not yet added — out of scope; see Apêndice 1 of plan)

## Rollback

Three production files touched + 1 new test file + 2 snapshot updates. `git revert` reverts cleanly. Behavior reverts to silent-miscompile-and-deadlock.

## Linked Issues

Closes #129. Builds on PR #139 (refactor extracting helpers) + PR #140 (timeout test helper).

## Documentation Sync

- [ ] CHANGELOG.md — N/A (auto via release-plz from `fix(codegen): …` commit)
- [x] CLAUDE.md test count — needs update from 235 → 245 (will batch with subsequent PRs)
- [ ] README.md — N/A
- [ ] MASTER_PLAN.md — N/A
- [ ] NestJS roadmap — N/A
- [ ] ADR — N/A (tactical fix, no architectural decision)
- [ ] Codemap (`docs/CODEMAPS/codegen.md`) — `expr/misc.rs` + `expr/member.rs` sections need note about state-field guarded-block pattern (defer to docs PR)

## Checklist

- [x] One branch = one concern (the deadlock fix)
- [x] Conventional Commits format (`fix(codegen): …`)
- [x] Local validation: fmt + clippy + 245/245 nextest pass
- [x] No `unwrap`/`expect`/`panic`/`todo` in production code
- [x] All functions under 50 lines (max: 46 — `emit_state_field_assign`)
- [x] Files under 400 lines (`misc.rs` 269; `member.rs` 157)
- [x] `pub(crate)` for entry points; new helpers are private (`fn`)