### PR TITLE
ci(gates): add cargo-llvm-cov 73% coverage enforcement (#150)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,42 @@ jobs:
           ./target/debug/tyrus build examples/real_world_demo/src --output examples/real_world_demo/output
           cd examples/real_world_demo/output && cargo check
 
+  # Coverage — Rule 5 (POWER_OF_TEN.md) enforcement via cargo-llvm-cov.
+  # Runs in parallel with `bench` after `build` succeeds. Workspace line
+  # coverage must stay at or above the threshold configured in
+  # `scripts/gates.sh::gate_coverage` (default 80%, override via
+  # TYRUS_COVERAGE_MIN). The coverage gate ignores test/bench infra so the
+  # denominator only counts product code.
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Setup Node.js 22 (for semantic equivalence tests)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install cargo-llvm-cov and nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov,cargo-nextest
+
+      - name: Run coverage gate (gates.sh)
+        run: ./scripts/gates.sh coverage
+        env:
+          # Initial threshold = 2026-05-03 baseline floor (73.61% rounded
+          # down to 73). Ramp-up to 80 tracked with the Sprint 3
+          # equivalence-test work (#154); raise this number in the PR
+          # that closes the gap.
+          TYRUS_COVERAGE_MIN: '73'
+
   # Benchmarks — run after tests pass, upload criterion HTML reports
   bench:
     name: Benchmarks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,15 +38,36 @@ We use [Conventional Commits](https://www.conventionalcommits.org/).
 ## 🚀 Pull Request Process
 
 1.  Create a branch complying with the strategy above.
-2.  Ensure tests pass locally: `cargo nextest run --workspace`
-3.  Run the full clippy suite and fix all warnings:
+2.  Run **all** local gates (single command — same script CI runs):
     ```bash
-    cargo clippy --workspace -- -D warnings -W clippy::unwrap_used -W clippy::expect_used -W clippy::panic
+    ./scripts/gates.sh all
     ```
-4.  Run formatter: `cargo fmt -- --check`
-5.  Open a PR to `main`.
-6.  Fill out the **PR Template** completely.
-7.  Wait for CI checks to pass and request review.
+    This covers fmt, clippy, tests, coverage (≥ 80%), `cargo deny`, and `cargo audit`. See `docs/standards/POWER_OF_TEN.md` Rule 9 (Local-First Validation Parity).
+3.  Open a PR to `main`.
+4.  Fill out the **PR Template** completely.
+5.  Wait for CI checks to pass and request review.
+
+### Local coverage check (Rule 5)
+
+The `coverage` gate uses `cargo-llvm-cov` to enforce the workspace line-coverage threshold. The current default is **73%** (the 2026-05-03 baseline floor); ramp-up to 80% is tracked with the equivalence-test sprint (#154).
+
+Install once:
+
+```bash
+cargo install cargo-llvm-cov
+```
+
+Then run on demand:
+
+```bash
+./scripts/gates.sh coverage                          # uses default 73% threshold
+TYRUS_COVERAGE_MIN=80 ./scripts/gates.sh coverage    # one-off stricter check
+TYRUS_SKIP_COVERAGE=1 ./scripts/gates.sh all         # skip in slow paths only
+```
+
+Test infrastructure (`tests/`, `crates/*/test_utils`, `crates/*/benches`) is excluded from the denominator so the threshold reflects product code coverage only.
+
+Internally, `gate_coverage` runs as four steps (`clean` → `run --bin tyrus` → `nextest --workspace` → `report`) because CLI integration tests under `tests/src/cli.rs` use `assert_cmd::cargo_bin("tyrus")` and need the binary present inside the llvm-cov target dir.
 
 ## 🧪 Test Infrastructure
 

--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -10,17 +10,20 @@
 # mandates this single-source design. Adopted via ADR 0008.
 #
 # Usage:
-#   ./scripts/gates.sh           # run all gates
-#   ./scripts/gates.sh all       # same as above
-#   ./scripts/gates.sh fmt       # cargo fmt --check
-#   ./scripts/gates.sh clippy    # cargo clippy --workspace --all-targets -D warnings
-#   ./scripts/gates.sh test      # cargo nextest run --workspace --all-targets
-#   ./scripts/gates.sh deny      # cargo deny check
-#   ./scripts/gates.sh audit     # cargo audit --deny warnings
+#   ./scripts/gates.sh             # run all gates
+#   ./scripts/gates.sh all         # same as above
+#   ./scripts/gates.sh fmt         # cargo fmt --check
+#   ./scripts/gates.sh clippy      # cargo clippy --workspace --all-targets -D warnings
+#   ./scripts/gates.sh test        # cargo nextest run --workspace --all-targets
+#   ./scripts/gates.sh coverage    # cargo llvm-cov nextest --workspace --fail-under-lines <threshold>
+#   ./scripts/gates.sh deny        # cargo deny check
+#   ./scripts/gates.sh audit       # cargo audit --deny warnings
 #
 # Environment variables:
-#   TYRUS_SKIP_DENY=1   Skip cargo deny check (use only when tool unavailable).
-#   TYRUS_SKIP_AUDIT=1  Skip cargo audit (use only when tool unavailable).
+#   TYRUS_SKIP_DENY=1      Skip cargo deny check (use only when tool unavailable).
+#   TYRUS_SKIP_AUDIT=1     Skip cargo audit (use only when tool unavailable).
+#   TYRUS_SKIP_COVERAGE=1  Skip cargo llvm-cov coverage check (e.g. fast pre-commit path).
+#   TYRUS_COVERAGE_MIN     Override the minimum line-coverage % (default: 80).
 #
 # Exit code: 0 on all gates pass, non-zero on first failure.
 
@@ -55,6 +58,38 @@ gate_test() {
     cargo nextest run --workspace
 }
 
+gate_coverage() {
+    if [ "${TYRUS_SKIP_COVERAGE:-0}" = "1" ]; then
+        echo "=== gate: coverage (SKIPPED via TYRUS_SKIP_COVERAGE=1) ==="
+        return 0
+    fi
+    echo "=== gate: coverage ==="
+    # Rule 5 enforcement (POWER_OF_TEN.md): workspace line coverage threshold.
+    # Threshold is configurable via TYRUS_COVERAGE_MIN (default 73, the
+    # 2026-05-03 baseline floor; ramp-up to 80 is tracked alongside the
+    # equivalence-test sprint #154). Test harness, benchmarks, and
+    # test-utils crates are excluded from the denominator — they are
+    # infrastructure, not product code.
+    #
+    # Multi-step invocation rationale: integration tests in `tests/src/cli.rs`
+    # use `assert_cmd::Command::cargo_bin("tyrus")`, which expects the
+    # `tyrus` binary inside `target/llvm-cov-target/debug/`. A plain
+    # `cargo llvm-cov nextest` builds test binaries but not the bin —
+    # CLI tests then fail with NotFoundError. Splitting the run into
+    # (1) clean profraw, (2) `--no-report run --bin tyrus` to populate
+    # the binary, (3) `--no-report nextest --workspace` for tests, and
+    # (4) a final `report` for threshold enforcement keeps both worlds
+    # consistent.
+    threshold="${TYRUS_COVERAGE_MIN:-73}"
+    cargo llvm-cov clean --workspace --profraw-only
+    cargo llvm-cov --no-report run --bin tyrus -- --version > /dev/null
+    cargo llvm-cov --no-report nextest --workspace
+    cargo llvm-cov report \
+        --fail-under-lines "$threshold" \
+        --ignore-filename-regex '^tests/|^crates/.*test_utils/|^crates/.*/benches/' \
+        --summary-only
+}
+
 gate_deny() {
     if [ "${TYRUS_SKIP_DENY:-0}" = "1" ]; then
         echo "=== gate: deny (SKIPPED via TYRUS_SKIP_DENY=1) ==="
@@ -83,15 +118,17 @@ gate_audit() {
 
 cmd="${1:-all}"
 case "$cmd" in
-    fmt)    gate_fmt ;;
-    clippy) gate_clippy ;;
-    test)   gate_test ;;
-    deny)   gate_deny ;;
-    audit)  gate_audit ;;
+    fmt)      gate_fmt ;;
+    clippy)   gate_clippy ;;
+    test)     gate_test ;;
+    coverage) gate_coverage ;;
+    deny)     gate_deny ;;
+    audit)    gate_audit ;;
     all)
         gate_fmt
         gate_clippy
         gate_test
