### PR TITLE
refactor(orchestrator): split build_project_impl into named pipeline phases (#148)

### DIFF
--- a/crates/tyrus_orchestrator/src/pipeline.rs
+++ b/crates/tyrus_orchestrator/src/pipeline.rs
@@ -1,125 +1,186 @@
+use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use walkdir::WalkDir;
 
+use tyrus_di::graph::DiGraph;
 use tyrus_diagnostics::TyrusError;
 
 use crate::format::{format_code, get_app_error_code};
 use crate::scaffold::{generate_cargo_toml, generate_main_rs, generate_mod_rs};
 
-pub(crate) fn build_project_impl(input_dir: &Path, output_dir: &Path) -> Result<(), TyrusError> {
-    let mut controllers: Vec<String> = Vec::new(); // Just names of controllers
-    let mut class_module_map: std::collections::HashMap<String, String> =
-        std::collections::HashMap::new();
-    let mut generic_classes: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let mut programs = Vec::new();
-    let mut file_paths = Vec::new();
+/// Output of phase 1: every parsed `.ts` file plus the class metadata
+/// needed by phases 2-5.
+struct ParsedProject {
+    programs: Vec<swc_ecma_ast::Program>,
+    file_paths: Vec<PathBuf>,
+    class_module_map: HashMap<String, String>,
+    generic_classes: HashSet<String>,
+}
 
-    // 1. Walk, Parse, and Collect Info
+/// Inputs that `generate_main_rs` needs in phase 5.
+struct MainRsCtx<'a> {
+    init_order: &'a [String],
+    class_module_map: &'a HashMap<String, String>,
+    controllers: &'a [String],
+    graph: &'a DiGraph,
+    generic_classes: &'a HashSet<String>,
+}
+
+pub(crate) fn build_project_impl(input_dir: &Path, output_dir: &Path) -> Result<(), TyrusError> {
+    let parsed = parse_and_collect(input_dir)?;
+    let (graph, init_order) = analyze_di_graph(&parsed)?;
+    let controllers = transpile_files(input_dir, output_dir, &parsed)?;
+    finalize_module_tree(output_dir)?;
+    write_main_rs(
+        output_dir,
+        &MainRsCtx {
+            init_order: &init_order,
+            class_module_map: &parsed.class_module_map,
+            controllers: &controllers,
+            graph: &graph,
+            generic_classes: &parsed.generic_classes,
+        },
+    )?;
+    generate_cargo_toml(output_dir)?;
+    Ok(())
+}
+
+// ------- phase 1: walk, parse, collect class metadata -------
+
+fn parse_and_collect(input_dir: &Path) -> Result<ParsedProject, TyrusError> {
+    let mut acc = ParsedProject {
+        programs: Vec::new(),
+        file_paths: Vec::new(),
+        class_module_map: HashMap::new(),
+        generic_classes: HashSet::new(),
+    };
+
     for entry in WalkDir::new(input_dir) {
         let entry = entry.map_err(|e| TyrusError::IoError(e.into()))?;
         let path = entry.path();
+        if !is_typescript_file(path) {
+            continue;
+        }
+        ingest_typescript_file(input_dir, path, &mut acc)?;
+    }
+    Ok(acc)
+}
 
-        if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("ts") {
-            let program = tyrus_parser::parse(path)?;
+fn is_typescript_file(path: &Path) -> bool {
+    path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("ts")
+}
 
-            // Calculate module path
-            let relative_path = path.strip_prefix(input_dir).unwrap_or(path);
-            let file_stem = path
-                .file_stem()
-                .ok_or_else(|| {
-                    TyrusError::IoError(std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        "Invalid file path",
-                    ))
-                })?
-                .to_string_lossy();
-            let sanitized_stem = file_stem.replace(['.', '-'], "_");
+fn ingest_typescript_file(
+    input_dir: &Path,
+    path: &Path,
+    acc: &mut ParsedProject,
+) -> Result<(), TyrusError> {
+    let program = tyrus_parser::parse(path)?;
+    let module_path = compute_module_path(input_dir, path)?;
+    record_classes(&program, &module_path, acc);
+    acc.programs.push(program);
+    acc.file_paths.push(path.to_path_buf());
+    Ok(())
+}
 
-            let mut module_parts = Vec::new();
-            module_parts.push("tyrus_app".to_string()); // Use lib crate name
+fn compute_module_path(input_dir: &Path, path: &Path) -> Result<String, TyrusError> {
+    let relative_path = path.strip_prefix(input_dir).unwrap_or(path);
+    let file_stem = path
+        .file_stem()
+        .ok_or_else(|| {
+            TyrusError::IoError(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Invalid file path",
+            ))
+        })?
+        .to_string_lossy();
+    let sanitized_stem = file_stem.replace(['.', '-'], "_");
 
-            if let Some(parent) = relative_path.parent() {
-                for part in parent.components() {
-                    if let std::path::Component::Normal(s) = part {
-                        let s_str = s.to_string_lossy();
-                        if s_str != "src" {
-                            module_parts.push(s_str.replace('-', "_"));
-                        }
-                    }
+    let mut module_parts = vec!["tyrus_app".to_string()];
+    if let Some(parent) = relative_path.parent() {
+        for part in parent.components() {
+            if let std::path::Component::Normal(s) = part {
+                let s_str = s.to_string_lossy();
+                if s_str != "src" {
+                    module_parts.push(s_str.replace('-', "_"));
                 }
             }
-            // index.ts → lib.rs (crate root), don't add "index" to module path
-            if sanitized_stem != "index" {
-                module_parts.push(sanitized_stem);
-            }
-            let module_path = module_parts.join("::");
-
-            // Extract classes to map them
-            if let swc_ecma_ast::Program::Module(m) = &program {
-                for item in &m.body {
-                    // Exported class declarations
-                    if let swc_ecma_ast::ModuleItem::ModuleDecl(
-                        swc_ecma_ast::ModuleDecl::ExportDecl(export),
-                    ) = item
-                    {
-                        if let swc_ecma_ast::Decl::Class(class_decl) = &export.decl {
-                            let class_name = class_decl.ident.sym.to_string();
-                            class_module_map.insert(class_name.clone(), module_path.clone());
-
-                            if let Some(type_params) = &class_decl.class.type_params {
-                                if !type_params.params.is_empty() {
-                                    generic_classes.insert(class_name);
-                                }
-                            }
-                        }
-                    }
-                    // Non-exported class declarations (common in NestJS single-file)
-                    if let swc_ecma_ast::ModuleItem::Stmt(swc_ecma_ast::Stmt::Decl(
-                        swc_ecma_ast::Decl::Class(class_decl),
-                    )) = item
-                    {
-                        let class_name = class_decl.ident.sym.to_string();
-                        class_module_map
-                            .entry(class_name.clone())
-                            .or_insert_with(|| module_path.clone());
-
-                        if let Some(type_params) = &class_decl.class.type_params {
-                            if !type_params.params.is_empty() {
-                                generic_classes.insert(class_name);
-                            }
-                        }
-                    }
-                }
-            } else if let swc_ecma_ast::Program::Script(s) = &program {
-                for stmt in &s.body {
-                    if let swc_ecma_ast::Stmt::Decl(swc_ecma_ast::Decl::Class(class_decl)) = stmt {
-                        let class_name = class_decl.ident.sym.to_string();
-                        class_module_map.insert(class_name.clone(), module_path.clone());
-
-                        if let Some(type_params) = &class_decl.class.type_params {
-                            if !type_params.params.is_empty() {
-                                generic_classes.insert(class_name);
-                            }
-                        }
-                    }
-                }
-            }
-
-            programs.push(program);
-            file_paths.push(path.to_path_buf());
         }
     }
+    if sanitized_stem != "index" {
+        module_parts.push(sanitized_stem);
+    }
+    Ok(module_parts.join("::"))
+}
 
-    // 2. Analyze (Build Dependency Graph)
-    let mut graph = tyrus_di::graph::DiGraph::new();
+fn record_classes(program: &swc_ecma_ast::Program, module_path: &str, acc: &mut ParsedProject) {
+    match program {
+        swc_ecma_ast::Program::Module(m) => {
+            for item in &m.body {
+                record_class_from_module_item(item, module_path, acc);
+            }
+        }
+        swc_ecma_ast::Program::Script(s) => {
+            for stmt in &s.body {
+                if let swc_ecma_ast::Stmt::Decl(swc_ecma_ast::Decl::Class(class_decl)) = stmt {
+                    insert_class(class_decl, module_path, acc, true);
+                }
+            }
+        }
+    }
+}
 
-    // We already parsed programs in the loop above.
-    // Ideally we analyze inside the loop, but we need to iterate again or move analysis into step 1.
-    // Let's iterate programs again since we have them in memory.
-    for (i, program) in programs.iter().enumerate() {
-        let path = &file_paths[i];
+fn record_class_from_module_item(
+    item: &swc_ecma_ast::ModuleItem,
+    module_path: &str,
+    acc: &mut ParsedProject,
+) {
+    match item {
+        swc_ecma_ast::ModuleItem::ModuleDecl(swc_ecma_ast::ModuleDecl::ExportDecl(export)) => {
+            if let swc_ecma_ast::Decl::Class(class_decl) = &export.decl {
+                insert_class(class_decl, module_path, acc, true);
+            }
+        }
+        swc_ecma_ast::ModuleItem::Stmt(swc_ecma_ast::Stmt::Decl(swc_ecma_ast::Decl::Class(
+            class_decl,
+        ))) => {
+            insert_class(class_decl, module_path, acc, false);
+        }
+        _ => {}
+    }
+}
+
+fn insert_class(
+    class_decl: &swc_ecma_ast::ClassDecl,
+    module_path: &str,
+    acc: &mut ParsedProject,
+    overwrite: bool,
+) {
+    let class_name = class_decl.ident.sym.to_string();
+    if overwrite {
+        acc.class_module_map
+            .insert(class_name.clone(), module_path.to_string());
+    } else {
+        acc.class_module_map
+            .entry(class_name.clone())
+            .or_insert_with(|| module_path.to_string());
+    }
+
+    if let Some(type_params) = &class_decl.class.type_params {
+        if !type_params.params.is_empty() {
+            acc.generic_classes.insert(class_name);
+        }
+    }
+}
+
+// ------- phase 2: build DI graph + topological order -------
+
+fn analyze_di_graph(parsed: &ParsedProject) -> Result<(DiGraph, Vec<String>), TyrusError> {
+    let mut graph = DiGraph::new();
+    for (i, program) in parsed.programs.iter().enumerate() {
+        let path = &parsed.file_paths[i];
         let source_code = std::fs::read_to_string(path).map_err(TyrusError::IoError)?;
         let file_name = path.to_string_lossy().to_string();
 
@@ -133,46 +194,63 @@ pub(crate) fn build_project_impl(input_dir: &Path, output_dir: &Path) -> Result<
                 tyrus_analyzer::report::format_pretty(&analysis_result.diagnostics)
             );
         }
-
         graph.merge(analysis_result.graph);
     }
 
     let init_order = graph
         .resolve()
         .map_err(|e| TyrusError::Validation(e.to_string()))?;
+    Ok((graph, init_order))
+}
 
-    // 3. Transpile
-    for (i, program) in programs.iter().enumerate() {
-        let path = &file_paths[i];
-        let relative_path = path.strip_prefix(input_dir).unwrap_or(path);
-        let relative_path = relative_path.strip_prefix("src").unwrap_or(relative_path);
-        let output_path = output_dir.join("src").join(relative_path);
+// ------- phase 3: codegen + write .rs files -------
 
-        // Calculate module path for this file
-        let file_stem = path.file_stem().unwrap_or_default().to_string_lossy();
-        let sanitized_stem = file_stem.replace(['.', '-'], "_");
-
-        // Check if it's index.ts
-        let is_index = path.file_stem().and_then(|s| s.to_str()) == Some("index");
-
-        let generated = tyrus_codegen::generate(program, is_index);
-        let formatted_code = format_code(&generated.code)?;
-
-        let output_file = output_path.with_file_name(format!("{}.rs", sanitized_stem));
-
-        if let Some(parent) = output_file.parent() {
-            fs::create_dir_all(parent).map_err(TyrusError::IoError)?;
-        }
-
-        fs::write(output_file, formatted_code).map_err(TyrusError::IoError)?;
-
-        // Collect controllers
-        for controller in generated.controllers {
-            controllers.push(controller.struct_name);
-        }
+fn transpile_files(
+    input_dir: &Path,
+    output_dir: &Path,
+    parsed: &ParsedProject,
+) -> Result<Vec<String>, TyrusError> {
+    let mut controllers = Vec::new();
+    for (i, program) in parsed.programs.iter().enumerate() {
+        let path = &parsed.file_paths[i];
+        write_transpiled_file(input_dir, output_dir, path, program, &mut controllers)?;
     }
+    Ok(controllers)
+}
 
-    // 4. Generate mod.rs
+fn write_transpiled_file(
+    input_dir: &Path,
+    output_dir: &Path,
+    path: &Path,
+    program: &swc_ecma_ast::Program,
+    controllers: &mut Vec<String>,
+) -> Result<(), TyrusError> {
+    let relative_path = path.strip_prefix(input_dir).unwrap_or(path);
+    let relative_path = relative_path.strip_prefix("src").unwrap_or(relative_path);
+    let output_path = output_dir.join("src").join(relative_path);
+
+    let file_stem = path.file_stem().unwrap_or_default().to_string_lossy();
+    let sanitized_stem = file_stem.replace(['.', '-'], "_");
+    let is_index = path.file_stem().and_then(|s| s.to_str()) == Some("index");
+
+    let generated = tyrus_codegen::generate(program, is_index);
+    let formatted_code = format_code(&generated.code)?;
+    let output_file = output_path.with_file_name(format!("{sanitized_stem}.rs"));
+
+    if let Some(parent) = output_file.parent() {
+        fs::create_dir_all(parent).map_err(TyrusError::IoError)?;
+    }
+    fs::write(output_file, formatted_code).map_err(TyrusError::IoError)?;
+
+    for controller in generated.controllers {
+        controllers.push(controller.struct_name);
+    }
+    Ok(())
+}
+
+// ------- phase 4: walk dirs, build mod.rs tree, finalize lib.rs + error.rs -------
+
+fn finalize_module_tree(output_dir: &Path) -> Result<(), TyrusError> {
     for entry in WalkDir::new(output_dir) {
         let entry = entry.map_err(|e| TyrusError::IoError(e.into()))?;
         let path = entry.path();
@@ -181,51 +259,53 @@ pub(crate) fn build_project_impl(input_dir: &Path, output_dir: &Path) -> Result<
         }
     }
 
-    // Rename src/mod.rs to src/lib.rs for the crate root
+    rename_src_mod_to_lib(output_dir)?;
+    write_error_rs(output_dir)?;
+    patch_lib_rs_preamble(output_dir)
+}
+
+fn rename_src_mod_to_lib(output_dir: &Path) -> Result<(), TyrusError> {
     let src_mod = output_dir.join("src").join("mod.rs");
     let src_lib = output_dir.join("src").join("lib.rs");
     if src_mod.exists() {
-        fs::rename(src_mod, src_lib.clone()).map_err(TyrusError::IoError)?;
+        fs::rename(src_mod, src_lib).map_err(TyrusError::IoError)?;
     }
+    Ok(())
+}
 
-    // Generate error.rs
+fn write_error_rs(output_dir: &Path) -> Result<(), TyrusError> {
     let error_rs = output_dir.join("src").join("error.rs");
-    let error_content = get_app_error_code();
-    fs::write(error_rs, error_content).map_err(TyrusError::IoError)?;
+    fs::write(error_rs, get_app_error_code()).map_err(TyrusError::IoError)
+}
 
-    // Prepend #![allow(unused)] and append mod error + pub use error::AppError to lib.rs
+fn patch_lib_rs_preamble(output_dir: &Path) -> Result<(), TyrusError> {
+    let src_lib = output_dir.join("src").join("lib.rs");
     let mut lib_content = fs::read_to_string(&src_lib).map_err(TyrusError::IoError)?;
-    // Add crate-level allow(unused) to suppress NestJS module import warnings
-    lib_content = format!("#![allow(unused)]\n\n{}", lib_content);
-    // Only add `pub mod error;` if not already present (generate_mod_rs may have added it)
+    lib_content = format!("#![allow(unused)]\n\n{lib_content}");
     if !lib_content.contains("pub mod error;") {
         lib_content.push_str("\npub mod error;\n");
     }
     if !lib_content.contains("pub use error::AppError;") {
         lib_content.push_str("pub use error::AppError;\n");
     }
-    fs::write(&src_lib, lib_content).map_err(TyrusError::IoError)?;
+    fs::write(&src_lib, lib_content).map_err(TyrusError::IoError)
+}
 
-    // 5. Generate main.rs
+// ------- phase 5: main.rs -------
+
+fn write_main_rs(output_dir: &Path, ctx: &MainRsCtx<'_>) -> Result<(), TyrusError> {
     let main_content = generate_main_rs(
-        &init_order,
-        &class_module_map,
-        &controllers,
-        &graph,
-        &generic_classes,
+        ctx.init_order,
+        ctx.class_module_map,
+        ctx.controllers,
+        ctx.graph,
+        ctx.generic_classes,
     )?;
 
-    // Ensure src directory exists
     let src_dir = output_dir.join("src");
     if !src_dir.exists() {
         fs::create_dir_all(&src_dir).map_err(TyrusError::IoError)?;
     }
-
     let main_rs = src_dir.join("main.rs");
-    fs::write(main_rs, main_content).map_err(TyrusError::IoError)?;
-
-    // 6. Generate Cargo.toml
-    generate_cargo_toml(output_dir)?;
-
-    Ok(())
+    fs::write(main_rs, main_content).map_err(TyrusError::IoError)
 }


### PR DESCRIPTION
## Summary

`build_project_impl` was a 220-line procedure with 5 commented phases — CRITICAL Rule 4 violation (≤50 line ceiling). This PR turns each phase into its own function, with state flowing through two small structs.

Closes #148.

## Approach

The original code already documented its phases via `// 1. Walk, Parse, …`, `// 2. Analyze`, etc. comments — this PR makes those sections real functions:

| Phase | Function | Lines |
|-------|----------|-------|
| top | `build_project_impl` | 20 (was 220) |
| 1 — walk + parse + class meta | `parse_and_collect` | 18 |
| 1 helpers | `ingest_typescript_file`, `compute_module_path`, `record_classes`, `record_class_from_module_item`, `insert_class` | 12, 29, 16, 19, 24 |
| 2 — DI graph + topo order | `analyze_di_graph` | 27 |
| 3 — codegen + write `.rs` | `transpile_files`, `write_transpiled_file` | 12, 31 |
| 4 — mod.rs / lib.rs / error.rs | `finalize_module_tree`, `rename_src_mod_to_lib`, `write_error_rs`, `patch_lib_rs_preamble` | 13, 8, 4, 14 |
| 5 — main.rs | `write_main_rs` | 15 |

State flows through two scoped structs:

```rust
struct ParsedProject {            // phase 1 → 2/3/5
    programs: Vec<swc_ecma_ast::Program>,
    file_paths: Vec<PathBuf>,
    class_module_map: HashMap<String, String>,
    generic_classes: HashSet<String>,
}

struct MainRsCtx<'a> {            // caller → phase 5
    init_order: &'a [String],
    class_module_map: &'a HashMap<String, String>,
    controllers: &'a [String],
    graph: &'a DiGraph,
    generic_classes: &'a HashSet<String>,
}
```

`MainRsCtx` exists specifically so `write_main_rs` stays at 2 params (Rule 4 ≤5-arg ceiling) — `generate_main_rs` itself takes 5 args, which we just unpack from the borrowed context.

## Files Changed

| File | Before | After |
|------|--------|-------|
| `crates/tyrus_orchestrator/src/pipeline.rs` | 231 | 311 |

The line count grew because helper signatures + struct definitions add boilerplate, but distribution is healthy: largest function is 31 lines.

## Test Plan

- [x] `cargo nextest run --workspace` — 248/248 passing (1 skipped)
- [x] `bash scripts/gates.sh fmt clippy filesize audit` — all green
- [x] `test_http_equivalence_rust_server` — NestJS pipeline still serves correct responses
- [x] `test_reference_nestjs_transpiles_and_compiles` — multi-module reference unchanged
- [x] `test_multi_module_build` — DI ordering preserved
- [x] No semantic change: pure structural split of a single procedure

## Power of Ten Compliance

- **Rule 4:** all 16 functions ≤31 lines (was 1 function at 220), ≤5 params, file 311 lines (under cap)
- **Rule 6:** no new `unwrap`/`expect` — every `?` propagates `TyrusError`
- **Rule 11:** single-issue PR, only addresses #148