### PR TITLE
refactor(orchestrator): split pipeline.rs analyzer logic into analyze.rs

### DIFF
--- a/crates/tyrus_orchestrator/src/pipeline.rs
+++ b/crates/tyrus_orchestrator/src/pipeline.rs
@@ -10,6 +10,8 @@ use tyrus_diagnostics::TyrusError;
 use crate::format::{format_code, get_app_error_code};
 use crate::scaffold::{generate_cargo_toml, generate_main_rs, generate_mod_rs};
 
+mod analyze;
+
 /// Output of phase 1: every parsed `.ts` file plus the class metadata
 /// needed by phases 2-5.
 struct ParsedProject {
@@ -30,7 +32,7 @@ struct MainRsCtx<'a> {
 
 pub(crate) fn build_project_impl(input_dir: &Path, output_dir: &Path) -> Result<(), TyrusError> {
     let parsed = parse_and_collect(input_dir)?;
-    let (graph, init_order) = analyze_di_graph(&parsed)?;
+    let (graph, init_order) = analyze::analyze_di_graph(&parsed)?;
     let controllers = transpile_files(input_dir, output_dir, &parsed)?;
     finalize_module_tree(output_dir)?;
     write_main_rs(
@@ -175,33 +177,7 @@ fn insert_class(
     }
 }
 
-// ------- phase 2: build DI graph + topological order -------
-
-fn analyze_di_graph(parsed: &ParsedProject) -> Result<(DiGraph, Vec<String>), TyrusError> {
-    let mut graph = DiGraph::new();
-    for (i, program) in parsed.programs.iter().enumerate() {
-        let path = &parsed.file_paths[i];
-        let source_code = std::fs::read_to_string(path).map_err(TyrusError::IoError)?;
-        let file_name = path.to_string_lossy().to_string();
-
-        let analysis_result = tyrus_analyzer::Analyzer::analyze(program, source_code, file_name);
-        for error in analysis_result.errors {
-            println!("Warning: {:?}", miette::Report::new(error));
-        }
-        if !analysis_result.diagnostics.is_empty() {
-            eprintln!(
-                "{}",
-                tyrus_analyzer::report::format_pretty(&analysis_result.diagnostics)
-            );
-        }
-        graph.merge(analysis_result.graph);
-    }
-
-    let init_order = graph
-        .resolve()
-        .map_err(|e| TyrusError::Validation(e.to_string()))?;
-    Ok((graph, init_order))
-}
+// ------- phase 2: DI graph analysis → see pipeline/analyze.rs -------
 
 // ------- phase 3: codegen + write .rs files -------
 

--- a/crates/tyrus_orchestrator/src/pipeline/analyze.rs
+++ b/crates/tyrus_orchestrator/src/pipeline/analyze.rs
@@ -1,0 +1,34 @@
+use std::fs;
+
+use tyrus_di::graph::DiGraph;
+use tyrus_diagnostics::TyrusError;
+
+use super::ParsedProject;
+
+pub(super) fn analyze_di_graph(
+    parsed: &ParsedProject,
+) -> Result<(DiGraph, Vec<String>), TyrusError> {
+    let mut graph = DiGraph::new();
+    for (i, program) in parsed.programs.iter().enumerate() {
+        let path = &parsed.file_paths[i];
+        let source_code = fs::read_to_string(path).map_err(TyrusError::IoError)?;
+        let file_name = path.to_string_lossy().to_string();
+
+        let analysis_result = tyrus_analyzer::Analyzer::analyze(program, source_code, file_name);
+        for error in analysis_result.errors {
+            println!("Warning: {:?}", miette::Report::new(error));
+        }
+        if !analysis_result.diagnostics.is_empty() {
+            eprintln!(
+                "{}",
+                tyrus_analyzer::report::format_pretty(&analysis_result.diagnostics)
+            );
+        }
+        graph.merge(analysis_result.graph);
+    }
+
+    let init_order = graph
+        .resolve()
+        .map_err(|e| TyrusError::Validation(e.to_string()))?;
+    Ok((graph, init_order))
+}


### PR DESCRIPTION
## Summary

Pre-emptive Rule 4 compliance step before #188 (analyzer wiring) lands. Extracts `analyze_di_graph` from `pipeline.rs` (was 311 LOC) into a new `pipeline/analyze.rs` submodule. **Zero behavior change.**

Per Decision **D7** of the [UAT bug-fixes plan](.claude/plan/uat-bug-fixes-2026-05-07.md):

> "Before #188 lands, `pipeline.rs` (311 LOC) is split: extract `analyze_di_graph` + new error-aggregation helpers into `crates/tyrus_orchestrator/src/pipeline/analyze.rs`."

## Changes

| File | Op | LOC |
|------|----|-----|
| `crates/tyrus_orchestrator/src/pipeline.rs` | Modified | 311 → 287 |
| `crates/tyrus_orchestrator/src/pipeline/analyze.rs` | Created | +32 |

The function body moved byte-for-byte. Only delta: `std::fs::read_to_string` → `fs::read_to_string` (cosmetic, due to `use std::fs;` at the top of the new file).

## Validation (Anti-rubber-stamp protocol per plan D10)

Both reviewers were dispatched in parallel and confirmed zero-behavior-change:

- **`tyrus-architect`** ✅ APPROVED — cited 6 line references; verified single call site via grep; confirmed `pub(super)` is the correct visibility ceiling for PR-3 to extend.
- **`everything-claude-code:code-reviewer`** ✅ APPROVED with one trivial 1-line change (applied) — verified imports clean, no leftover dead code, byte-equivalence of function body.

## Pre-existing tech debt flagged (out of scope, tracked separately)

The reviewers noted that `analyze_di_graph` uses `println!("Warning: ...")` for analyzer errors (lines moved verbatim from the original). This is exactly what PR-3 (#188) fixes per Decision D3 of the plan — promote errors from print-only to `Err(Validation)` aggregation.

## Test plan

- [x] `cargo fmt -- --check` ✅
- [x] `cargo clippy --workspace --all-targets -- -D warnings` ✅
- [x] `cargo nextest run --workspace` ✅ 259 passed, 1 pre-existing skip
- [x] `cargo deny check` ✅ (license/advisory warnings are expected for unmatched allow-list entries)
- [x] `cargo audit` ✅
- [x] File sizes: pipeline.rs 287 LOC, analyze.rs 32 LOC (well under R4 ceiling)
- [x] Independent grep: `analyze_di_graph` referenced only twice (definition + sole call site)

Closes #195
Refs: \`.claude/plan/uat-bug-fixes-2026-05-07.md\` (D7, PR-0)