### PR TITLE
test(orchestrator): add format_code regression gates (#131)

### DIFF
--- a/crates/tyrus_orchestrator/src/format.rs
+++ b/crates/tyrus_orchestrator/src/format.rs
@@ -6,6 +6,95 @@ pub(crate) fn format_code(code: &str) -> Result<String, TyrusError> {
     Ok(prettyplease::unparse(&syntax_tree))
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression gate for #131 — `prettyplease::unparse` must be a fixed point.
+    /// Historically a "formatting skipped" bypass for async code violated this:
+    /// downstream `cargo fmt --check` saw spurious diffs and the user mistook
+    /// the bypass output for current behavior.
+    #[test]
+    fn format_code_is_idempotent() {
+        let inputs = [
+            r#"
+fn main() {
+    println!("hello");
+}
+"#,
+            r#"
+struct Foo {
+    x: i32,
+    y: String,
+}
+
+impl Foo {
+    fn new() -> Self {
+        Self { x: 0, y: String::new() }
+    }
+}
+"#,
+            // Async + Result — the historical bypass class.
+            r#"
+async fn handler() -> Result<String, Box<dyn std::error::Error>> {
+    Ok("ok".to_string())
+}
+"#,
+            // Mutex pattern from generated NestJS services.
+            r#"
+pub struct Svc { x: std::sync::Arc<std::sync::Mutex<f64>> }
+impl Svc {
+    pub fn read(&self) -> f64 {
+        { let __g = self.x.lock().unwrap_or_else(|e| e.into_inner()); *__g }
+    }
+}
+"#,
+        ];
+        for src in inputs {
+            let once = format_code(src).expect("first format must succeed");
+            let twice = format_code(&once).expect("second format must succeed");
+            assert_eq!(
+                once, twice,
+                "format_code is not idempotent on:\n--- input ---\n{src}\n--- once ---\n{once}\n--- twice ---\n{twice}",
+            );
+        }
+    }
+
+    /// Invalid Rust must error, never silently pass through. The historical
+    /// "formatting skipped for edition compatibility" comment indicated a
+    /// fallback that did exactly that — long single-line declarations leaked
+    /// to disk and the user couldn't tell formatting had been bypassed.
+    #[test]
+    fn format_code_propagates_parse_errors() {
+        let invalid = "fn (((( this is :: not valid";
+        let result = format_code(invalid);
+        assert!(
+            matches!(result, Err(TyrusError::FormattingError(_))),
+            "Expected FormattingError on invalid Rust, got: {result:?}"
+        );
+    }
+
+    /// Specific regression for the historical async bypass — async code must
+    /// flow through prettyplease cleanly with no edition-compat fallback.
+    #[test]
+    fn format_code_handles_async_without_bypass() {
+        let async_code = r#"
+async fn fetch() -> Result<String, AppError> {
+    let response = reqwest::get("https://example.com").await?;
+    Ok(response.text().await?)
+}
+"#;
+        let formatted = format_code(async_code).expect("async must format");
+        assert!(formatted.contains("async fn fetch"));
+        assert!(formatted.contains(".await"));
+        // No bypass marker should ever appear in formatted output.
+        assert!(
+            !formatted.contains("formatting skipped"),
+            "Bypass marker leaked into output: {formatted}"
+        );
+    }
+}
+
 /// Minimal AppError for non-web async code (no axum dependency).
 pub(crate) fn get_app_error_simple() -> &'static str {
     r#"


### PR DESCRIPTION
## Resumo

Closes #131. Three `#[cfg(test)]` regression gates inside `crates/tyrus_orchestrator/src/format.rs` that lock down the historical "formatting skipped for edition compatibility" failure mode investigated in Ordem 0a of the plan.

This is **Ordem 2** of `.claude/plan/critical-issues-roadmap-2026-05-03.md`.

## Motivação

Ordem 0a investigation ([issue #131 comment](https://github.com/Gefferson-Souza/Tyrus/issues/131#issuecomment-4367011669)) confirmed the original symptoms (bypass comment, >200-char single-line declarations) **no longer reproduce** on main. The bypass code was removed in earlier hygiene work. This PR adds the regression gates that ensure it stays gone.

The full Step 3 of the plan also envisioned a `cargo fmt --check` parity gate, but Ordem 0a discovered prettyplease and rustfmt diverge on minor stylistic points (import grouping, mod ordering — 100 lines of diff). That parity decision is out of scope here and tracked as a follow-up enhancement (canonical authority).

## Mudanças

`crates/tyrus_orchestrator/src/format.rs` — added `#[cfg(test)] mod tests` with 3 focused gates:

- **`format_code_is_idempotent`** — `prettyplease::unparse` must be a fixed point on 4 representative inputs (plain, struct + impl, async + Result, Mutex-locked field). Idempotence is exactly the property the historical bypass violated.
- **`format_code_propagates_parse_errors`** — invalid Rust returns `Err(TyrusError::FormattingError)`, never silently passes through. Locks down the passthrough fallback class.
- **`format_code_handles_async_without_bypass`** — direct regression for the historical bypass marker; ensures async + Result formats cleanly and the bypass string never leaks.

No production code change. `format_code` stays `pub(crate)`; tests live in the same module.

## Testes

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo nextest run --workspace` — **248/248 pass** (245 baseline + 3 new)

## Rollback

Single-file addition (`format.rs` only). `git revert` reverts cleanly. No production behavior touched.

## Linked Issues

Closes #131. Ordem 0a investigation in plan v2.

## Documentation Sync

- [ ] CHANGELOG.md — N/A (auto via release-plz from `test:` commit)
- [x] CLAUDE.md test count — pending (235 → 248, batch with subsequent PRs)
- [ ] README.md — N/A (no user-visible feature)
- [ ] MASTER_PLAN.md — N/A (test addition only)
- [ ] NestJS roadmap — N/A
- [ ] ADR — N/A
- [ ] Codemap — N/A

## Out of scope (follow-up candidate)

Decide canonical formatting authority: keep prettyplease (current) and document divergence vs run `rustfmt` post-prettyplease for ecosystem parity. Open issue separately if the team values `cargo fmt --check` cleanliness on transpiler output.

## Checklist

- [x] One branch = one concern (regression gate only)
- [x] Conventional Commits format (`test(orchestrator): …`)
- [x] Local validation: 248/248 nextest + fmt + clippy
- [x] No production code changed
- [x] All test functions self-contained