### PR TITLE
feat(gates): add gate_filesize + complete Rule 1 bound comments

### DIFF
--- a/crates/tyrus_codegen/src/convert/expr/mod.rs
+++ b/crates/tyrus_codegen/src/convert/expr/mod.rs
@@ -75,10 +75,12 @@ impl RustGenerator {
         }
     }
 
+    // Bound: SWC AST is finite; recursion depth ≤ AST depth (Rule 1, POWER_OF_TEN.md).
     pub fn convert_expr_or_spread(&self, arg: &ExprOrSpread) -> TokenStream {
         self.convert_expr(&arg.expr)
     }
 
+    // Bound: SWC AST is finite; recursion depth ≤ AST depth (Rule 1, POWER_OF_TEN.md).
     fn convert_cond_expr(&self, cond: &swc_ecma_ast::CondExpr) -> TokenStream {
         let test = self.convert_expr(&cond.test);
         let cons = self.convert_expr(&cond.cons);
@@ -86,6 +88,7 @@ impl RustGenerator {
         quote! { if #test { #cons } else { #alt } }
     }
 
+    // Bound: SWC AST is finite; recursion depth ≤ AST depth (Rule 1, POWER_OF_TEN.md).
     fn convert_new_expr(&self, new_expr: &NewExpr) -> TokenStream {
         if let Expr::Ident(ident) = &*new_expr.callee {
             match ident.sym.as_ref() {

--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -16,6 +16,7 @@
 #   ./scripts/gates.sh clippy      # cargo clippy --workspace --all-targets -D warnings
 #   ./scripts/gates.sh test        # cargo nextest run --workspace --all-targets
 #   ./scripts/gates.sh coverage    # cargo llvm-cov nextest --workspace --fail-under-lines <threshold>
+#   ./scripts/gates.sh filesize    # enforce Rule 4 file ceiling (≤ 400 lines per .rs)
 #   ./scripts/gates.sh deny        # cargo deny check
 #   ./scripts/gates.sh audit       # cargo audit --deny warnings
 #
@@ -23,7 +24,10 @@
 #   TYRUS_SKIP_DENY=1      Skip cargo deny check (use only when tool unavailable).
 #   TYRUS_SKIP_AUDIT=1     Skip cargo audit (use only when tool unavailable).
 #   TYRUS_SKIP_COVERAGE=1  Skip cargo llvm-cov coverage check (e.g. fast pre-commit path).
-#   TYRUS_COVERAGE_MIN     Override the minimum line-coverage % (default: 80).
+#   TYRUS_SKIP_FILESIZE=1  Skip the Rule 4 file ceiling check.
+#   TYRUS_COVERAGE_MIN     Override the minimum line-coverage %
+#                          (default: 73 — the 2026-05-03 baseline floor;
+#                           ramp-up to 80 tracked in issue #163).
 #
 # Exit code: 0 on all gates pass, non-zero on first failure.
 
@@ -90,6 +94,63 @@ gate_coverage() {
         --summary-only
 }
 
+gate_filesize() {
+    if [ "${TYRUS_SKIP_FILESIZE:-0}" = "1" ]; then
+        echo "=== gate: filesize (SKIPPED via TYRUS_SKIP_FILESIZE=1) ==="
+        return 0
+    fi
+    echo "=== gate: filesize ==="
+    # Rule 4 (POWER_OF_TEN.md) file ceiling: ≤ 400 lines per `.rs` file
+    # under `crates/`. ADR 0008 also names a 800-line hard cap. Pre-existing
+    # soft-cap violations are allowlisted (tracked in issue #153 — refactor);
+    # they still fail if they cross the hard cap. New files must respect
+    # the soft cap.
+    soft_cap=400
+    hard_cap=800
+
+    # Allowlisted soft-cap violators (tracked in #153). Files in this
+    # set may exceed the 400-line soft cap but never the 800-line hard cap.
+    allowlist_pattern='/convert/class/constructor\.rs$|/convert/interface\.rs$'
+
+    # "<lines> <path>" for every .rs file under crates/, descending.
+    all=$(find crates -type f -name '*.rs' -print0 \
+        | xargs -0 wc -l \
+        | awk '$2 != "total" {print $1, $2}' \
+        | sort -rn)
+
+    fail=0
+
+    # Hard cap violations are always fatal.
+    hard=$(echo "$all" | awk -v cap="$hard_cap" '$1 > cap')
+    if [ -n "$hard" ]; then
+        echo "FAIL: Rule 4 hard cap (> $hard_cap lines) violations:"
+        echo "$hard" | sed 's/^/  /'
+        fail=1
+    fi
+
+    # Soft cap violations: fatal unless the file is on the allowlist.
+    soft=$(echo "$all" | awk -v lo="$soft_cap" -v hi="$hard_cap" '$1 > lo && $1 <= hi')
+    if [ -n "$soft" ]; then
+        non_allowed=$(echo "$soft" | grep -vE "$allowlist_pattern" || true)
+        allowed=$(echo "$soft" | grep -E "$allowlist_pattern" || true)
+        if [ -n "$non_allowed" ]; then
+            echo "FAIL: Rule 4 soft cap (> $soft_cap lines) violations:"
+            echo "$non_allowed" | sed 's/^/  /'
+            fail=1
+        fi
+        if [ -n "$allowed" ]; then
+            echo "Allowlisted soft-cap warnings (tracked in #153):"
+            echo "$allowed" | sed 's/^/  /'
+        fi
+    fi
+
+    if [ "$fail" -eq 0 ] && [ -z "$soft" ]; then
+        echo "All .rs files under crates/ are at or below $soft_cap lines."
+    fi
+
+    return "$fail"
+}
+
 gate_deny() {
     if [ "${TYRUS_SKIP_DENY:-0}" = "1" ]; then
         echo "=== gate: deny (SKIPPED via TYRUS_SKIP_DENY=1) ==="
@@ -122,11 +183,13 @@ case "$cmd" in
     clippy)   gate_clippy ;;
     test)     gate_test ;;
     coverage) gate_coverage ;;
+    filesize) gate_filesize ;;
     deny)     gate_deny ;;
     audit)    gate_audit ;;
     all)
         gate_fmt
         gate_clippy