+        gate_coverage
         gate_deny
         gate_audit
         echo ""


### PR DESCRIPTION
## Summary

Closes #150. Wires `cargo-llvm-cov` enforcement of Rule 5 (POWER_OF_TEN.md) into both `scripts/gates.sh` (single source of truth) and CI.

## Baseline

Local baseline run on `main` HEAD `9d1dc3c`:

```
TOTAL                                  73.61%         80.57%         73.92%
                                      lines          functions     regions
```

Initial threshold = **73%** (baseline floor, rounded down). Ramp-up to 80% is tracked as **issue #163** alongside the equivalence-test sprint #154.

## Changes

### `scripts/gates.sh`

- New `gate_coverage` sub-command running a multi-step workflow:
  1. `cargo llvm-cov clean --workspace --profraw-only`
  2. `cargo llvm-cov --no-report run --bin tyrus -- --version` (populates the `tyrus` binary in `target/llvm-cov-target/debug/` so CLI integration tests can find it via `assert_cmd::cargo_bin`)
  3. `cargo llvm-cov --no-report nextest --workspace`
  4. `cargo llvm-cov report --fail-under-lines $TYRUS_COVERAGE_MIN ...`
- New env vars: `TYRUS_COVERAGE_MIN` (default `73`), `TYRUS_SKIP_COVERAGE` (default `0`).
- `gates.sh all` now includes coverage between `test` and `deny`.

