### PR TITLE
chore(scripts): add disk-clean.sh + CONTRIBUTING disk hygiene section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,3 +151,26 @@ The orchestrator (`crates/tyrus_orchestrator/src/`) coordinates multi-file build
 | `pipeline.rs` | Core multi-file build orchestration |
 | `scaffold.rs` | Project scaffolding (`main.rs`, `Cargo.toml`, `mod.rs`) |
 | `format.rs` | Code formatting + `AppError` generation |
+
+## 💾 Disk Hygiene
+
+The Tyrus build tree can reach **~22 GB** during heavy use. Two reasons:
+
+1. `target/` carries the standard Rust artefacts (debug ≈2.5 GB, llvm-cov-target ≈2 GB, tests ≈1.6 GB).
+2. `/tmp/tyrus_test_target/` is a **shared `CARGO_TARGET_DIR`** used by every `assert_rust_compiles` and `assert_output_equivalent` test (see `crates/tyrus_test_utils/src/lib.rs:18`). Each test compiles a generated Rust project that depends on `axum`, `tokio`, `serde`, `reqwest`, etc. Sharing the target dir avoids rebuilding those crates per test (≈10× speed-up); the cost is unbounded growth.
+
+**Cleanup:**
+
+```bash
+# See current footprint
+bash scripts/disk-clean.sh --report
+
+# Drop only stale artifacts (>14 days untouched in /tmp, >30 days
+# in cargo's incremental cache, >7 days .profraw files)
+bash scripts/disk-clean.sh
+
+# Full wipe — recover everything (requires next test run to rebuild deps)
+bash scripts/disk-clean.sh --all
+```
+
+The shared `/tmp` target is intentional. Do **not** redirect tests to a per-test target — the suite walltime jumps from ≈60 s to ≈10 min.

--- a/scripts/disk-clean.sh
+++ b/scripts/disk-clean.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Tyrus disk hygiene.
+#
+# Usage:
+#   bash scripts/disk-clean.sh             # incremental: drop stale artifacts only
+#   bash scripts/disk-clean.sh --all       # full wipe: cargo clean + remove shared targets
+#   bash scripts/disk-clean.sh --report    # report current footprint without deleting
+#
+# The shared `/tmp/tyrus_test_target` is intentional — it lets every
+# `assert_rust_compiles` and `assert_output_equivalent` test reuse compiled
+# dependencies (axum, tokio, serde, reqwest, ...) instead of rebuilding each
+# crate per test. Without it, the test suite is ≈10× slower and drowns CI.
+# The trade-off is unbounded growth, hence this script.
+
+set -euo pipefail
+
+mode="${1:-incremental}"
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+shared_target="${TMPDIR:-/tmp}/tyrus_test_target"
+
+report() {
+    echo "=== Tyrus disk footprint ==="
+    du -sh "$repo_root/target" 2>/dev/null || echo "(no repo target)"
+    du -sh "$repo_root/tests/target" 2>/dev/null || true
+    du -sh "$shared_target" 2>/dev/null || echo "(no shared test target)"
+    du -sh "$repo_root/benchmarks/academic" 2>/dev/null || true
+    echo "Repo total: $(du -sh "$repo_root" | cut -f1)"
+}
+
+case "$mode" in
+    --report)
+        report
+        ;;
+    --all)
+        echo "Full wipe — recovering all build artifacts..."
+        (cd "$repo_root" && cargo clean) || true
+        (cd "$repo_root" && cargo llvm-cov clean --workspace 2>/dev/null) || true
+        rm -rf "$shared_target" "$repo_root/tests/target"
+        echo "Done."
+        report
+        ;;
+    incremental|"")
+        echo "Incremental cleanup — dropping stale artifacts only..."
+        # Stale .profraw files (coverage instrumentation) > 7 days
+        find "$repo_root/target/llvm-cov-target" -name '*.profraw' -atime +7 -delete 2>/dev/null || true
+        # Test target files unused for > 14 days
+        find "$shared_target" -type f -atime +14 -delete 2>/dev/null || true
+        # Cargo's own incremental build cache > 30 days
+        find "$repo_root/target/debug/incremental" -mindepth 1 -maxdepth 1 -atime +30 -exec rm -rf {} + 2>/dev/null || true
+        echo "Done."
+        report
+        ;;
+    *)
+        echo "ERROR: unknown mode '$mode'" >&2
+        echo "Usage: $0 [--all|--report|incremental]" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

Tyrus build tree can reach **~22 GB** during heavy use. This PR introduces a hygiene script and documents the trade-off.

## Why so much disk

| Path | Size | Reason |
|------|------|--------|
| `target/` | 6.1 GB | standard cargo (debug + llvm-cov-target + tests) |
| `tests/target/` | 542 MB | nextest binaries |
| `benchmarks/academic/` | 259 MB | criterion HTML reports |
| **`/tmp/tyrus_test_target/`** | **15 GB** | shared CARGO_TARGET_DIR for assert_rust_compiles |

The 15 GB `/tmp` directory is intentional. Every `assert_rust_compiles` and `assert_output_equivalent` test compiles a generated Rust project that depends on `axum`, `tokio`, `serde`, `reqwest`, etc. Sharing the target dir avoids rebuilding those crates per test (~10× speed-up). The cost is unbounded growth — hence this script.

## Changes

- `scripts/disk-clean.sh` — three modes:
  - `--report` — show current footprint, no deletions
  - default (incremental) — drop `.profraw` >7 days, `/tmp/tyrus_test_target` files >14 days, `target/debug/incremental` >30 days
  - `--all` — full wipe: `cargo clean` + remove shared targets
- `CONTRIBUTING.md` — new 'Disk Hygiene' section explaining the trade-off and pointing to the script

## Verified

- [x] `bash scripts/disk-clean.sh --report` prints current footprint
- [x] `bash scripts/disk-clean.sh --all` recovers ~21 GB on a heavily-used tree (22 GB → 291 MB)
- [x] `bash scripts/gates.sh all` — green
- [x] No production code changes; pure tooling addition