### PR TITLE
refactor(codegen): extract state_field.rs from class/mod.rs (#143 prep)

### DIFF
--- a/crates/tyrus_codegen/src/convert/class/mod.rs
+++ b/crates/tyrus_codegen/src/convert/class/mod.rs
@@ -3,13 +3,15 @@ mod getter_setter;
 mod method;
 mod mutation;
 mod routing;
+mod state_field;
 
 use quote::{format_ident, quote};
 use swc_ecma_ast::{ClassDecl, ClassMember, Constructor};
 
 use super::helpers::to_snake_case;
 use super::interface::RustGenerator;
-use super::type_mapper::{is_optional_type, map_ts_type};
+use super::type_mapper::map_ts_type;
+use state_field::wrap_state_field_type;
 
 impl RustGenerator {
     pub fn process_class_decl(&mut self, n: &ClassDecl) {
@@ -75,7 +77,7 @@ impl RustGenerator {
         for member in &n.class.body {
             if let ClassMember::ClassProp(prop) = member {
                 if let Some((field_tokens, name, is_opt, is_dep, type_str)) =
-                    self.convert_prop(prop, &generic_params, is_service_or_controller)
+                    state_field::convert_prop(self, prop, &generic_params, is_service_or_controller)
                 {
                     fields.push(field_tokens);
                     class_fields_meta.push((name.clone(), is_opt));
@@ -136,8 +138,8 @@ impl RustGenerator {
                         let field_name = format_ident!("{}", to_snake_case(&field_name_str));
 
                         let type_ann = ident.type_ann.as_ref();
-                        let mut field_type = map_ts_type(type_ann);
-                        let raw_type_str = field_type.to_string();
+                        let inner_type = map_ts_type(type_ann);
+                        let raw_type_str = inner_type.to_string();
 
                         // Only wrap in Arc for NestJS service/controller DI
                         let is_dependency = is_service_or_controller
@@ -147,16 +149,17 @@ impl RustGenerator {
                             );
 
                         if is_dependency {
-                            field_type = quote! { std::sync::Arc<#field_type> };
                             dependency_fields.insert(field_name_str.clone());
                         } else if is_service_or_controller {
-                            // State field: Wrap in Arc<Mutex<T>> for Interior Mutability
-                            field_type = quote! { std::sync::Arc<std::sync::Mutex<#field_type>> };
                             self.current_class_state_fields
                                 .insert(field_name_str.clone(), raw_type_str);
-                        } else {
-                            // DTO field: Raw type, no mutex
                         }
+
+                        let field_type = wrap_state_field_type(
+                            &inner_type,
+                            is_dependency,
+                            is_service_or_controller,
+                        );
 
                         fields.push(quote! { pub #field_name: #field_type });
                     }
@@ -322,56 +325,5 @@ impl RustGenerator {
 
         self.code.push_str(&impl_block.to_string());
         self.code.push('\n');
-    }
-
-    fn convert_prop(
-        &self,
-        prop: &swc_ecma_ast::ClassProp,
-        generic_params: &std::collections::HashSet<String>,
-        is_service_or_controller: bool,
-    ) -> Option<(proc_macro2::TokenStream, String, bool, bool, String)> {
-        let field_name_str = if let Some(ident) = prop.key.as_ident() {
-            ident.sym.to_string()
-        } else {
-            return None;
-        };
-        let field_name = format_ident!("{}", to_snake_case(&field_name_str));
-        let mut field_type = map_ts_type(prop.type_ann.as_ref());
-
-        // Capture the raw inner type string before wrapping in Option/Arc
-        let raw_type_str = field_type.to_string();
-
-        let is_dependency = is_service_or_controller
-            && super::class::constructor::is_dependency_type(
-                prop.type_ann.as_deref(),
-                generic_params,
-            );
-
-        if is_dependency {
-            field_type = quote! { std::sync::Arc<#field_type> };
-        } else if is_service_or_controller {
-            // State field: Wrap in Arc<Mutex<T>> ONLY for services/controllers
-            field_type = quote! { std::sync::Arc<std::sync::Mutex<#field_type>> };
-        } else {
-            // DTO/Entity field: Keep raw type (or map type normally)
-        }
-
-        let is_optional_union = is_optional_type(prop.type_ann.as_deref());
-        let is_effectively_optional = prop.is_optional || is_optional_union;
-
-        if prop.is_optional {
-            // If it's optional via `?`, we wrap in Option.
-            field_type = quote! { Option<#field_type> };
-        }
-
-        Some((
-            quote! {
-                pub #field_name: #field_type
-            },
-            field_name_str,
-            is_effectively_optional,
-            is_dependency,
-            raw_type_str,
-        ))
     }
 }

--- a/crates/tyrus_codegen/src/convert/class/state_field.rs
+++ b/crates/tyrus_codegen/src/convert/class/state_field.rs
@@ -1,0 +1,84 @@
+//! State-field property emission for `@Injectable` / `@Controller` classes.
+//!
+//! Today every state field is wrapped in `Arc<Mutex<T>>` for interior
+//! mutability. The wrapping decision lives in a single place
+//! ([`wrap_state_field_type`]) so the upcoming atomic-state-fields work
+//! (#143) can swap the wrapper based on the field's type without touching
+//! the surrounding class-emission logic.
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use std::collections::HashSet;
+use swc_ecma_ast::ClassProp;
+
+use crate::convert::helpers::to_snake_case;
+use crate::convert::interface::RustGenerator;
+use crate::convert::type_mapper::{is_optional_type, map_ts_type};
+
+/// Convert a class field declaration into its emitted struct field token,
+/// metadata, and wrapper-classification flags. Returns `None` if the field
+/// has a non-ident key (computed property names are not supported).
+///
+/// Fields:
+/// 0. emitted struct field (`pub <name>: <wrapped_type>`)
+/// 1. raw field name (camelCase as written in TS)
+/// 2. is the field "effectively optional" (Option-wrapped or `?`-suffixed)
+/// 3. is the field a DI dependency (rather than mutable state)
+/// 4. the raw inner type as a string — used by codegen to detect primitives
+pub(super) fn convert_prop(
+    gen: &RustGenerator,
+    prop: &ClassProp,
+    generic_params: &HashSet<String>,
+    is_service_or_controller: bool,
+) -> Option<(TokenStream, String, bool, bool, String)> {
+    let field_name_str = prop.key.as_ident()?.sym.to_string();
+    let field_name = format_ident!("{}", to_snake_case(&field_name_str));
+    let inner_type = map_ts_type(prop.type_ann.as_ref());
+
+    let raw_type_str = inner_type.to_string();
+
+    let is_dependency = is_service_or_controller
+        && super::constructor::is_dependency_type(prop.type_ann.as_deref(), generic_params);
+
+    let mut field_type =
+        wrap_state_field_type(&inner_type, is_dependency, is_service_or_controller);
+
+    let is_optional_union = is_optional_type(prop.type_ann.as_deref());
+    let is_effectively_optional = prop.is_optional || is_optional_union;
+
+    if prop.is_optional {
+        field_type = quote! { Option<#field_type> };
+    }
+
+    let _ = gen; // reserved for upcoming wrapper-kind selection (#143).
+    Some((
+        quote! { pub #field_name: #field_type },
+        field_name_str,
+        is_effectively_optional,
+        is_dependency,
+        raw_type_str,
+    ))
+}
+
+/// Wrap a raw field type with the appropriate sharing/sync wrapper based on
+/// the field's role. Centralised here so the atomic-state-fields refactor
+/// (#143) can swap `Arc<Mutex<T>>` for `Arc<AtomicXxx>` per primitive type
+/// without touching every emission site.
+///
+/// Roles:
+/// * Dependency injection target → `Arc<T>` (shared, immutable from caller).
+/// * Service/controller state → `Arc<Mutex<T>>` (interior mutability).
+/// * DTO / entity field → raw type (no wrapper).
+pub(super) fn wrap_state_field_type(
+    inner: &TokenStream,
+    is_dependency: bool,
+    is_service_or_controller: bool,
+) -> TokenStream {
+    if is_dependency {
+        quote! { std::sync::Arc<#inner> }
+    } else if is_service_or_controller {
+        quote! { std::sync::Arc<std::sync::Mutex<#inner>> }
+    } else {
+        inner.clone()
+    }
+}


### PR DESCRIPTION
## Resumo

Pure refactor — extracts state-field property emission from `class/mod.rs` into a focused sibling module. **Ordem 3a** of `.claude/plan/critical-issues-roadmap-2026-05-03.md`. Prep for the upcoming atomic-state-fields work in #143 (PR2).

No behavioral change. All 248 tests pass; tier4 NestJS snapshots unchanged.

## Motivação

`class/mod.rs` was at **377/400 lines**. Adding wrapper-kind branching for atomic state fields (`Arc<AtomicI64>` vs `Arc<Mutex<T>>` based on field type) would push it past the project's 400-line guideline. Doing the structural prep now keeps PR2 (#143) focused on the actual atomic logic.

## Mudanças

- **`crates/tyrus_codegen/src/convert/class/state_field.rs`** (new, 85 lines):
  - `convert_prop(gen, prop, generic_params, is_service_or_controller)` — moved from `mod.rs`. Same signature, same return shape.
  - `wrap_state_field_type(inner, is_dependency, is_service_or_controller)` — the single seam where wrapper choice is made (currently always `Arc<Mutex<T>>` for state fields). The atomic refactor will dispatch on the inner type here.
- **`crates/tyrus_codegen/src/convert/class/mod.rs`**:
  - 377 → 330 lines.
  - `mod state_field;` registered.
  - `convert_prop` removed (now in `state_field.rs`); call updated to `state_field::convert_prop(self, ...)`.
  - The inline `Arc<Mutex<T>>` wrapping in the constructor-params block now uses `wrap_state_field_type` — same logic as `convert_prop`, single source of truth.

Two routes were duplicating the same wrapping logic; consolidated.

## Testes

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo nextest run --workspace` — **248/248 pass** (zero regression)
- [x] Tier4 NestJS snapshots (controller + injectable_service) unchanged — proves byte-for-byte semantic equivalence

## Rollback

Two-file change, mechanical extraction. `git revert` reverts cleanly to the inline pattern.

## Linked Issues

Refs #143 — prep for atomic state fields. Refs #129 — original deadlock report.

## Documentation Sync

- [ ] CHANGELOG.md — N/A (auto via release-plz from `refactor:` commit)
- [ ] CLAUDE.md test count — N/A (still 248)
- [ ] README.md — N/A
- [ ] MASTER_PLAN.md — N/A
- [ ] NestJS roadmap — N/A
- [ ] ADR — N/A (deferred to PR2 #143 → ADR 0008)
- [ ] Codemap (`docs/CODEMAPS/codegen.md`) — minor: mention `class/state_field.rs` as the wrapper-choice seam (defer to docs PR)

## Checklist

- [x] One branch = one concern (structural prep only)
- [x] Conventional Commits format (`refactor(codegen): …`)
- [x] Local validation: 248/248 nextest + fmt + clippy pass
- [x] No `unwrap`/`expect`/`panic`/`todo` introduced
- [x] All functions under 50 lines (max: ~25)
- [x] Both files under 400 lines (`mod.rs` 330; `state_field.rs` 85)
- [x] `pub(super)` for the new helpers — minimum visibility for cross-module use within `class/`