### PR TITLE
fix(gates): correct gate_coverage regex, drop dead flags, cache target dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,10 @@ jobs:
   # Coverage — Rule 5 (POWER_OF_TEN.md) enforcement via cargo-llvm-cov.
   # Runs in parallel with `bench` after `build` succeeds. Workspace line
   # coverage must stay at or above the threshold configured in
-  # `scripts/gates.sh::gate_coverage` (default 80%, override via
-  # TYRUS_COVERAGE_MIN). The coverage gate ignores test/bench infra so the
-  # denominator only counts product code.
+  # `scripts/gates.sh::gate_coverage` (default 73%, override via
+  # TYRUS_COVERAGE_MIN). Ramp-up to 80% tracked in issue #163. The
+  # coverage gate ignores test/bench infra (`tyrus_test_utils`,
+  # `*/benches/`) so the denominator only counts product code.
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
@@ -99,7 +100,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+      # Namespace the rust-cache key so coverage-instrumented artifacts
+      # don't share storage with the regular `build`/`test` jobs.
+      # Mixing instrumented and non-instrumented `target/` confuses
+      # incremental builds and silently invalidates the cache.
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: coverage
+          cache-directories: target/llvm-cov-target
 
       - name: Setup Node.js 22 (for semantic equivalence tests)
         uses: actions/setup-node@v4
@@ -114,10 +122,10 @@ jobs:
       - name: Run coverage gate (gates.sh)
         run: ./scripts/gates.sh coverage
         env:
