### PR TITLE
docs(codegen): add bound-justifying comments to recursive functions (#151)

### DIFF
--- a/crates/tyrus_codegen/src/convert/expr/binary.rs
+++ b/crates/tyrus_codegen/src/convert/expr/binary.rs
@@ -12,6 +12,7 @@ use crate::convert::helpers::is_string_expr;
 use crate::convert::interface::RustGenerator;
 
 impl RustGenerator {
+    // Bound: SWC AST is finite; recursion depth ≤ AST depth (Rule 1, POWER_OF_TEN.md).
     pub(crate) fn convert_bin_expr(&self, bin: &BinExpr) -> TokenStream {
         match bin.op {
             BinaryOp::Add => {
@@ -59,6 +60,7 @@ impl RustGenerator {
 /// `a + b + c + d` → [convert(a), convert(b), convert(c), convert(d)]
 /// instead of nested format!("{}{}", format!("{}{}", ...), d)
 /// Once we know we're inside a string concat chain, ALL child Add nodes are string parts.
+// Bound: SWC AST is finite; recursion depth ≤ AST depth (Rule 1, POWER_OF_TEN.md).
 fn collect_string_concat_parts(gen: &RustGenerator, expr: &Expr, parts: &mut Vec<TokenStream>) {
     if let Expr::Bin(bin) = expr {
         if bin.op == BinaryOp::Add {

--- a/crates/tyrus_codegen/src/convert/expr/call.rs
+++ b/crates/tyrus_codegen/src/convert/expr/call.rs
@@ -12,6 +12,8 @@ use crate::convert::helpers::to_snake_case;
 use crate::convert::interface::RustGenerator;
 
 impl RustGenerator {
+    // Bound: SWC AST is finite; recursion depth ≤ AST depth via convert_expr on
+    // callee + args (Rule 1, POWER_OF_TEN.md).
     pub(crate) fn convert_call_expr(&self, call: &CallExpr) -> TokenStream {
         // Try stdlib handlers first
         if let Some(stdlib_code) =

--- a/crates/tyrus_codegen/src/convert/expr/mod.rs
+++ b/crates/tyrus_codegen/src/convert/expr/mod.rs
@@ -32,6 +32,7 @@ use super::interface::RustGenerator;
 
 impl RustGenerator {
     /// Main expression dispatcher — routes each expression type to its handler.
+    // Bound: SWC AST is finite; recursion depth ≤ AST depth (Rule 1, POWER_OF_TEN.md).
     pub fn convert_expr(&self, expr: &Expr) -> TokenStream {
         match expr {
             Expr::Bin(bin) => self.convert_bin_expr(bin),

--- a/crates/tyrus_codegen/src/convert/stmt/loops.rs
+++ b/crates/tyrus_codegen/src/convert/stmt/loops.rs
@@ -39,6 +39,7 @@ fn ensure_block(stmt: &Stmt, tokens: TokenStream) -> TokenStream {
 }
 
 impl RustGenerator {
+    // Bound: SWC AST is finite; recursion depth ≤ AST depth (Rule 1, POWER_OF_TEN.md).
     pub(crate) fn convert_while_stmt(&self, while_stmt: &WhileStmt) -> TokenStream {
         let test = self.convert_expr(&while_stmt.test);
         let body = self.convert_stmt(&while_stmt.body);
@@ -46,6 +47,7 @@ impl RustGenerator {
         quote! { while #test #body_block }
     }
 
+    // Bound: SWC AST is finite; recursion depth ≤ AST depth (Rule 1, POWER_OF_TEN.md).
     pub(crate) fn convert_for_of_stmt(&self, for_of: &ForOfStmt) -> TokenStream {
         let body = self.convert_stmt(&for_of.body);
         let right = self.convert_expr(&for_of.right);
@@ -54,6 +56,7 @@ impl RustGenerator {
         quote! { for #var_ident in #right #body_block }
     }
 
+    // Bound: SWC AST is finite; recursion depth ≤ AST depth (Rule 1, POWER_OF_TEN.md).
     pub(crate) fn convert_for_in_stmt(&self, for_in: &ForInStmt) -> TokenStream {
         let body = self.convert_stmt(&for_in.body);
         let right = self.convert_expr(&for_in.right);
@@ -62,6 +65,7 @@ impl RustGenerator {
         quote! { for #var_ident in #right.keys() #body_block }
     }
 
+    // Bound: SWC AST is finite; recursion depth ≤ AST depth (Rule 1, POWER_OF_TEN.md).
     pub(crate) fn convert_for_stmt(&self, for_stmt: &ForStmt) -> TokenStream {
         let init = match &for_stmt.init {
             Some(swc_ecma_ast::VarDeclOrExpr::VarDecl(var_decl)) => {
@@ -106,6 +110,7 @@ impl RustGenerator {
         }
     }
 
+    // Bound: SWC AST is finite; recursion depth ≤ AST depth (Rule 1, POWER_OF_TEN.md).
     pub(crate) fn convert_do_while_stmt(&self, do_while: &DoWhileStmt) -> TokenStream {
         let test = self.convert_expr(&do_while.test);
         let body = self.convert_stmt(&do_while.body);

--- a/crates/tyrus_codegen/src/convert/stmt/mod.rs
+++ b/crates/tyrus_codegen/src/convert/stmt/mod.rs
@@ -31,6 +31,7 @@ fn nestjs_exception_to_app_error(class_name: &str) -> Option<&'static str> {
 impl RustGenerator {
     /// Recursively convert statements with a custom return handler.
     /// Used by process_fn_decl to inject Result wrapping for async functions.
+    // Bound: SWC AST is finite; recursion depth ≤ AST depth (Rule 1, POWER_OF_TEN.md).
     pub fn convert_stmt_recursive<F>(&self, stmt: &Stmt, return_handler: &mut F) -> TokenStream
     where
         F: FnMut(&swc_ecma_ast::ReturnStmt) -> TokenStream,
@@ -73,6 +74,7 @@ impl RustGenerator {
     }
 
     /// Convert a single TypeScript statement to Rust tokens.
+    // Bound: SWC AST is finite; recursion depth ≤ AST depth (Rule 1, POWER_OF_TEN.md).
     pub fn convert_stmt(&self, stmt: &Stmt) -> TokenStream {
         match stmt {
             Stmt::Return(ret_stmt) => {


### PR DESCRIPTION
## Summary

Closes #151. Adds Rule 1 (POWER_OF_TEN.md) bound-justifying comments to 11 recursive sites in `tyrus_codegen`.

Each function that recurses into a strict syntactic sub-term of the SWC AST now carries a uniform comment:

```rust
// Bound: SWC AST is finite; recursion depth ≤ AST depth (Rule 1, POWER_OF_TEN.md).
```

The bound is documentation-only — recursion is *de facto* safe because all recursion descends into AST sub-terms and SWC ASTs from valid TS input are finite-depth. The uniform wording enables a future advisory gate (`gate_recursion_audit`) to grep for `Bound: SWC AST is finite`.

## Sites annotated

- `convert_expr` (`expr/mod.rs`)
- `convert_stmt`, `convert_stmt_recursive` (`stmt/mod.rs`)
- `convert_while_stmt`, `convert_for_of_stmt`, `convert_for_in_stmt`, `convert_for_stmt`, `convert_do_while_stmt` (`stmt/loops.rs`)
- `convert_bin_expr`, `collect_string_concat_parts` (`expr/binary.rs`)
- `convert_call_expr` (`expr/call.rs`)

## Compliance

- **Rule 1** ✅ — bound comment satisfies condition (b) of the rule.
- **Rule 4** ✅ — no function size change.
- **Rule 5** ✅ — N/A (no codegen behavior change).
- **Rule 9** ✅ — `./scripts/gates.sh all` verde local antes do push.
- **Rule 11** ✅ — branch única, conventional commits.

## Test plan

- [x] `./scripts/gates.sh all` verde local (fmt + clippy + test 248/248 + deny + audit)
- [ ] CI verde
- [ ] Reviewer audit

Origem: [`.claude/plan/audit-2026-05-03-results.md`](.claude/plan/audit-2026-05-03-results.md), Sprint 1 PR1/4.
