### PR TITLE
fix(benches): replace deprecated criterion::black_box with std::hint::black_box

### DIFF
--- a/crates/tyrus_orchestrator/benches/transpiler.rs
+++ b/crates/tyrus_orchestrator/benches/transpiler.rs
@@ -1,8 +1,9 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
+use std::hint::black_box;
 use std::io::Write;
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use tempfile::NamedTempFile;
 use tyrus_common::fs::FilePath;
 


### PR DESCRIPTION
## Summary

After PR #171 (criterion `0.5.1` → `0.8.2`) merged, `criterion::black_box` is deprecated. With `-D warnings` in clippy, this breaks `cargo clippy --workspace --all-targets` and therefore the local pre-commit + CI clippy job.

`runtime_comparison.rs` does not import the helper — only `transpiler.rs` is affected.

## Change

```diff
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::hint::black_box;
+use std::io::Write;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
```

The 7 call sites already use unqualified `black_box(...)`; only the import had to change. Net diff: +2 / -1 line.

## Test Plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green
- [x] `bash scripts/gates.sh fmt clippy filesize audit` — green (transpiler.rs at 400 lines, exactly at the soft cap)
- [x] `cargo bench --bench transpiler --no-run` — compiles cleanly

## Notes

- Pre-commit was run with `TYRUS_SKIP_COVERAGE=1` because of unrelated regression #178 (main coverage at 69.88% post-#170 syn bump).
- This is a clean prep step — Sprint 2 PR #153 (constructor.rs split) was blocked locally by the bench compile error this PR resolves.