-          # Initial threshold = 2026-05-03 baseline floor (73.61% rounded
-          # down to 73). Ramp-up to 80 tracked with the Sprint 3
-          # equivalence-test work (#154); raise this number in the PR
-          # that closes the gap.
+          # Threshold pinned to the 2026-05-03 baseline floor.
+          # Ramp-up to 80 is tracked in issue #163 alongside the
+          # Sprint 3 equivalence-test work (#154); raise this number
+          # in the PR that closes the gap.
           TYRUS_COVERAGE_MIN: '73'
 
   # Benchmarks — run after tests pass, upload criterion HTML reports

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ We use [Conventional Commits](https://www.conventionalcommits.org/).
 
 ### Local coverage check (Rule 5)
 
-The `coverage` gate uses `cargo-llvm-cov` to enforce the workspace line-coverage threshold. The current default is **73%** (the 2026-05-03 baseline floor); ramp-up to 80% is tracked with the equivalence-test sprint (#154).
+The `coverage` gate uses `cargo-llvm-cov` to enforce the workspace line-coverage threshold. The current default is **73%** (the 2026-05-03 baseline floor at 73.25% with test-infra excluded); ramp-up to 80% is tracked in [issue #163](https://github.com/Gefferson-Souza/Tyrus/issues/163) alongside the equivalence-test sprint (#154).
 
 Install once:
 
@@ -65,9 +65,16 @@ TYRUS_COVERAGE_MIN=80 ./scripts/gates.sh coverage    # one-off stricter check
 TYRUS_SKIP_COVERAGE=1 ./scripts/gates.sh all         # skip in slow paths only
 ```
 
-Test infrastructure (`tests/`, `crates/*/test_utils`, `crates/*/benches`) is excluded from the denominator so the threshold reflects product code coverage only.
+`tyrus_test_utils` and any `*/benches/` are excluded from the denominator (they are infrastructure, not product code). Integration tests under `tests/` do not appear in the coverage report at all (they are test runners, not target code).
 
-Internally, `gate_coverage` runs as four steps (`clean` → `run --bin tyrus` → `nextest --workspace` → `report`) because CLI integration tests under `tests/src/cli.rs` use `assert_cmd::cargo_bin("tyrus")` and need the binary present inside the llvm-cov target dir.
+Internally, `gate_coverage` runs as four steps:
+
+1. `cargo llvm-cov clean --profraw-only` — clear stale instrumentation
+2. `cargo llvm-cov --no-report run --bin tyrus -- --version` — build the `tyrus` binary into `target/llvm-cov-target/debug/` so CLI integration tests (`tests/src/cli.rs::assert_cmd::cargo_bin`) can find it
+3. `cargo llvm-cov --no-report nextest --workspace` — collect coverage data
+4. `cargo llvm-cov report --fail-under-lines $TYRUS_COVERAGE_MIN ...` — render report and enforce threshold
+
+`cargo-llvm-cov` must be installed locally (`cargo install cargo-llvm-cov`) — `gate_coverage` preflight-checks for it and prints an install hint if missing.
 
 ## 🧪 Test Infrastructure
 

--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -23,7 +23,9 @@
 #   TYRUS_SKIP_DENY=1      Skip cargo deny check (use only when tool unavailable).
 #   TYRUS_SKIP_AUDIT=1     Skip cargo audit (use only when tool unavailable).
 #   TYRUS_SKIP_COVERAGE=1  Skip cargo llvm-cov coverage check (e.g. fast pre-commit path).
-#   TYRUS_COVERAGE_MIN     Override the minimum line-coverage % (default: 80).
+#   TYRUS_COVERAGE_MIN     Override the minimum line-coverage %
+#                          (default: 73 — the 2026-05-03 baseline floor;
+#                           ramp-up to 80 tracked in issue #163).
 #
 # Exit code: 0 on all gates pass, non-zero on first failure.
 
@@ -64,30 +66,46 @@ gate_coverage() {
         return 0
     fi
     echo "=== gate: coverage ==="
-    # Rule 5 enforcement (POWER_OF_TEN.md): workspace line coverage threshold.
-    # Threshold is configurable via TYRUS_COVERAGE_MIN (default 73, the
-    # 2026-05-03 baseline floor; ramp-up to 80 is tracked alongside the
-    # equivalence-test sprint #154). Test harness, benchmarks, and
-    # test-utils crates are excluded from the denominator — they are
-    # infrastructure, not product code.
+    if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
+        echo "ERROR: cargo-llvm-cov is not installed."
+        echo "Install with: cargo install cargo-llvm-cov"
+        echo "Or skip this gate locally with: TYRUS_SKIP_COVERAGE=1"
+        return 1
+    fi
+    # Rule 5 enforcement (POWER_OF_TEN.md): workspace line coverage
+    # threshold. Configurable via TYRUS_COVERAGE_MIN (default tracks the
+    # 2026-05-03 baseline floor — see issue #163 for ramp-up to 80%).
+    # Benchmarks and `tyrus_test_utils` are excluded from the
+    # denominator. The `--ignore-filename-regex` matches against the
+    # *absolute path* of each source file (NOT the relative path
+    # displayed in the report), so each fragment is anchored on `/`
+    # rather than on a leading `^`.
     #
-    # Multi-step invocation rationale: integration tests in `tests/src/cli.rs`
-    # use `assert_cmd::Command::cargo_bin("tyrus")`, which expects the
-    # `tyrus` binary inside `target/llvm-cov-target/debug/`. A plain
-    # `cargo llvm-cov nextest` builds test binaries but not the bin —
-    # CLI tests then fail with NotFoundError. Splitting the run into
-    # (1) clean profraw, (2) `--no-report run --bin tyrus` to populate
-    # the binary, (3) `--no-report nextest --workspace` for tests, and
-    # (4) a final `report` for threshold enforcement keeps both worlds
-    # consistent.
+    # Multi-step invocation rationale: integration tests in
+    # `tests/src/cli.rs` use `assert_cmd::Command::cargo_bin("tyrus")`,
+    # which expects the `tyrus` binary inside
+    # `target/llvm-cov-target/debug/`. A plain `cargo llvm-cov nextest`
+    # builds test binaries but not the bin — CLI tests then fail with
+    # NotFoundError. Splitting the run into
+    # (1) clean profraw,
+    # (2) `--no-report run --bin tyrus` to populate the binary,
+    # (3) `--no-report nextest --workspace` for tests, and
+    # (4) a final `report` for threshold enforcement
+    # keeps both worlds consistent.
     threshold="${TYRUS_COVERAGE_MIN:-73}"
-    cargo llvm-cov clean --workspace --profraw-only
+    # `--profraw-only` is incompatible with `--workspace` (cargo-llvm-cov
+    # warns and ignores the latter). Cleaning at the workspace target
+    # is implicit, so `--profraw-only` alone is correct.
+    cargo llvm-cov clean --profraw-only
     cargo llvm-cov --no-report run --bin tyrus -- --version > /dev/null
     cargo llvm-cov --no-report nextest --workspace
+    # `--summary-only` only takes effect with structured output
+    # (--json/--lcov/--cobertura). For the human-readable text report
+    # we rely on `--fail-under-lines` for the gate signal; the per-file
+    # table is informative for the contributor and forwarded by CI.
     cargo llvm-cov report \
         --fail-under-lines "$threshold" \
-        --ignore-filename-regex '^tests/|^crates/.*test_utils/|^crates/.*/benches/' \
-        --summary-only
+        --ignore-filename-regex '/tyrus_test_utils/|/benches/'
 }
 
 gate_deny() {


### PR DESCRIPTION
## Summary

Follow-up to PR #164. Post-merge review (`tyrus-devops` agent) found that `gate_coverage` had multiple bugs that made it not actually enforce what it claimed. This PR fixes them.

## Bugs fixed

### 1. `--ignore-filename-regex` was a NO-OP (HIGH)

The regex `^tyrus_test_utils/|^crates/.*test_utils/|^crates/.*/benches/` matched against the **relative paths displayed in the report**. cargo-llvm-cov actually matches against the **absolute path** of each source file, which never starts with `tyrus_test_utils` or `crates/`. Result: `tyrus_test_utils/src/lib.rs` (224 LoC, 87.50% covered) silently stayed in the denominator.

**Fix:** regex `/tyrus_test_utils/|/benches/` — anchored on `/` boundaries that exist in the absolute path.

**Impact on baseline:** 73.61% → **73.25%** (the 0.36% delta is the high-coverage `tyrus_test_utils` no longer inflating the numerator). Threshold `73` still passes.

### 2. `--summary-only` was silently ignored (HIGH)

Per `cargo llvm-cov report --help`: "This flag can only be used together with --json, --lcov, or --cobertura." With text output, it is dropped — the full per-file table prints regardless.

**Fix:** flag removed (the text report is informative for contributors anyway). If we ever switch to LCOV upload for Codecov, re-add `--lcov` together.

### 3. `--workspace` warned every run (MEDIUM)

`cargo llvm-cov clean --workspace --profraw-only` is incompatible — cargo-llvm-cov warns and ignores `--workspace`.

**Fix:** dropped `--workspace`.

### 4. No preflight check for `cargo-llvm-cov` (LOW)

If the tool isn't installed, the gate failed with `error: no such subcommand: 'llvm-cov'` (exit 101) — not friendly.

**Fix:** added `command -v cargo-llvm-cov` preflight with install hint.

### 5. `target/llvm-cov-target/` not cached in CI (MEDIUM)

`Swatinem/rust-cache@v2` defaults to caching `target/`, but coverage uses a separate target dir. Every CI run rebuilt instrumented artifacts from scratch, also risking cross-pollution with the regular `build`/`test` cache.

**Fix:** namespaced the coverage job's cache (`key: coverage`) and explicitly added `cache-directories: target/llvm-cov-target`.

### 6. Docstring drift (MEDIUM)

`scripts/gates.sh` line-26 docstring still said `default: 80` while the implementation defaulted to `73`. CI yaml comment had the same drift.

**Fix:** both updated to `default: 73 (2026-05-03 baseline floor; ramp-up to 80 tracked in #163)`.

## Files

| File | Change |
|---|---|
| `scripts/gates.sh` | Fix regex, drop `--summary-only` and `--workspace`, add preflight, update docstring |
| `.github/workflows/ci.yml` | Cache `target/llvm-cov-target/` with `key: coverage`; correct comment |
| `CONTRIBUTING.md` | Updated baseline note (73.25%), 4-step pipeline rationale, install/preflight expectation |

## Compliance

- **Rule 5** ✅ — `gate_coverage` now actually enforces what it claims
- **Rule 9** ✅ — `gates.sh` remains the single source; CI invokes the same script
- **Rule 11** ✅ — single concern (gate_coverage correctness)

## Test plan

- [x] `./scripts/gates.sh coverage` verde local at threshold 73 (actual 73.25%)
- [x] `./scripts/gates.sh all` verde
- [x] Confirmed `tyrus_test_utils/src/lib.rs` no longer in the per-file report
- [ ] CI Coverage job verde

## Out of scope

- **pre-commit hook running coverage** — the devops review flagged this as a Rule 9 architectural question (5-15 min cold cache; contributors will set `TYRUS_SKIP_COVERAGE=1` permanently). Resolving it cleanly likely needs an ADR amendment to ADR 0008. Tracked separately; not blocking this PR.
- **Threshold ratchet to 73.6** — the devops reviewer suggested catching sub-percent regressions. Deferred to issue #163 (the ramp-up issue) since it changes the policy, not just the wiring.

Origem: post-merge audit `2026-05-03` (`tyrus-devops` agent findings on PR #164).
