### PR TITLE
docs(adr): correct accuracy gaps in ADRs 0009 and 0011

### DIFF
--- a/docs/architecture/decisions/0009-mutex-re-entrance-protocol.md
+++ b/docs/architecture/decisions/0009-mutex-re-entrance-protocol.md
@@ -17,35 +17,49 @@ PR #141 (`b5af050`) closed both bugs by establishing a uniform emission protocol
 
 ## Decision
 
-Generated Rust for `@Injectable` state fields obeys two emission patterns. Both are implemented in `crates/tyrus_codegen/src/convert/expr/`:
+Generated Rust for `@Injectable` state fields obeys two emission patterns. Both are implemented in `crates/tyrus_codegen/src/convert/expr/`.
+
+The receiver token is selected by the codegen flag `RustGenerator::use_state_for_this`: handler bodies emitted under axum's `State<Arc<Self>>` pattern use `state.field`, while regular methods use `self.field`. Both paths obey the protocols below; the snippets show `self` for brevity.
+
+Every `.lock()` call uses `.unwrap_or_else(|e| e.into_inner())`, never `.unwrap()`. This is **poisoning-safe**: a panic on another thread that left the mutex poisoned is recovered (the inner value is still consistent because the codegen never holds a guard across a fallible operation). Rule 6 (no `.unwrap()` in production code) is satisfied while preserving the lock semantics.
 
 ### Pattern A — Block-scoped read
 
-Every read of `this.field` where `field` is a state-field expands to:
+Every read of `this.field` where `field` is a tracked state field expands to one of two forms, depending on whether the payload type is `Copy`:
 
 ```rust
-{ let __g = self.field.lock().unwrap(); *__g }
+// Copy payload (f64, bool, i32, usize, u64, i64): deref the guard.
+{ let __g = self.field.lock().unwrap_or_else(|e| e.into_inner()); *__g }
+
+// Non-Copy payload (String, Vec, etc.): clone via the guard.
+{ let __g = self.field.lock().unwrap_or_else(|e| e.into_inner()); __g.clone() }
 ```
 
-(or `.clone()` for non-`Copy` payloads). The guard `__g` is bound in an **inner block**, so Rust's drop scope ends at the closing `}` of that block — *before* the consuming expression evaluates the next subexpression. Two reads in the same statement therefore release each guard between reads.
+The guard `__g` is bound in an **inner block**, so Rust's drop scope ends at the closing `}` of that block — *before* the consuming expression evaluates the next subexpression. Two reads in the same statement therefore release each guard between reads.
 
-This is implemented in `convert_this_member` and propagated through `convert_member_expr` for every `Expr::Member` whose object resolves to `self` and whose property is registered in `current_class_state_fields`.
+This is implemented in `convert_this_member` (`convert/expr/member.rs`) and reached via `convert_member_expr` for every `Expr::Member` whose object resolves to `self`/`state` and whose property is registered in `current_class_state_fields`.
 
 ### Pattern B — Read-then-write split for compound writes
 
-Compound assignments and update expressions (`+=`, `-=`, `*=`, `/=`, `%=`, `&=`, `|=`, `^=`, `<<=`, `>>=`, prefix/postfix `++`/`--`) on state fields expand into two statements:
+Compound assignments and update expressions (`+=`, `-=`, `*=`, `/=`, `%=`, `&=`, `|=`, `^=`, `<<=`, `>>=`, prefix/postfix `++`/`--`) on state fields expand into a block holding two statements:
 
 ```rust
-let __cur = { let __g = self.field.lock().unwrap(); *__g };
-let __new = __cur <op> rhs;
-{ let mut __g = self.field.lock().unwrap(); *__g = __new; }
+{
+    let __new_val = #guarded_read <op> #rhs;
+    *self.field.lock().unwrap_or_else(|e| e.into_inner()) = __new_val;
+}
 ```
 
