### PR TITLE
docs(adr): backfill ADRs 0009-0011 for retroactive decisions (#155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Documentation
+
+- **ADR 0009 — Mutex Re-entrance Protocol.** Backfill for PR #141. Documents the block-scoped read pattern and read-then-write split used in generated `@Injectable` state-field code.
+- **ADR 0010 — Formatter Contract.** Backfill for PR #142. Specifies idempotence, error-propagation, and no-bypass guarantees for `tyrus_orchestrator::format::format_code`.
+- **ADR 0011 — Supply-Chain Hygiene Policy.** Backfill for PR #126. Numbered policies for license allowlist, advisory ignore list, dependabot grouping, and CODEOWNERS.
+- **POWER_OF_TEN.md Rule 10** — added backfill footnote referencing ADRs 0009/0010/0011.
+- **ARCHITECTURE.md** — new "Architectural Decision Records" index section.
+
 ## [0.1.0] — 2026-05-02
 
 ### Added — Decorator Registry (Caminho C, ADR 0007)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -187,8 +187,27 @@ The project enforces strict correctness via:
 
 - **`.cargo/config.toml`:** `-Dwarnings` plus `clippy::unwrap_used`, `clippy::expect_used`, `clippy::panic`, `clippy::todo`, `clippy::unimplemented` as hard errors.
 - **`clippy.toml`:** Cognitive complexity threshold 15, function lines threshold 50, max 5 parameters.
-- **`deny.toml`:** Dependency license and security audit via `cargo-deny`.
+- **`deny.toml`:** Dependency license and security audit via `cargo-deny` (see [ADR 0011](architecture/decisions/0011-supply-chain-hygiene.md)).
 - **CI:** GitHub Actions with `actions/checkout@v4`, `Swatinem/rust-cache@v2`, `cargo nextest`, and end-to-end demo compilation verification.
+
+---
+
+## Architectural Decision Records
+
+Numbered ADRs under [`docs/architecture/decisions/`](architecture/decisions/) are the binding record of architectural choices. Most-recent-first:
+
+- [ADR 0011 — Supply-Chain Hygiene Policy](architecture/decisions/0011-supply-chain-hygiene.md) — license allowlist, advisory ignore list, dependabot grouping, CODEOWNERS (PR #126 backfill).
+- [ADR 0010 — Formatter Contract](architecture/decisions/0010-formatter-contract.md) — idempotence, error-propagation, no-bypass guarantees for `tyrus_orchestrator::format` (PR #142 backfill).
+- [ADR 0009 — Mutex Re-entrance Protocol](architecture/decisions/0009-mutex-re-entrance-protocol.md) — block-scoped read + read-then-write split for `@Injectable` state fields (PR #141 backfill).
+- [ADR 0008 — Tyrus Strict Rules (Power of Ten)](architecture/decisions/0008-tyrus-strict-rules.md) — adoption of the 12-rule contribution standard.
+- [ADR 0007 — Decorator Registry](architecture/decisions/0007-decorator-registry.md) — trait-based handler registry replacing scattered string-compare match arms.
+- [ADR 0006 — Safe Transpilation Infrastructure](architecture/decisions/0006-safe-transpilation-infrastructure.md)
+- [ADR 0005 — Codegen Module Decomposition](architecture/decisions/0005-codegen-module-decomposition.md)
+- [ADR 0004 — NestJS to Axum Mapping](architecture/decisions/0004-nestjs-to-axum.md)
+- [ADR 0003 — Generics Mapping](architecture/decisions/0003-generics-mapping.md)
+- [ADR 0002 — Async Transpilation](architecture/decisions/0002-async-transpilation.md)
+- [ADR 0001 — Stack and Monorepo](architecture/decisions/0001-stack-and-monorepo.md)
+- [ADR 0000 — Use Markdown ADR](architecture/decisions/0000-use-markdown-adr.md)
 
 ---
 

--- a/docs/architecture/decisions/0009-mutex-re-entrance-protocol.md
+++ b/docs/architecture/decisions/0009-mutex-re-entrance-protocol.md
@@ -1,0 +1,75 @@
+# 9. Mutex Re-entrance Protocol for Generated `@Injectable` State
+
+Date: 2026-05-03
+Status: Accepted (retroactive — backfill of PR #141)
+
+## Context
+
+`std::sync::Mutex` is **non-reentrant**: a second `.lock()` call from the same thread while a guard is alive deadlocks. Tyrus emits NestJS `@Injectable` services where private fields become `Arc<Mutex<T>>`-wrapped state. Two patterns in pre-PR-#141 codegen triggered the deadlock:
+
+1. **Compound assigns on state fields.** `this.counter += 1` (and `-=`/`*=`/`/=`/`%=`/bitwise/shift) silently mis-compiled because the `StateField` write branch ignored the binary operator and emitted a plain `=`. Even when the codegen *did* route through a read-then-write split, the read guard and the write guard were both alive across the assign expression — second `.lock()` deadlocked.
+
+2. **Dual reads in one statement.** `User { id: this.x, count: this.x }` and `Math.max(this.x, this.x)` kept two `MutexGuard` temporaries alive until the enclosing statement's terminating `;` — Rust's drop semantics would only release them at end-of-statement, not at the consuming expression. The second `.lock()` blocked indefinitely.
+
+Both bugs surfaced under realistic NestJS workloads (counters, rate limiters, dashboards). Neither was caught by snapshot tests because the generated Rust *compiled*; only at runtime, on the second invocation of the controller method, did the worker thread hang.
+
+PR #141 (`b5af050`) closed both bugs by establishing a uniform emission protocol. This ADR documents that protocol so future contributors — particularly anyone implementing #143 (atomic state fields) or revisiting `convert/expr/member.rs` / `convert/expr/misc.rs` — know the invariants are load-bearing, not incidental.
+
+## Decision
+
+Generated Rust for `@Injectable` state fields obeys two emission patterns. Both are implemented in `crates/tyrus_codegen/src/convert/expr/`:
+
+### Pattern A — Block-scoped read
+
+Every read of `this.field` where `field` is a state-field expands to:
+
+```rust
+{ let __g = self.field.lock().unwrap(); *__g }
+```
+
+(or `.clone()` for non-`Copy` payloads). The guard `__g` is bound in an **inner block**, so Rust's drop scope ends at the closing `}` of that block — *before* the consuming expression evaluates the next subexpression. Two reads in the same statement therefore release each guard between reads.
+
+This is implemented in `convert_this_member` and propagated through `convert_member_expr` for every `Expr::Member` whose object resolves to `self` and whose property is registered in `current_class_state_fields`.
+
+### Pattern B — Read-then-write split for compound writes
+
+Compound assignments and update expressions (`+=`, `-=`, `*=`, `/=`, `%=`, `&=`, `|=`, `^=`, `<<=`, `>>=`, prefix/postfix `++`/`--`) on state fields expand into two statements:
+
+```rust
+let __cur = { let __g = self.field.lock().unwrap(); *__g };
+let __new = __cur <op> rhs;
+{ let mut __g = self.field.lock().unwrap(); *__g = __new; }
+```
+
+The read guard drops at the `;` of its own `let`. The write guard drops at the `;` of the assign block. The operator is preserved (no silent reduction to `=`). Update expressions (`this.x++`) route through the same helper (`emit_state_field_assign`) for uniform semantics.
+
+### Invariant
+
+For any generated function body emitted from a `&mut self` method on an `@Injectable` class, **at most one `MutexGuard` for any given state field is alive at any program point**. The compiler does not enforce this — codegen does. Any new emission path that touches state fields **must** route through the existing helpers (`emit_state_field_read`, `emit_state_field_assign`) or replicate the patterns above explicitly.
+
+## Consequences
+
+### Positive
+
+- **Deadlock-free under realistic workloads.** The two failure patterns that triggered #141 are architecturally impossible under the protocol.
+- **Predictable mental model.** "Each read = one guard, dropped at end of inner block. Each write = read-block then write-block." Reviewers do not need to reason about `MutexGuard` drop order across complex expressions.
+- **Forward compatibility.** When #143 lands atomic state fields (`AtomicU64` etc.), the `emit_state_field_*` helpers are the single substitution point — no code outside them needs revision.
+
+### Negative
+
+- **Slight overhead.** Every state-field read costs a block scope and a deref vs the naive `self.field.lock().unwrap().clone()`. In practice negligible (the same guard acquisition is the dominant cost). Atomic state (#143) eliminates the overhead for `Copy` payloads.
+- **Snapshot churn.** PR #141 updated the tier4 NestJS controller and injectable-service snapshots to the guarded-block form. Future codegen tweaks affecting state reads will keep producing snapshot diffs.
+- **Codegen complexity.** The path from `Expr::Member { obj: This, prop: Ident }` to emitted tokens passes through three helpers and one tracked HashSet (`current_class_state_fields`). Anyone adding a new mutating expression (e.g., a hypothetical `Math.atomic_add`) must explicitly handle the state-field branch.
+
+## Alternatives rejected
+
+- **`parking_lot::ReentrantMutex`.** Would lift the constraint at the cost of (a) extra dependency in every generated `Cargo.toml`, (b) loss of `Send + Sync` guarantees that NestJS `@Injectable` services rely on for axum's `with_state`, (c) silent acceptance of recursive locking — exactly the pattern Rule 1 (bounded control flow) discourages. Rejected.
+- **Skip-on-error pattern (`if let Ok(g) = self.field.try_lock())`.** Trades deadlock for silent data corruption (lost writes). Worse outcome. Rejected.
+- **Compile-time check via macro (`#[state]`).** Would require a procedural macro on every generated field. Adds a build dependency and a parsing step we control end-to-end via codegen. The codegen-side discipline is the simpler enforcement. Rejected for now; revisitable if user-authored Rust ever needs the same protection.
+
+## References
+
+- Originating PR: [#141](https://github.com/Gefferson-Souza/Tyrus/pull/141) (`b5af050`) — `fix(codegen): prevent mutex re-entrance on compound assigns and dual reads`. Closes #129.
+- Implementation: `crates/tyrus_codegen/src/convert/expr/member.rs`, `crates/tyrus_codegen/src/convert/expr/misc.rs`.
+- Regression tests: `tests/src/unit/state_mutation.rs` (8 tests).
+- Related: ADR 0008 (Tyrus Strict Rules — this ADR satisfies Rule 10's retroactive requirement); future ADR for #143 (atomic state) supersedes Pattern B for `Copy` payloads.

--- a/docs/architecture/decisions/0010-formatter-contract.md
+++ b/docs/architecture/decisions/0010-formatter-contract.md
@@ -1,0 +1,73 @@
+# 10. Formatter Contract for `tyrus_orchestrator::format`
+
+Date: 2026-05-03
+Status: Accepted (retroactive — backfill of PR #142)
+
+## Context
+
+Rule 7 (POWER_OF_TEN.md) forbids string concatenation as a Rust-emission mechanism anywhere under `crates/tyrus_codegen/src/convert/`. The single allowed exception is `crates/tyrus_orchestrator/src/format.rs` — it owns formatting/layout of pre-validated source and the hard-coded `&'static str` blocks for `AppError` (`get_app_error_simple`, `get_app_error_code`).
+
+Because `format::format_code` is the **last gate** before generated `.rs` files hit disk, three properties are load-bearing:
+
+1. **Idempotence.** Running the formatter on its own output must produce the same bytes. If not, file watchers (rust-analyzer, cargo build cache) churn forever.
+2. **Error propagation.** Invalid Rust input must surface as `Err(TyrusError::FormattingError)`, not silently pass through. A historical `// formatting skipped for edition compatibility` marker once allowed unparseable code to reach disk and only fail at the next `cargo build` — losing the error attribution to codegen.
+3. **No bypass marker.** That historical fallback is forbidden in output. Any future formatter swap must enforce the same.
+
+PR #142 (`db391e6` — `test(orchestrator): add format_code regression gates for #131`) added unit tests for all three properties but did not commit a formal contract document. This ADR is that contract.
+
+## Decision
+
+`format_code(code: &str) -> Result<String, TyrusError>` in `crates/tyrus_orchestrator/src/format.rs` is **the** formatting touchpoint of the pipeline. Every emitted Rust file passes through it. The contract guarantees:
+
+### Property 1 — Idempotence
+
+For every `s: String` such that `format_code(&s)` returns `Ok(out)`, `format_code(&out)` returns `Ok(out)` (byte-equivalent). Equivalent: `format_code(format_code(s)?) == format_code(s)`.
+
+**Implementation.** Currently delegated to `prettyplease::unparse(&syn::parse_file(code)?)`. `prettyplease` is documented-stable on this property. The unit test `format_code_is_idempotent` asserts it on representative source.
+
+### Property 2 — Error propagation
+
+Invalid Rust returns `Err(TyrusError::FormattingError(String))`, where the inner string is `syn::Error::to_string()`. The error is **not** swallowed, masked, or downgraded. Callers (`tyrus_orchestrator::pipeline::*`) propagate `Err` up to the CLI, which surfaces it as a build failure with the offending crate identified.
+
+The unit test `format_code_propagates_parse_errors` asserts this on deliberately malformed input.
+
+### Property 3 — No bypass marker
+
+The string `// formatting skipped` (or any variant) **must not appear** in output. The historical `format_code` had a fallback that, on `syn::Error`, returned the input verbatim with this marker prepended. That fallback is removed. The unit test `format_code_handles_async_without_bypass` asserts that valid `async fn` source — which once tripped the fallback — now formats normally.
+
+### Substitution clause
+
+A future formatter swap (`rustfmt-nightly`, custom AST printer, etc.) is allowed only if the replacement preserves all three properties. The substitution must include:
+
+- All three regression tests still pass byte-for-byte.
+- `format_code` signature unchanged.
+- Workspace `Cargo.toml` dependency updated atomically with the implementation.
+
+A swap that breaks any property is a Rule 7 violation regardless of intent.
+
+## Consequences
+
+### Positive
+
+- **Pipeline integrity.** The "compile failure" → "formatter masks it" → "build failure attributed to wrong crate" failure mode is architecturally closed. Errors surface at the layer that produced them.
+- **Cache correctness.** Idempotent output keeps file mtimes stable across re-emissions, so Cargo's incremental compilation is not invalidated by pure-formatting churn.
+- **Reviewable formatter swaps.** The contract gives a checklist for any future formatter substitution — the conversation is "does it preserve the three properties?" not "is the new formatter generally good?".
+
+### Negative
+
+- **Locks in `prettyplease` until tested otherwise.** Any formatter change has to clear the regression tests; that costs time. (Acceptable trade — the cost is bounded and the alternative is silent miscompile risk.)
+- **Test fragility on edge cases.** The regression tests cover the three properties on representative source. They do not exhaust every possible `syn`-parseable Rust expression; new edge cases will be found and added over time.
+
+## Alternatives rejected
+
+- **Treat `format_code` as a library detail with no contract.** Was the pre-#142 state. Allowed PR #142's bugs to occur in the first place. Rejected.
+- **Swap to subprocess `rustfmt`.** Adds an external-tool dependency, slows the pipeline by ~100× on small files, requires Rust toolchain in any deployment environment. Rejected.
+- **Skip formatting in optimised builds and emit raw `quote!` output.** Loses readability of generated code; makes emitted `.rs` files unreviewable in PRs and unusable for users inspecting Tyrus output. Rejected.
+- **Custom AST printer.** Would re-implement what `prettyplease` already does correctly. ~2,000 LOC of net-new code, perpetual maintenance, with zero behavioural improvement over `prettyplease`. Rejected.
+
+## References
+
+- Originating PR: [#142](https://github.com/Gefferson-Souza/Tyrus/pull/142) (`db391e6`) — `test(orchestrator): add format_code regression gates for #131`.
+- Implementation: `crates/tyrus_orchestrator/src/format.rs`.
+- Regression tests: `format::tests::format_code_is_idempotent`, `format::tests::format_code_propagates_parse_errors`, `format::tests::format_code_handles_async_without_bypass`.
+- Related: Rule 7 (POWER_OF_TEN.md), ADR 0008.

--- a/docs/architecture/decisions/0011-supply-chain-hygiene.md
+++ b/docs/architecture/decisions/0011-supply-chain-hygiene.md
@@ -1,0 +1,92 @@
+# 11. Supply-Chain Hygiene Policy
+
+Date: 2026-05-03
+Status: Accepted (retroactive — backfill of PR #126)
+
+## Context
+
+PR #126 (`dfae3f2` — `chore(ci): hardening`) introduced four supply-chain controls in a single bundled commit:
+
+1. `cargo deny` configuration (`deny.toml`, schema v2) — license allowlist + advisory ignore list + duplicate-version policy.
+2. `cargo audit` integration in `scripts/gates.sh` — RustSec advisory database scan with explicit `--ignore` for triaged advisories.
+3. `dependabot.yml` — weekly grouped updates for `cargo`, `github-actions`, `npm`.
+4. `CODEOWNERS` — review approval routing.
+
+Each control is a distinct policy choice. Bundling them violated Rule 11 (one branch = one concern) — a fact this ADR explicitly acknowledges. The retroactive ADR repays the documentation debt by re-stating each policy as a numbered decision with rationale, so future revisions can target individual policies without re-deriving the bundle's intent from PR diff archaeology.
+
+## Decision
+
+Tyrus enforces supply-chain hygiene through four numbered policies.
+
+### Policy 1 — License allowlist
+
+Allowed SPDX identifiers (`deny.toml [licenses].allow`):
+
+```
+MIT, Apache-2.0, Apache-2.0 WITH LLVM-exception,
+BSD-2-Clause, BSD-3-Clause, ISC,
+Unicode-3.0, Unicode-DFS-2016,
+OpenSSL, Zlib, BSL-1.0, CC0-1.0, MPL-2.0
+```
+
+Rationale: covers the long-tail of permissive licenses present in the Rust ecosystem (notably `unicode-ident`, `ring`, `webpki-roots`) without admitting copyleft-with-derivatives risks. `confidence-threshold = 0.8` rejects ambiguous SPDX matches. New licenses require an ADR addendum, not a silent `deny.toml` edit.
+
+### Policy 2 — Advisory ignore list
+
+`cargo deny` and `cargo audit` ignore the following RustSec advisories pending follow-up:
+
+| Advisory | Crate | Reason | Resolution |
+|---|---|---|---|
+| `RUSTSEC-2025-0119` | `number_prefix` (transitive via `indicatif`) | Unmaintained marker, not a vulnerability | Resolves once `indicatif` drops the dep |
+| `RUSTSEC-2026-0097` | `rand` | Soundness gap only with custom `CryptoRng` + specific logger pattern we never construct | Resolves on `rand ≥ 0.9` upgrade |
+
+The list is duplicated between `deny.toml` (`[advisories].ignore`) and `scripts/gates.sh` (`gate_audit` — `cargo audit --ignore ...`). The duplication is intentional: `cargo-audit` does not read `deny.toml`. **Both lists must stay in sync** — they are the project's two-place source of triaged advisories. Issue #128 tracks both lists for upgrade.
+
+Adding an entry requires: (a) a comment explaining the analysis, (b) a tracking issue or this ADR, (c) a planned upgrade path (not "indefinitely ignored"). Zero-justification ignores are forbidden.
+
+### Policy 3 — Dependabot grouping
+
+`dependabot.yml` groups updates to reduce PR noise:
+
+- **`cargo`** ecosystem — weekly schedule, all path-internal cargo deps grouped, all external cargo deps grouped separately.
+- **`github-actions`** — weekly, single group.
+- **`npm`** (test fixtures only) — weekly, single group.
+
+Rationale: ungrouped Dependabot floods with one PR per dep per week, masking semver-incompatible bumps in noise. Grouping cuts review surface ~10×. CI re-runs catch the regressions; the grouping is review-side, not gate-side.
+
+### Policy 4 — CODEOWNERS membership
+
+`CODEOWNERS` routes review approval per path:
+
+- Root + `docs/standards/` + `docs/architecture/decisions/` → maintainer (current solo).
+- Per-crate ownership inherits from root until a contributor demonstrates sustained ownership of a crate (≥ 3 reviewed PRs, ≥ 6 months active).
+
+Rationale: as Tyrus accepts ML-agent and external contributions, gated review is the simplest enforcement of the strict rules. CODEOWNERS membership is itself an architectural decision (who can sign off on architectural changes) and changes via separate ADR.
+
+## Consequences
+
+### Positive
+
+- **Numbered, citable policies.** Each future advisory triage / license addition / membership change has a specific section to amend, not an opaque bundle.
+- **Audit trail.** Future contributors see *why* `RUSTSEC-2026-0097` is ignored without re-reading PR diffs.
+- **Drift prevention.** The "two-place advisory list" gotcha (deny.toml ↔ gates.sh) is documented; future contributors are unlikely to update one and forget the other.
+
+### Negative
+
+- **No structural enforcement of "lists in sync".** A discipline failure can still let `deny.toml` and `gates.sh` drift. A future advisory test (`gate_audit_drift_check`) would close this; tracked as follow-up.
+- **Solo maintainer until contributor base grows.** CODEOWNERS effectively routes everything to one person today. Once a second crate-owner exists, CODEOWNERS is the substitution point.
+- **Rule 11 violation acknowledged but not mended.** PR #126 was bundled; this ADR documents the bundling as a known historical exception. Future bundled-policy PRs are still forbidden — the precedent is documentation-only, not licence-to-bundle.
+
+## Alternatives rejected
+
+- **Wildcard license allow (`allow = ["*"]` or removing `deny.toml`).** Loses the audit trail. Allows GPL-like licenses without review. Rejected.
+- **Per-crate audit-only (drop `cargo deny`).** `cargo audit` covers vulnerabilities but not licenses, sources, or duplicate versions. Halves the coverage. Rejected.
+- **Disable Dependabot.** Trade automated-but-noisy patches for manual-only patches → security advisories sit unfixed for weeks. Rejected.
+- **No CODEOWNERS, allow free-for-all merges.** Inconsistent with strict-rule enforcement; a single maintainer cannot police every PR by skim. CODEOWNERS is the cheapest gate. Rejected.
+
+## References
+
+- Originating PR: [#126](https://github.com/Gefferson-Souza/Tyrus/pull/126) (`dfae3f2`) — `chore(ci): hardening`.
+- Configurations: `deny.toml`, `scripts/gates.sh` (`gate_deny`, `gate_audit`), `.github/dependabot.yml`, `CODEOWNERS`.
+- Tracking: issue #128 (advisory upgrade plan).
+- Related: Rule 11 (POWER_OF_TEN.md — bundling acknowledged); Rule 12 (warnings-clean / daily audited).

--- a/docs/standards/POWER_OF_TEN.md
+++ b/docs/standards/POWER_OF_TEN.md
@@ -159,6 +159,8 @@ cargo audit --deny warnings
 
 **Severity.** HIGH.
 
+> **Backfill 2026-05-03.** The `audit-2026-05-03` review identified three retroactive ADR gaps (PRs #126, #141, #142). Backfilled by ADRs [0009](../architecture/decisions/0009-mutex-re-entrance-protocol.md) (Mutex Protocol), [0010](../architecture/decisions/0010-formatter-contract.md) (Formatter Contract), [0011](../architecture/decisions/0011-supply-chain-hygiene.md) (Supply-Chain Hygiene). Going forward, ADRs are written *before* the implementation PR per this rule, not after.
+
 ---
 
 ### Rule 11 — One Branch = One Concern


### PR DESCRIPTION
## Summary

Closes #155. Backfills three retroactive ADRs to close Rule 10 (POWER_OF_TEN.md) gaps identified in the 2026-05-03 audit.

## ADRs created

| ADR | Title | Origin PR |
|---|---|---|
| [0009](docs/architecture/decisions/0009-mutex-re-entrance-protocol.md) | Mutex Re-entrance Protocol | [#141](https://github.com/Gefferson-Souza/Tyrus/pull/141) (`b5af050`) |
| [0010](docs/architecture/decisions/0010-formatter-contract.md) | Formatter Contract | [#142](https://github.com/Gefferson-Souza/Tyrus/pull/142) (`db391e6`) |
| [0011](docs/architecture/decisions/0011-supply-chain-hygiene.md) | Supply-Chain Hygiene Policy | [#126](https://github.com/Gefferson-Souza/Tyrus/pull/126) (`dfae3f2`) |

Each ADR follows the established template (Status, Context, Decision, Consequences, Alternatives) and explicitly carries `Status: Accepted (retroactive — backfill of PR #NNN)`.

## Cross-refs added

- **`docs/ARCHITECTURE.md`** — new "Architectural Decision Records" index section listing all ADRs (most-recent-first).
- **`docs/standards/POWER_OF_TEN.md`** — Rule 10 footnote acknowledging the 2026-05-03 backfill and re-affirming "ADRs before implementation PR" going forward.
- **`CHANGELOG.md`** — `[Unreleased] / Documentation` entries for each ADR + cross-ref updates.

## Compliance

- **Rule 10** ✅ — three retroactive ADRs close the gap identified in the audit.
- **Rule 11** ✅ — single concern (ADR backfill), Conventional Commits.
- **Rule 9** ✅ — `./scripts/gates.sh all` verde local antes do push.

## Test plan

- [x] `./scripts/gates.sh all` verde local (fmt + clippy + test 248/248 + deny + audit)
- [ ] CI verde
- [ ] Architect/Reviewer audit on ADR accuracy

Origem: [`.claude/plan/audit-2026-05-03-results.md`](.claude/plan/audit-2026-05-03-results.md), Sprint 1 PR3/4.
