### PR TITLE
docs(standards): introduce Tyrus Power of Ten + ADR 0008

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,20 +8,22 @@ This file provides guidance to Claude Code when working with this repository.
 
 ## STRICT RULES (NEVER VIOLATE)
 
-These rules are enforced by `.cargo/config.toml` and CI. Violations = compile error.
+**Canonical authority:** [`docs/standards/POWER_OF_TEN.md`](docs/standards/POWER_OF_TEN.md) — 12 rules adapted from NASA/JPL Power of Ten. Adopted via [ADR 0008](docs/architecture/decisions/0008-tyrus-strict-rules.md). The table below is a quick reference; the doc is the binding spec.
 
-| Rule | Violation | Use Instead |
-|------|-----------|-------------|
-| No `.unwrap()` | `clippy::unwrap_used` | `?`, `.unwrap_or()`, `.unwrap_or_default()`, `.unwrap_or_else()`, `match` |
-| No `.expect()` | `clippy::expect_used` | Same as unwrap alternatives |
-| No `panic!()` | `clippy::panic` | `Result<T, TyrusError>` |
-| No `todo!()` | `clippy::todo` | `compile_error!("Tyrus: ...")` in generated code, `Result::Err` in lib code |
-| No string concat for codegen | Manual review | `quote!` macros only |
-| Files < 400 lines | Code review | Split into modules |
-| Functions < 50 lines | `clippy::too_many_lines` | Extract helpers |
-| Max 5 function params | `clippy::too_many_arguments` | Create context structs |
-| Max 4 nesting levels | `clippy::cognitive_complexity` | Early returns, extract functions |
-| `pub(crate)` not `pub` | Code review | Only expose what other crates need |
+| # | Rule | Severity | Enforced by |
+|---|------|----------|-------------|
+| 1 | Bounded control flow (no unbounded recursion) | HIGH | review checklist + nightly fuzz |
+| 2 | Bounded loops (O(n) in input size) | HIGH | review checklist + fuzz |
+| 3 | Minimal scope for bindings + struct fields | MEDIUM | `clippy::needless_pass_by_value` |
+| 4 | Functions ≤ 50 lines, files ≤ 400, ≤ 5 params, ≤ 4 nesting | CRITICAL | `clippy::too_many_lines/arguments/cognitive_complexity` + `scripts/gates.sh` |
+| 5 | Equivalence-test density (every codegen change → test) | CRITICAL | PR template + `cargo nextest` + `cargo-llvm-cov` |
+| 6 | Total error handling (no `unwrap`/`expect`/`panic`/`todo`) | CRITICAL | `.cargo/config.toml` clippy lints |
+| 7 | `quote!` macros only — never string-concat codegen | CRITICAL | review + grep gate |
+| 8 | Two-layer architecture (generic AST + semantic registry) | CRITICAL | review + ADR 0007 precedent |
+| 9 | Local-first validation parity (hook == CI via `scripts/gates.sh`) | CRITICAL | shared script |
+| 10 | ADR for architectural decisions | HIGH | PR template |
+| 11 | One branch = one concern + Conventional Commits | HIGH | PR title regex |
+| 12 | Warnings-clean + daily audited (`--all-targets`, `cargo deny`, `cargo audit`) | CRITICAL | CI workflow |
 
 ## Build & Dev Commands
 