-The read guard drops at the `;` of its own `let`. The write guard drops at the `;` of the assign block. The operator is preserved (no silent reduction to `=`). Update expressions (`this.x++`) route through the same helper (`emit_state_field_assign`) for uniform semantics.
+`#guarded_read` is the inline form `{ let __g = self.field.lock().unwrap_or_else(|e| e.into_inner()); *__g }` (Pattern A's Copy form, since compound assigns operate on numeric state).
+
+The read guard drops at the `;` of the `let __new_val = …` line. The write guard drops at the `;` of the assignment line. The two locks therefore never coexist. The operator is preserved (no silent reduction to `=`). Update expressions (`this.x++`, `this.x--`) route through the same helper (`emit_state_field_assign`) for uniform semantics.
 
 ### Invariant
 
-For any generated function body emitted from a `&mut self` method on an `@Injectable` class, **at most one `MutexGuard` for any given state field is alive at any program point**. The compiler does not enforce this — codegen does. Any new emission path that touches state fields **must** route through the existing helpers (`emit_state_field_read`, `emit_state_field_assign`) or replicate the patterns above explicitly.
+For any generated function body emitted from a method on an `@Injectable` class, **at most one `MutexGuard` for any given state field is alive at any program point**. The compiler does not enforce this — codegen does. Any new emission path that touches state fields **must** either:
+
+- route through the existing helpers (`convert_this_member` for reads; `emit_state_field_assign` for compound writes), or
+- replicate the inline form (block-scoped guard + `.unwrap_or_else(|e| e.into_inner())`) explicitly, including the receiver dispatch on `use_state_for_this`.
 
 ## Consequences
 
@@ -57,9 +71,9 @@ For any generated function body emitted from a `&mut self` method on an `@Inject
 
 ### Negative
 
-- **Slight overhead.** Every state-field read costs a block scope and a deref vs the naive `self.field.lock().unwrap().clone()`. In practice negligible (the same guard acquisition is the dominant cost). Atomic state (#143) eliminates the overhead for `Copy` payloads.
+- **Slight overhead.** Every state-field read costs a block scope and a deref/clone vs the naive `self.field.lock()…`. In practice negligible (the lock acquisition is the dominant cost). Atomic state (#143) eliminates the overhead for `Copy` payloads.
 - **Snapshot churn.** PR #141 updated the tier4 NestJS controller and injectable-service snapshots to the guarded-block form. Future codegen tweaks affecting state reads will keep producing snapshot diffs.
-- **Codegen complexity.** The path from `Expr::Member { obj: This, prop: Ident }` to emitted tokens passes through three helpers and one tracked HashSet (`current_class_state_fields`). Anyone adding a new mutating expression (e.g., a hypothetical `Math.atomic_add`) must explicitly handle the state-field branch.
+- **Codegen complexity.** The path from `Expr::Member { obj: This, prop: Ident }` to emitted tokens passes through `convert_member_expr` → `convert_this_member` and consults a tracked HashMap (`current_class_state_fields`) plus a flag (`use_state_for_this`). Anyone adding a new mutating expression (e.g., a hypothetical `Math.atomic_add`) must explicitly handle the state-field branch and propagate the receiver dispatch.
 
 ## Alternatives rejected
 
@@ -70,6 +84,10 @@ For any generated function body emitted from a `&mut self` method on an `@Inject
 ## References
 
 - Originating PR: [#141](https://github.com/Gefferson-Souza/Tyrus/pull/141) (`b5af050`) — `fix(codegen): prevent mutex re-entrance on compound assigns and dual reads`. Closes #129.
-- Implementation: `crates/tyrus_codegen/src/convert/expr/member.rs`, `crates/tyrus_codegen/src/convert/expr/misc.rs`.
-- Regression tests: `tests/src/unit/state_mutation.rs` (8 tests).
+- Implementation:
+  - `crates/tyrus_codegen/src/convert/expr/member.rs::convert_this_member` (read path).
+  - `crates/tyrus_codegen/src/convert/expr/misc.rs::emit_state_field_assign` (compound write path).
+- Receiver dispatch: `RustGenerator::use_state_for_this: Cell<bool>` toggled around handler-body codegen.
+- State-field tracking: `RustGenerator::current_class_state_fields: HashMap<String, String>` (field name → Rust type name; populated in `class/state_field.rs`).
+- Regression tests: `tests/src/unit/state_mutation.rs` (covers compound `+=`/`-=`, update `++`/`--`, dual read in struct literal, dual read in fn args).
 - Related: ADR 0008 (Tyrus Strict Rules — this ADR satisfies Rule 10's retroactive requirement); future ADR for #143 (atomic state) supersedes Pattern B for `Copy` payloads.

--- a/docs/architecture/decisions/0011-supply-chain-hygiene.md
+++ b/docs/architecture/decisions/0011-supply-chain-hygiene.md
@@ -44,24 +44,33 @@ The list is duplicated between `deny.toml` (`[advisories].ignore`) and `scripts/
 
 Adding an entry requires: (a) a comment explaining the analysis, (b) a tracking issue or this ADR, (c) a planned upgrade path (not "indefinitely ignored"). Zero-justification ignores are forbidden.
 
-### Policy 3 — Dependabot grouping
+### Policy 3 — Dependabot grouping and cadence
 
-`dependabot.yml` groups updates to reduce PR noise:
+`.github/dependabot.yml` runs three update streams:
 
-- **`cargo`** ecosystem — weekly schedule, all path-internal cargo deps grouped, all external cargo deps grouped separately.
-- **`github-actions`** — weekly, single group.
-- **`npm`** (test fixtures only) — weekly, single group.
+- **`cargo`** — weekly (Monday), max 5 open PRs. Two groups:
+  - `swc` — pattern `swc_*` (the SWC family version-locks, so a single grouped bump reviews better than per-crate noise).
+  - `dev-dependencies` — `dependency-type: development` (test/bench-only updates do not affect runtime).
+  - Everything else (production dependencies outside the SWC family) updates as individual PRs so semver-incompatible bumps are reviewed in isolation.
+- **`github-actions`** — weekly (Monday), max 3 PRs, **no grouping** (the action ecosystem changes slowly enough that single-PR review is fine).
+- **`npm`** — **monthly**, max 2 PRs, scoped to `tests/fixtures/reference_nestjs/` (the reference NestJS fixture, used for E2E equivalence). Slower cadence because the fixture pins a stable NestJS surface intentionally.
 
-Rationale: ungrouped Dependabot floods with one PR per dep per week, masking semver-incompatible bumps in noise. Grouping cuts review surface ~10×. CI re-runs catch the regressions; the grouping is review-side, not gate-side.
+Rationale: ungrouped weekly Dependabot floods with one PR per dep, masking semver-incompatible bumps in noise. Targeted grouping (SWC family + dev-deps) cuts cargo review surface meaningfully without hiding production bumps. The npm monthly cadence keeps the test fixture tracking the broader ecosystem without thrashing it.
 
 ### Policy 4 — CODEOWNERS membership
 
-`CODEOWNERS` routes review approval per path:
+`CODEOWNERS` (at the repo root) routes review approval per path. The current rule set:
 
-- Root + `docs/standards/` + `docs/architecture/decisions/` → maintainer (current solo).
-- Per-crate ownership inherits from root until a contributor demonstrates sustained ownership of a crate (≥ 3 reviewed PRs, ≥ 6 months active).
+- `*` → maintainer (catch-all).
+- `/crates/tyrus_codegen/`, `/crates/tyrus_analyzer/`, `/crates/tyrus_decorator_kinds/`, `/crates/tyrus_di/` → maintainer (compiler-core extra scrutiny).
+- `/docs/architecture/decisions/`, `/docs/specs/` → maintainer (public-contract documents).
+- `/.github/`, `/.cargo/`, `/clippy.toml`, `/deny.toml`, `/release-plz.toml` → maintainer (anything that changes the gates).
 
-Rationale: as Tyrus accepts ML-agent and external contributions, gated review is the simplest enforcement of the strict rules. CODEOWNERS membership is itself an architectural decision (who can sign off on architectural changes) and changes via separate ADR.
+Per-crate ownership inherits from `*` until a contributor demonstrates sustained ownership of a crate (≥ 3 reviewed PRs, ≥ 6 months active). At that point, CODEOWNERS gains an additional reviewer for that crate via separate ADR.
+
+Rationale: as Tyrus accepts ML-agent and external contributions, gated review is the simplest enforcement of the strict rules. The compiler-core and gates-changing surfaces are explicitly carved out so they can never be approved by a less-scoped contributor accidentally.
+
+> **Note.** `docs/standards/POWER_OF_TEN.md` is not currently routed via CODEOWNERS — it lives under `/docs/standards/` which has no rule. The `*` catch-all covers it. A follow-up could add an explicit `/docs/standards/` rule to mirror the `/docs/architecture/decisions/` carve-out, but that is a CODEOWNERS edit, not an ADR-level decision.
 
 ## Consequences
 


### PR DESCRIPTION
## Summary

Follow-up to PR #162. Post-merge accuracy audit (`tyrus-architect` agent) found that ADRs 0009 and 0011 contained code-level mismatches that would mislead anyone re-deriving the invariants from the ADR alone. ADR 0010 was clean. This PR corrects 0009 and 0011.

## ADR 0009 — Mutex Re-entrance Protocol

| Gap | Fix |
|---|---|
| Code snippets used `.unwrap()` (Pattern A and B) | Updated to `.unwrap_or_else(\|e\| e.into_inner())` to match `convert/expr/member.rs:58,62` and `convert/expr/misc.rs:55,88`. The actual emission is **poisoning-safe** and Rule 6-compliant; the wrong snippet would have led a future contributor to re-introduce `.unwrap()` violations. |
| Cited helper `emit_state_field_read` (does not exist) | Replaced with `convert_this_member` (the actual read entrypoint). `emit_state_field_assign` was correct and is preserved. |
| Pattern B described as 3 statements (`__cur` / `__new` / write) | Replaced with the actual 2-statement form: `let __new_val = #guarded_read <op> #rhs; *self.field.lock().…() = __new_val;` (matches `misc.rs:85-90`). The `#guarded_read` term is the inline form of Pattern A. |
| `use_state_for_this` flag entirely missing | New paragraph in Decision section: handler bodies under axum `State<Arc<Self>>` use `state.field`; regular methods use `self.field`. Both paths obey both patterns. |
| Receiver dispatch / state-field tracking absent from Implementation references | Added explicit refs: `RustGenerator::use_state_for_this: Cell<bool>` and `RustGenerator::current_class_state_fields: HashMap<String, String>` (with `class/state_field.rs` population point). |

## ADR 0011 — Supply-Chain Hygiene Policy

| Gap | Fix |
|---|---|
| Policy 3 claimed cargo deps grouped as "path-internal vs external" | Rewritten to match `.github/dependabot.yml:19-26`: groups are `swc` (pattern `swc_*`) and `dev-dependencies` (`dependency-type: development`). Production deps update as individual PRs by design. |
| Policy 3 claimed npm "weekly, single group" | Corrected to **monthly**, no grouping (`dependabot.yml:42-47`). Scope is the reference NestJS fixture under `tests/fixtures/reference_nestjs/`. |
| Policy 4 claimed CODEOWNERS covers `docs/standards/` | Removed that claim. CODEOWNERS actually covers `/docs/architecture/decisions/`, `/docs/specs/`, `/.github/`, `/.cargo/`, `clippy.toml`, `deny.toml`, `release-plz.toml`, plus the four compiler-core crates (`tyrus_codegen`, `tyrus_analyzer`, `tyrus_decorator_kinds`, `tyrus_di`). Added a Note about `docs/standards/` falling under the `*` catch-all and the option to add an explicit rule later. |

## Files

| File | Change |
|---|---|
| `docs/architecture/decisions/0009-mutex-re-entrance-protocol.md` | Decision section + Negative consequences + References — see table above |
| `docs/architecture/decisions/0011-supply-chain-hygiene.md` | Policy 3 (rewritten) + Policy 4 (rewritten) |

## Compliance

- **Rule 10** ✅ — ADRs now accurately document the load-bearing invariants of #141 and #126.
- **Rule 11** ✅ — single concern (ADR accuracy).
- **Rule 9** ✅ — `./scripts/gates.sh fmt clippy` verde local; docs-only change does not affect tests.

## Verification

Each fix was cross-referenced against the actual code/config:

- ADR 0009 Pattern A → `crates/tyrus_codegen/src/convert/expr/member.rs:30-65`
- ADR 0009 Pattern B → `crates/tyrus_codegen/src/convert/expr/misc.rs:46-91`
- ADR 0009 Receiver dispatch → `member.rs:35-39`, `misc.rs:112-116`
- ADR 0011 Policy 3 cargo → `.github/dependabot.yml:7-26`
- ADR 0011 Policy 3 npm → `.github/dependabot.yml:42-47`
- ADR 0011 Policy 4 → `CODEOWNERS:1-23`

Origem: post-merge audit `2026-05-03` (`tyrus-architect` agent findings on PR #162).