### `.github/workflows/ci.yml`

- New `coverage` job on Ubuntu-latest, depends on `build`. Installs `cargo-llvm-cov` and `cargo-nextest` via `taiki-e/install-action@v2`. Runs `./scripts/gates.sh coverage` with `TYRUS_COVERAGE_MIN: '73'`.
- Adds `llvm-tools-preview` rustup component. Reuses `Swatinem/rust-cache@v2` for compilation caching.

### `CONTRIBUTING.md`

- New "Local coverage check (Rule 5)" subsection under Pull Request Process.
- Documents the install one-liner (`cargo install cargo-llvm-cov`) and the multi-step rationale.
- Pull Request Process step list condensed to "run `./scripts/gates.sh all`" — same script as CI per Rule 9.

## Compliance

- **Rule 5** ✅ — `cargo-llvm-cov` infra now exists; threshold enforced.
- **Rule 9** ✅ — `gates.sh` is still the single source of truth; CI calls the same script.
- **Rule 11** ✅ — single concern (coverage wiring), Conventional Commits.

## Test plan

- [x] `./scripts/gates.sh coverage` verde local at 73% threshold (actual 73.61%)
- [x] `./scripts/gates.sh all` verde local (fmt + clippy + test 248/248 + coverage + deny + audit)
- [ ] CI `coverage` job verde
- [ ] Reviewer audit on multi-step rationale

## Follow-ups (this PR opens)

- **#163** — Ramp coverage threshold from 73% baseline to 80% target. Primary vehicle: closing #154 (10 critical equivalence tests).

Origem: [`.claude/plan/audit-2026-05-03-results.md`](.claude/plan/audit-2026-05-03-results.md), Sprint 1 PR4/4 (final).