+        gate_filesize
         gate_test
         gate_coverage
         gate_deny


### PR DESCRIPTION
## Summary

Two related Sprint 1 follow-ups bundled under a single concern: **closing Rule 4 enforcement and Rule 1 coverage gaps identified in the post-merge audit.**

> **Stacked on top of [#167](https://github.com/Gefferson-Souza/Tyrus/pull/167)** (Fix-C — extract `expr/call_array.rs`). `gate_filesize` would otherwise fail on `expr/call.rs` (404 lines on `main`) until #167 lands.

## Changes

### 1. New gate: `scripts/gates.sh::gate_filesize`

The post-merge reviewer flagged that **Rule 4's file ceiling has had zero machine enforcement** since adoption. Functions get `clippy::too_many_lines`, but file size is review-only — and PR #160 demonstrated that 2-line additions to a 402-line file silently push it over. This gate closes that gap.

Behaviour:

- **Soft cap (400 lines):** failure unless the file is on the allowlist. Allowlist = files with **pre-existing** soft-cap violations tracked in [#153](https://github.com/Gefferson-Souza/Tyrus/issues/153). Currently:
  - `crates/tyrus_codegen/src/convert/class/constructor.rs` (503 lines)
  - `crates/tyrus_codegen/src/convert/interface.rs` (405 lines)
- **Hard cap (800 lines):** failure regardless of allowlist. ADR 0008 names this as the absolute ceiling.
- New files **always** subject to the soft cap. Future additions can never cross 400 lines undetected.
- Skippable via `TYRUS_SKIP_FILESIZE=1` (consistent with the other optional gates).

`gates.sh all` now runs `gate_filesize` between `gate_clippy` and `gate_test` so the cheap structural check fails fast before the expensive test step.

Local output on this branch (after #167):

```
=== gate: filesize ===
Allowlisted soft-cap warnings (tracked in #153):
  503 crates/tyrus_codegen/src/convert/class/constructor.rs
  405 crates/tyrus_codegen/src/convert/interface.rs
```

### 2. Complete Rule 1 bound comments in `expr/mod.rs`

PR #160 added Rule 1 (`// Bound: SWC AST is finite ...`) annotations to 11 recursive sites but missed three **siblings of `convert_expr`** in the same file:

| Function | File:Line |
|---|---|
| `convert_expr_or_spread` | `crates/tyrus_codegen/src/convert/expr/mod.rs:78` |
| `convert_cond_expr` | `crates/tyrus_codegen/src/convert/expr/mod.rs:84` |
| `convert_new_expr` | `crates/tyrus_codegen/src/convert/expr/mod.rs:92` |

All three call `self.convert_expr(...)` (the canonical recursion entry), so they recurse on strict syntactic sub-terms of the SWC AST. Same wording as #160 keeps the future `gate_recursion_audit` regex (`Bound: SWC AST is finite`) usable.

## Out of scope (deferred)

The reviewer also flagged analyzer `Visit` impls (`tyrus_analyzer/src/{lints,unsupported,decorators}.rs`) as missing bound comments. Those recurse via SWC's `Visit` trait — library-controlled depth — and the project deferred them as LOW. Tracked separately if revisited.

## Compliance

- **Rule 1** ✅ — Rule 1 coverage in `expr/mod.rs` is now complete.
- **Rule 4** ✅ — `gate_filesize` adds the missing machine enforcement; stacked on #167 so the gate passes immediately.
- **Rule 9** ✅ — `./scripts/gates.sh all` (which now includes `filesize`) verde local.
- **Rule 11** ✅ — single concern (Rule 1/4 enforcement). Stacking on Fix-C is required because #167 contains the codebase-side fix the gate enforces.

## Test plan

- [x] `./scripts/gates.sh fmt clippy filesize test` verde local
- [x] `gate_filesize` correctly classifies: 2 allowlisted, 0 fails (with Fix-C applied)
- [x] Verified `gate_filesize` fails on a regression: when call.rs was 404 (without Fix-C), the gate flagged it as a soft-cap violation
- [ ] CI verde once #167 merges and this PR rebases onto main

## Verification

```
$ ./scripts/gates.sh filesize
=== gate: filesize ===
Allowlisted soft-cap warnings (tracked in #153):
  503 crates/tyrus_codegen/src/convert/class/constructor.rs
  405 crates/tyrus_codegen/src/convert/interface.rs
$ echo $?
0
```

Origem: post-merge audit `2026-05-03` (`tyrus-reviewer` agent findings on PR #160 + Rule 4 enforcement gap).