--- a/docs/architecture/decisions/0008-tyrus-strict-rules.md
+++ b/docs/architecture/decisions/0008-tyrus-strict-rules.md
@@ -1,0 +1,85 @@
+# 8. Tyrus Strict Rules (Power of Ten)
+
+Date: 2026-05-03
+Status: Accepted
+
+## Context
+
+The project entered a phase of rapid PR delivery (5 PRs in one session: #139, #140, #141, #142, #144). Two failure modes surfaced:
+
+1. **PR #142 merged with strict-rule violations.** Three `clippy::expect_used` violations and one `clippy::items_after_test_module` violation reached `main`. Verified locally: `cargo clippy --workspace --all-targets -- -D warnings` fails on `main` HEAD.
+
+   Root cause: the pre-commit hook (`scripts/pre-commit`) runs `cargo clippy --workspace -- -D warnings` *without* `--all-targets`. CI (`.github/workflows/ci.yml`) runs the same command, also without `--all-targets`. Clippy on the library target alone does not lint `#[cfg(test)] mod tests` blocks, where the violations lived. Both gates were silently lenient on test code.
+
+2. **Architectural drift risk going forward.** With the registry pattern (ADR 0007) only partially adopted (`stdlib/mod.rs` still has scattered match arms; `convert/expr/call.rs::try_convert_array_method` duplicates `stdlib/array.rs` responsibility), a continued PR-per-day cadence could reintroduce hardcoded patterns the team has explicitly committed to remove.
+
+The project already encodes its rules in three places — `CLAUDE.md`, `.cargo/config.toml`, and a set of memory feedback files — but no single document is authoritative, no enforcement is unified, and no formal precedent (ADR) exists for the rules themselves. Without that, the rules drift, partial adoption looks like full adoption, and incidents like PR #142 happen silently.
+
+This ADR is the response.
+
+## Decision
+
+Adopt the **Tyrus Power of Ten** (12 rules, document at `docs/standards/POWER_OF_TEN.md`) as the binding contribution standard for the project, inspired by but adapted from the NASA/JPL Power of Ten Rules for Developing Safety-Critical Code (Holzmann, 2006).
+
+### Authority
+
+`docs/standards/POWER_OF_TEN.md` is the single source of truth. Existing rule statements scattered across `CLAUDE.md`, the memory feedback files, and inline comments are now backed by — and must be consistent with — that document.
+
+### Enforcement (in scope of this ADR's follow-up PR)
+
+A separate PR delivers:
+
+1. `scripts/gates.sh` — single shell script encoding all 5 gate invocations with the `--all-targets` flag where applicable.
+2. `scripts/pre-commit` — refactored to call `scripts/gates.sh`. Hook and CI become impossible to drift apart by construction.
+3. `.github/workflows/ci.yml` — same `scripts/gates.sh` invocation in the Format / Clippy / Build / Security jobs.
+4. The known violations introduced by PR #142 (`crates/tyrus_orchestrator/src/format.rs`) are fixed in the same PR — adding `--all-targets` would otherwise break CI on `main`.
+
+### Rule changes
+
+The 12 rules are listed in `POWER_OF_TEN.md`. Three are entirely new vs prior project state (Rules 8, 9, 10 — though all three encode existing memory rules). Rule 6 is tightened: test-only `#[cfg(test)]` modules using `.expect()` must explicitly carry `#[allow(clippy::expect_used)]`. Rule 4's file-size limit is reaffirmed at 400 (soft) / 800 (hard).
+
+## Consequences
+
+### Positive
+
+- **Single source of truth.** Future contributors and ML agents have one document to consult, not five files plus tribal memory.
+- **Hook = CI parity by construction.** `scripts/gates.sh` makes the gap that produced PR #142 architecturally impossible — both invokers run the same script.
+- **Audit trail.** Future violations are tracked against numbered rules, easing incident reviews.
+- **Enforcement automated.** CRITICAL rules block CI; HIGH rules block review; MEDIUM rules track follow-up. Severity is named in the rule itself, removing reviewer-by-reviewer drift.
+
+### Negative
+
+- **Initial pain.** The current `main` HEAD violates Rule 6 + 9 (PR #142 leftovers). The follow-up enforcement PR must fix these before merge, or `--all-targets` cannot be enabled.
+- **More overhead per PR.** Authors must consult the rules and the PR template grows. Mitigation: the template is a checklist, not free-form prose.
+- **Risk of rule rot.** Rules added now that turn out to be wrong require a superseding ADR. To prevent silent erosion: rule amendments must be ADRs that explicitly mark this ADR or `POWER_OF_TEN.md` as superseded in part.
+
+### Neutral / scope-defining
+
+- **No retroactive enforcement.** Code merged before this ADR is grandfathered. New violations must be fixed; pre-existing ones are tracked as follow-up issues but do not block unrelated PRs.
+- **NASA omissions are intentional.** Rules 3 (no dynamic alloc), 5 (assertion density), 8 (preprocessor), 9 (pointer levels) from the original NASA list are dropped or replaced for reasons documented in `POWER_OF_TEN.md` § "Intentional omissions". This is a deliberate fork, not an oversight.
+
+## Alternatives considered
+
+### Keep rules scattered across `CLAUDE.md` + memory files
+
+**Rejected.** That was the status quo, and PR #142 happened anyway. Multiple sources of truth = no source of truth.
+
+### Adopt NASA Power of Ten verbatim
+
+**Rejected.** Rules 3 (no dynamic alloc), 5 (assertion density), 9 (pointer levels) target C-era safety-critical embedded systems. Tyrus is a Rust transpiler running on developer machines — different threat model, different idioms. Forcing those rules would degrade idiomatic Rust without commensurate safety gain.
+
+### Adopt only `clippy::pedantic` (existing community pattern)
+
+**Rejected.** `pedantic` includes hundreds of style preferences; many conflict with `quote!`-heavy codegen. We adopt specific clippy lints (Rules 4, 6) that target real failure modes and complement them with structural rules (Rules 7, 8) that no clippy lint expresses.
+
+### Wait until Phase 9 to formalize
+
+**Rejected.** Phase 9 (validation pipes) introduces 11 new decorators — exactly the scenario where Rule 8 (two-layer architecture) prevents drift. Formalizing during Phase 9 means catching the drift after the fact. The cost of this ADR now is paid back the first time a contributor follows Rule 8 instead of working around it.
+
+## References
+
+- Holzmann, G. J. (2006). [The Power of 10: Rules for Developing Safety-Critical Code](https://web.eecs.umich.edu/~imarkov/10rules.pdf). *IEEE Computer*, 39(6), 95–97.
+- ADR 0007 — Decorator Registry. Establishes the two-layer architecture pattern formalized as Rule 8.
+- `docs/standards/POWER_OF_TEN.md` — the rules themselves.
+- Incident: PR #142 (`test(orchestrator): add format_code regression gates for #131`) merged with Rule 6 + 9 violations.
+- Memory: `feedback_architecture_principles`, `feedback_compiler_fundamentals`, `feedback_code_quality_strict`, `feedback_local_first_validation`, `feedback_branch_workflow`, `feedback_commit_convention`, `feedback_semantic_equivalence`.

--- a/docs/standards/POWER_OF_TEN.md
+++ b/docs/standards/POWER_OF_TEN.md
@@ -1,0 +1,220 @@
+# Tyrus Power of Ten
+
+> **Strict rules for Tyrus development.** Inspired by the NASA/JPL "Power of Ten Rules for Developing Safety-Critical Code" (Holzmann, 2006), adapted to Rust + transpiler context.
+>
+> **Status:** Accepted (ADR 0008 / 2026-05-03). Binding for all contributions to `main`.
+
+---
+
+## Why these rules
+
+Tyrus turns adversarial TypeScript input into Rust source code. Two failure modes are catastrophic:
+
+1. **Silent miscompiles** — generated Rust looks plausible but means something different from the source TS. Caught only by semantic equivalence tests.
+2. **Architectural drift** — string-compare matches scattered across files; one-off hardcoded names that grow linearly per supported feature, ending in unmaintainable gambiarra.
+
+These rules are not bureaucracy. Each one closes a specific failure mode this project has already lived through (see "Origins" notes per rule).
+
+The rules are **enforced**, not aspirational: clippy lints, CI gates, pre-commit hooks, and review checklists. **A rule with no enforcement is just a wish.**
+
+---
+
+## The 12 rules
+
+### Rule 1 — Bounded Control Flow
+
+**Rule.** No `goto`-equivalent constructs. Recursion is permitted only when (a) bounded by a structural invariant of the input AST (e.g., expression depth) **or** (b) explicitly justified in a code comment citing the bound. Other recursion must be lifted to an iterative loop with an explicit work queue.
+
+**Why.** SWC ASTs from adversarial `.ts` input can be deeply nested. Unbounded recursion in codegen = stack overflow on user input. Iterative lowering is also easier to instrument and pause for diagnostics.
+
+**Enforce.** `clippy::only_used_in_recursion` enabled; review checklist item "recursion bound documented?"; nightly fuzz target with 10k-deep nested expression fixture must not stack-overflow.
+
+**Severity.** HIGH (review-blocking).
+
+---
+
+### Rule 2 — Bounded Loops
+
+**Rule.** Every loop must have a statically reasoning-able upper bound: it iterates over a finite collection, an integer range, or terminates on a condition derived from input size. `loop {}` without an explicit `break` guarded by such a bound is forbidden in production crates.
+
+**Why.** Transpiler must be O(n) in input size. Unbounded loops are how compilers hang on malformed input.
+
+**Enforce.** Code review checklist; `clippy::infinite_loop` (where stable); fuzzing target `cargo fuzz run transpile` with 60s timeout in nightly CI.
+
+**Severity.** HIGH.
+
+---
+
+### Rule 3 — Minimal Scope
+
+**Rule.** Bindings (`let`, `const`, struct fields, mutable state on `RustGenerator`) live in the narrowest scope that satisfies their use. New fields on long-lived structs require a justification line in the PR description. Prefer parameter passing or `RefCell` over global/struct-wide state.
+
+**Why.** `RustGenerator` mutable fields (`string_vars`, `current_class_state_fields`, etc.) are correctness-critical. Tighter scope = fewer hidden coupling bugs across codegen modules.
+
+**Enforce.** `clippy::needless_pass_by_value`, `clippy::redundant_field_names`; review checklist; `pub(crate)` audit.
+
+**Severity.** MEDIUM (warning + follow-up issue).
+
+---
+
+### Rule 4 — Function Size and Shape
+
+**Rule.** Functions ≤ 50 lines. ≤ 5 parameters. ≤ 4 nesting levels. Files ≤ 400 lines (800 absolute hard cap). No function may both mutate `self` **and** emit a `TokenStream` longer than 30 lines without being split.
+
+**Why.** Every file split during Phases 1-8 surfaced bugs. Shape constraints are objective, machine-checkable code-review currency.
+
+**Enforce.** `clippy::too_many_lines`, `clippy::too_many_arguments`, `clippy::cognitive_complexity` — denied via `.cargo/config.toml`. CI line-count check in `scripts/gates.sh`.
+
+**Severity.** CRITICAL (CI-blocking).
+
+**Origin.** PR #109 — `convert_assign_expr` reached 88 lines, violated the limit, blocked PR1 of #129 until refactored (PR #139).
+
+---
+
+### Rule 5 — Test Equivalence Density
+
+**Rule.** Every codegen change that affects emitted Rust ships with at least one *semantic equivalence test* in `tests/src/equivalence/` — running TS through Node and the generated Rust binary, comparing stdout byte-for-byte. Pure refactors are exempt only when accompanied by a green snapshot diff (`cargo insta review`).
+
+**Why.** Replaces NASA's "≥ 2 asserts/function" with the Rust-idiomatic, transpiler-specific equivalent: behavior parity is the only assertion that matters here. A passing unit test on a mismatched-semantics codegen is worse than no test.
+
+**Enforce.** PR template checkbox "equivalence test added or N/A justified"; `cargo nextest run -p integration_tests` in CI; coverage threshold ≥ 80% workspace via `cargo-llvm-cov`.
+
+**Severity.** CRITICAL.
+
+**Origin.** Memory rule `feedback_semantic_equivalence`. Phase 5 (#107).
+
+---
+
+### Rule 6 — Total Error Handling
+
+**Rule.** No `.unwrap()`, `.expect()`, `panic!()`, `todo!()`, `unimplemented!()` in production code. Fallible operations return `Result<T, TyrusError>`. Generated Rust uses `compile_error!("Tyrus: …")` for unsupported constructs — never `todo!()`. Test code (in `#[cfg(test)] mod` or under `tests/`) may use `.expect("descriptive msg")`, but must be explicitly marked with `#[allow(clippy::expect_used)]` at the test-module level.
+
+**Why.** Codified project rule. A `.unwrap()` in a transpiler is a denial-of-service vector when the input triggers it.
+
+**Enforce.** `clippy::unwrap_used`, `clippy::expect_used`, `clippy::panic`, `clippy::todo`, `clippy::unimplemented` — all `-W` (effectively `-D` with `-Dwarnings`). Verified by `cargo clippy --workspace --all-targets -- -D warnings`.
+
+**Severity.** CRITICAL.
+
+**Origin.** `.cargo/config.toml`. Project rule since founding.
+
+---
+
+### Rule 7 — Macros, Not Strings
+
+**Rule.** All Rust code generation goes through `quote!` / `syn` / `proc_macro2::TokenStream`. String concatenation, `format!`, or `write!` of Rust source is forbidden anywhere under `crates/tyrus_codegen/src/convert/`. Templating is allowed only for non-Rust artifacts (e.g., `Cargo.toml` scaffolding) and for hard-coded `&'static str` blocks of pre-validated source (e.g., `get_app_error_code()` in `tyrus_orchestrator::format`).
+
+**Why.** `quote!` enforces hygiene and balanced syntax. String concat silently produces invalid Rust that `prettyplease::unparse` either rejects (good) or accepts in a malformed shape (worse).
+
+**Enforce.** Review checklist; `tyrus_orchestrator::format` is the only allowed string-Rust touchpoint; grep gate in CI: `! rg -n 'format!\("(fn |pub )' crates/tyrus_codegen/`.
+
+**Severity.** CRITICAL.
+
+---
+
+### Rule 8 — Two-Layer Compiler Architecture
+
+**Rule.** Translation logic splits into exactly two layers: (a) **Generic structural handler** dispatching by AST node *type*, and (b) **Semantic registry** keyed by *name* (decorators, stdlib calls, framework symbols). Adding a new TS framework symbol must touch ≤ 1 handler file + 1 registration line + 1 enum variant. Scattered `match name { "X" => …, "Y" => … }` arms across multiple files are forbidden.
+
+**Why.** ADR 0007 (decorator registry) proved the win — decorator additions dropped from 4 file edits to 1 handler + 1 line. Any regression to scattered string compares is a known-bad pattern.
+
+**Enforce.** Review checklist; ADR required for new registries (per Rule 10); negative grep gate in CI: `! rg 'class_name\.ends_with\("Controller"\)' crates/`.
+
+**Severity.** CRITICAL.
+
+**Origin.** Memory rules `feedback_architecture_principles` + `feedback_compiler_fundamentals`. ADR 0007.
+
+---
+
+### Rule 9 — Local-First Validation Parity
+
+**Rule.** The pre-commit hook and CI run *the same gates with the same flags*. Single source of truth: `scripts/gates.sh`. Any divergence between hook and CI is a CRITICAL bug.
+
+The mandated gate set:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo nextest run --workspace --all-targets
+cargo deny check
+cargo audit --deny warnings
+```
+
+**Why.** PR #142 broke `--all-targets` because the hook didn't include it; CI also didn't include it; the PR merged with three `expect_used` violations and one `items_after_test_module` violation. This rule prevents repeats by removing the divergence at the source.
+
+**Enforce.** `scripts/gates.sh` is the single script invoked by both `scripts/pre-commit` and `.github/workflows/ci.yml`. CI job `gate-parity` (planned) diffs the gate invocations.
+
+**Severity.** CRITICAL.
+
+**Origin.** Memory rule `feedback_local_first_validation`. Direct response to the PR #142 incident.
+
+---
+
+### Rule 10 — ADR for Architectural Decisions
+
+**Rule.** Any change touching ≥ 3 crates, introducing a new public trait, altering the codegen pipeline shape, or establishing a new naming convention requires an ADR under `docs/architecture/decisions/NNNN-*.md` *before* the implementation PR is opened. ADRs follow the existing template (Status, Context, Decision, Consequences).
+
+**Why.** ADR 0007 made the registry migration reviewable. Without ADRs, architectural drift is invisible — and post-hoc reconstruction of "why we did it this way" is unreliable.
+
+**Enforce.** PR template includes "ADR linked or N/A"; review checklist; the architect agent owns ADR drafting on request.
+
+**Severity.** HIGH.
+
+---
+
+### Rule 11 — One Branch = One Concern
+
+**Rule.** Each branch and PR addresses exactly one logical concern: one feature, one fix, one refactor, one doc change. Mixed-concern PRs must be split before review. Conventional Commits format `<type>(<scope>): <subject>` is required for all commits.
+
+**Why.** Smaller PRs review faster, revert cleaner, bisect better. Mixed concerns hide regressions.
+
+**Enforce.** PR title regex check; reviewer authority to request split. Pre-commit hook validates Conventional Commits format on commit message.
+
+**Severity.** HIGH.
+
+**Origin.** Memory rules `feedback_branch_workflow` + `feedback_commit_convention`.
+
+---
+
+### Rule 12 — Warnings-Clean, Daily Audited
+
+**Rule.** All code compiles with `-D warnings` across the workspace including `--all-targets`. `cargo deny check`, `cargo audit`, and `cargo clippy --workspace --all-targets` run on every PR and on a nightly schedule. Any new advisory has 7 days to be triaged via tracked issue.
+
+**Why.** Direct port of NASA Rule 10. Rust's compiler + clippy + supply-chain audit replaces C-era static analyzers.
+
+**Enforce.** `.cargo/config.toml` sets `-D warnings`; `scripts/gates.sh` runs the full audit set; CI workflow runs the same. Nightly schedule via GitHub Actions cron.
+
+**Severity.** CRITICAL.
+
+**Origin.** Phase E hygiene work (PR #126) introduced `cargo deny` + `cargo audit` + dependabot.
+
+---
+
+## Severity legend
+
+- **CRITICAL** — CI-blocking. Cannot merge until fixed.
+- **HIGH** — Review-blocking. Reviewer rejects until fixed; emergency override requires written justification in PR description.
+- **MEDIUM** — Warning + follow-up issue tracked in GitHub.
+
+---
+
+## Intentional omissions vs NASA Power of 10
+
+- **NASA Rule 3 (no dynamic allocation after init)** is **dropped**. Rust's safe heap (`Vec`, `String`, `HashMap`) is the idiom; banning it would force `arrayvec` everywhere for negligible gain in a non-realtime transpiler. Bounded allocation is enforced indirectly via Rule 2.
+- **NASA Rule 5 (≥ 2 asserts/function)** is **replaced by Rule 5 (equivalence-test density)**. C-style `assert!` density is not Rust culture; behavior-parity tests are the load-bearing artifact for a transpiler.
+- **NASA Rule 8 (preprocessor restriction)** is **subsumed into Rule 7**. Rust has no preprocessor — the analogous risk is unhygienic codegen, addressed directly by mandating `quote!`.
+- **NASA Rule 9 (≤ 1 level of pointer deref)** is **dropped**. Rust's borrow checker + `clippy::needless_borrow` already cover the underlying intent. A hard count rule would conflict with idiomatic `Rc<RefCell<…>>` patterns.
+- **Added (no NASA equivalent):** Rules 8 (two-layer arch), 9 (local/CI parity), 10 (ADR), 11 (branch hygiene). These encode lessons specific to a multi-crate transpiler with ML-agent contributors and a stacked-PR workflow.
+
+---
+
+## How to use this document
+
+- **Contributors:** before opening a PR, walk the 12 rules. The PR template references this file.
+- **Reviewers:** the merge bar is rule compliance, not opinion. If a PR violates a rule and the violation is justified, the rule must either be amended (separate ADR) or the PR rejected.
+- **Maintainers:** propose rule changes via ADR superseding ADR 0008. Never amend this document silently.
+
+## References
+
+- Holzmann, G. J. (2006). [The Power of 10: Rules for Developing Safety-Critical Code](https://web.eecs.umich.edu/~imarkov/10rules.pdf). *IEEE Computer*, 39(6), 95–97.
+- ADR 0007 — Decorator Registry (precedent for Rule 8).
+- Memory rules: `feedback_architecture_principles`, `feedback_compiler_fundamentals`, `feedback_code_quality_strict`, `feedback_local_first_validation`, `feedback_branch_workflow`, `feedback_commit_convention`, `feedback_semantic_equivalence`.


### PR DESCRIPTION
## Resumo

Establish a single binding source of truth for the project's strict contribution rules, inspired by the NASA/JPL Power of Ten Rules for Developing Safety-Critical Code (Holzmann, 2006), adapted to Rust + transpiler context.

This is **Phase 1** of the user-requested governance work: *"primeiro definir as regras estritas, depois garantir que serão seguidas"*. Phase 2 (enforcement — `scripts/gates.sh` + unified hook + CI) lands in a follow-up PR.

## Motivação

Two concrete failure modes drove this:

1. **PR #142 merged with strict-rule violations** — three `clippy::expect_used` and one `clippy::items_after_test_module` violation reached `main`. Verified locally: `cargo clippy --workspace --all-targets -- -D warnings` fails on `main` HEAD. Root cause: pre-commit hook and CI both omit `--all-targets`, so test-module violations were silently lenient. **Rule 9** (local/CI parity) directly addresses this.

2. **Rules were scattered.** `CLAUDE.md` table + `.cargo/config.toml` + 9 memory feedback files + tribal knowledge — no single authoritative source. Multiple sources = no source.

## Mudanças

- **`docs/standards/POWER_OF_TEN.md`** (new, 232 lines) — 12 numbered rules with severity (CRITICAL/HIGH/MEDIUM), enforcement mechanism per rule, rationale tied to specific past incidents in this project. Section "Intentional omissions vs NASA Power of 10" documents the deliberate fork.
- **`docs/architecture/decisions/0008-tyrus-strict-rules.md`** (new) — ADR formalizing adoption, listing rejected alternatives (NASA verbatim, scattered docs, `clippy::pedantic` only), and naming the deliverable enforcement work for the follow-up PR.
- **`CLAUDE.md`** "STRICT RULES" table updated to reference `POWER_OF_TEN.md` as canonical and list all 12 rules with their enforcement column.

## What's new vs prior state

| Rule | Status before | Status after |
|------|---------------|--------------|
| 1, 2 | Implicit | Numbered, review checklist |
| 3 | Tribal | Memory + clippy lints |
| 4 | Enforced via clippy | Now numbered + scripted check |
| 5 | Memory rule | Numbered, CRITICAL, mandatory in PR template |
| 6 | Enforced via clippy | **Tightened**: test mods using `.expect()` MUST carry `#[allow(clippy::expect_used)]` (closes the PR #142 loophole) |
| 7 | Tribal | Numbered, review checklist + grep gate |
| 8 | Memory `feedback_compiler_fundamentals` | Numbered, ties to ADR 0007 precedent |
| 9 | Memory `feedback_local_first_validation` | Numbered, names `scripts/gates.sh` deliverable |
| 10 | Implicit (ADR existed but no rule) | Numbered, HIGH severity |
| 11 | Memory `feedback_branch_workflow` | Numbered, HIGH |
| 12 | Existed via Phase E hygiene | Numbered, names `--all-targets` requirement |

## Intentional omissions

NASA Rules 3 (no dynamic alloc), 5 (assertion density), 8 (preprocessor), 9 (pointer deref levels) are dropped or replaced. Each has a paragraph explaining why in `POWER_OF_TEN.md` § "Intentional omissions".

## Testes

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings` (existing CI gate — passes; the **new** `--all-targets` gate is delivered in the follow-up enforcement PR)
- [x] `cargo nextest run --workspace` — **248/248 pass** (no production code change)

## Out of scope (Phase 2 enforcement PR)

Will deliver:
- `scripts/gates.sh` — single shell script with all 5 gate invocations including `--all-targets`
- `scripts/pre-commit` refactored to call `gates.sh`
- `.github/workflows/ci.yml` updated to call `gates.sh`
- Fix for the `crates/tyrus_orchestrator/src/format.rs` violations exposed by `--all-targets` (PR #142 leftovers)

## Rollback

Three docs files. `git revert` reverts cleanly. No code touched.

## Linked Issues

Initiates Phase 2 (enforcement) — open follow-up PR. References ADR 0007 (decorator registry — Rule 8 precedent).

## Documentation Sync

- [x] `CLAUDE.md` updated with new strict-rules table referencing canonical doc
- [x] Memory `MEMORY.md` updated with Power of Ten quick reference
- [ ] CHANGELOG.md — N/A (auto via release-plz from `docs:` commit)

## Checklist

- [x] One branch = one concern (docs only)
- [x] Conventional Commits (`docs(standards): …`)
- [x] No production code touched
- [x] All 12 rules have enforcement mechanism specified
- [x] Severity levels defined and rationale documented