### PR TITLE
docs(repo): justify #[allow(...)] overrides (#156)

### DIFF
--- a/crates/tyrus_analyzer/src/severity.rs
+++ b/crates/tyrus_analyzer/src/severity.rs
@@ -47,6 +47,8 @@ impl Diagnostic {
         }
     }
 
+    // Why allowed: API surface companion to Self::error / Self::warning.
+    // Kept public for future Info-level diagnostics; no callers yet.
     #[allow(dead_code)]
     pub fn info(code: &str, message: &str) -> Self {
         Self {

--- a/crates/tyrus_cli/src/ui/mod.rs
+++ b/crates/tyrus_cli/src/ui/mod.rs
@@ -1,4 +1,6 @@
 pub(crate) mod banner;
+// Why allowed: colors module exposes a complete palette; some constants are
+// reserved for upcoming banner/diagnostic surfaces (severity tiers, branding).
 #[allow(dead_code)]
 pub(crate) mod colors;
 pub(crate) mod progress;

--- a/crates/tyrus_cli/src/ui/progress.rs
+++ b/crates/tyrus_cli/src/ui/progress.rs
@@ -45,6 +45,9 @@ impl Pipeline {
     }
 }
 
+// Why allowed: spinner helper exported for the upcoming parallel-task
+// progress surface. Sibling of progress() / success() / failure(); removing
+// would force re-introducing it on first user of indeterminate progress.
 #[allow(dead_code)]
 pub(crate) fn spinner(msg: &str) -> ProgressBar {
     let pb = ProgressBar::new_spinner();

--- a/crates/tyrus_codegen/src/convert/class/routing.rs
+++ b/crates/tyrus_codegen/src/convert/class/routing.rs
@@ -271,6 +271,11 @@ impl RustGenerator {
 
     /// Emits controller-specific code: `FromRequestParts` impl, router method,
     /// and records the controller metadata.
+    // Why allowed: Axum router emission threads multiple unrelated context
+    // inputs (struct ident, class metadata, controller info, route table,
+    // impl-items accumulator). Rule 4 trade-off explicitly acknowledged;
+    // refactor to a `RoutingCtx` struct is tracked in #153 (file split of
+    // routing.rs). Until then, the override is the smaller compromise.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn emit_controller_routing(
         &mut self,

--- a/crates/tyrus_codegen/src/convert/type_mapper.rs
+++ b/crates/tyrus_codegen/src/convert/type_mapper.rs
@@ -128,6 +128,8 @@ fn map_type_core(ts_type: &TsType) -> TokenStream {
 }
 
 /// Maps TypeScript types to Rust types from an optional type annotation.
+// Why allowed: signature mirrors SWC's typed AST shape (`Option<&Box<TsTypeAnn>>`).
+// Relaxing to `Option<&TsTypeAnn>` would force every call site to unwrap the Box.
 #[allow(clippy::borrowed_box)]
 pub fn map_ts_type(type_ann: Option<&Box<TsTypeAnn>>) -> TokenStream {
     if let Some(type_ann) = type_ann {
@@ -138,6 +140,8 @@ pub fn map_ts_type(type_ann: Option<&Box<TsTypeAnn>>) -> TokenStream {
 }
 
 /// Unwraps Promise<T> to T for async function return types
+// Why allowed: same SWC-shaped signature as map_ts_type above; relaxing forces
+// Box-unwrapping at every call site.
 #[allow(clippy::borrowed_box)]
 pub fn unwrap_promise_type(type_ann: Option<&Box<TsTypeAnn>>) -> TokenStream {
     if let Some(type_ann) = type_ann {

--- a/tests/src/cli.rs
+++ b/tests/src/cli.rs
@@ -9,6 +9,9 @@ fn workspace_root() -> &'static Path {
 }
 
 fn tyrus_cmd() -> Command {
+    // Why allowed: `assert_cmd` 2.x deprecates `Command::cargo_bin` but the
+    // suggested replacement (`cargo_bin_str`) is not yet stable on our pinned
+    // version. Test-only call; migration tracked alongside `assert_cmd` bump.
     #[allow(deprecated)]
     let mut cmd = Command::cargo_bin("tyrus").expect("tyrus binary not found");
     cmd.current_dir(workspace_root());


### PR DESCRIPTION
## Summary

Closes #156. Adds `// Why allowed: ...` justifications to 7 `#[allow(...)]` overrides per Rule 12 (POWER_OF_TEN.md).

Each override now carries 1-2 lines explaining the intent. Per the issue's spec, this PR uses **option (a)** (justification) for all 7 sites — including `routing.rs:274`. Option (b) (refactor `emit_controller_routing` to a `RoutingCtx` struct) is intentionally deferred to issue #153 (file split of `routing.rs`), per Rule 11 (One-Branch=One-Concern).

## Sites annotated

| File:Line | Override | Rationale |
|---|---|---|
| `crates/tyrus_analyzer/src/severity.rs:50` | `dead_code` | Companion of `Self::error`/`Self::warning`; reserved for Info-level diagnostics |
| `crates/tyrus_codegen/src/convert/class/routing.rs:274` | `clippy::too_many_arguments` | **Rule 4 trade-off acknowledged**; refactor to `RoutingCtx` tracked in #153 |
| `crates/tyrus_cli/src/ui/progress.rs:48` | `dead_code` | Spinner helper for upcoming parallel-task progress surface |
| `crates/tyrus_codegen/src/convert/type_mapper.rs:131` | `clippy::borrowed_box` | Mirrors SWC AST shape `Option<&Box<TsTypeAnn>>` |
| `crates/tyrus_codegen/src/convert/type_mapper.rs:141` | `clippy::borrowed_box` | Same SWC-shape rationale (paired fn) |
| `crates/tyrus_cli/src/ui/mod.rs:2` | `dead_code` | Color palette reserved for future banner/diagnostic surfaces |
| `tests/src/cli.rs:12` | `deprecated` | `assert_cmd::Command::cargo_bin` deprecation; test-only call, migration tracked separately |

## Compliance

- **Rule 12** ✅ — every `#[allow]` carries a justification
- **Rule 4** ✅ — no new function size violations; `routing.rs:274` trade-off explicit
- **Rule 5** ✅ — N/A (no codegen behavior change)
- **Rule 9** ✅ — `./scripts/gates.sh all` verde local antes do push
- **Rule 11** ✅ — branch única, conventional commits

## Test plan

- [x] `./scripts/gates.sh all` verde local (fmt + clippy + test 248/248 + deny + audit)
- [ ] CI verde
- [ ] Reviewer audit

Origem: [`.claude/plan/audit-2026-05-03-results.md`](.claude/plan/audit-2026-05-03-results.md), Sprint 1 PR2/4.
