### PR TITLE
fix(codegen): emit top-level statements via visit_stmt override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,6 +1981,7 @@ dependencies = [
  "serde_json",
  "swc_common",
  "swc_ecma_ast",
+ "swc_ecma_parser",
  "swc_ecma_visit",
  "tyrus_common",
  "tyrus_decorator_kinds",

--- a/crates/tyrus_analyzer/Cargo.toml
+++ b/crates/tyrus_analyzer/Cargo.toml
@@ -19,3 +19,6 @@ miette = { version = "7.6.0", features = ["fancy"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 console = "0.15"
+
+[dev-dependencies]
+swc_ecma_parser = "39.0.2"

--- a/crates/tyrus_analyzer/src/lints.rs
+++ b/crates/tyrus_analyzer/src/lints.rs
@@ -1,8 +1,10 @@
 use miette::{NamedSource, SourceSpan};
 use tyrus_diagnostics::TyrusError;
 
+use swc_common::Spanned;
 use swc_ecma_ast::{
-    CallExpr, Callee, Expr, TsKeywordType, TsKeywordTypeKind, VarDecl, VarDeclKind,
+    CallExpr, Callee, Decl, DefaultDecl, Expr, FnDecl, Module, ModuleDecl, ModuleItem, Script,
+    Stmt, TsKeywordType, TsKeywordTypeKind, VarDecl, VarDeclKind,
 };
 use swc_ecma_visit::{Visit, VisitWith};
 
@@ -27,9 +29,115 @@ impl LintVisitor {
         let len = end - start;
         SourceSpan::new(start.into(), len)
     }
+
+    /// D1 — emit `AmbiguousMainEntrypoint` when the file both declares a
+    /// user-level `function main()` AND contains top-level non-decl statements.
+    /// Either alone is fine; combined, the codegen at `tyrus_codegen::generate`
+    /// (lib.rs `!has_declared_main` gate) would either drop the statements or
+    /// duplicate `fn main()`. Mirrors codegen's `has_declared_main` detection
+    /// across all three TS forms: bare, `export`, and `export default`.
+    fn check_ambiguous_main(&mut self, items: &ModuleItemsView<'_>) {
+        let (has_user_main, first_top_stmt_span) = items.classify();
+        if let (true, Some(span)) = (has_user_main, first_top_stmt_span) {
+            self.errors.push(TyrusError::AmbiguousMainEntrypoint {
+                src: NamedSource::new(self.file_name.clone(), self.source_code.clone()),
+                span: self.create_span(span),
+            });
+        }
+    }
+}
+
+/// Wraps either `&Module` or `&Script` items so D1 can scan a single uniform
+/// API. `Module` items may carry an `export function main()` decl (under
+/// `ModuleDecl::ExportDecl` or `ModuleDecl::ExportDefaultDecl`) — codegen
+/// recognises both, so D1 must mirror that.
+enum ModuleItemsView<'a> {
+    Module(&'a [ModuleItem]),
+    Script(&'a [Stmt]),
+}
+
+impl ModuleItemsView<'_> {
+    fn classify(&self) -> (bool, Option<swc_common::Span>) {
+        let mut has_user_main = false;
+        let mut first_top_stmt_span: Option<swc_common::Span> = None;
+        match self {
+            ModuleItemsView::Module(items) => {
+                for item in *items {
+                    match item {
+                        ModuleItem::Stmt(stmt) => {
+                            classify_stmt(stmt, &mut has_user_main, &mut first_top_stmt_span);
+                        }
+                        ModuleItem::ModuleDecl(decl) => {
+                            classify_module_decl(decl, &mut has_user_main);
+                        }
+                    }
+                }
+            }
+            ModuleItemsView::Script(stmts) => {
+                for stmt in *stmts {
+                    classify_stmt(stmt, &mut has_user_main, &mut first_top_stmt_span);
+                }
+            }
+        }
+        (has_user_main, first_top_stmt_span)
+    }
+}
+
+fn classify_stmt(
+    stmt: &Stmt,
+    has_user_main: &mut bool,
+    first_top_stmt_span: &mut Option<swc_common::Span>,
+) {
+    match stmt {
+        Stmt::Decl(Decl::Fn(fn_decl)) if is_main_fn(fn_decl) => {
+            *has_user_main = true;
+        }
+        Stmt::Decl(_) => {}
+        other => {
+            if first_top_stmt_span.is_none() {
+                *first_top_stmt_span = Some(other.span());
+            }
+        }
+    }
+}
+
+fn classify_module_decl(decl: &ModuleDecl, has_user_main: &mut bool) {
+    match decl {
+        ModuleDecl::ExportDecl(export) => {
+            if let Decl::Fn(fn_decl) = &export.decl {
+                if is_main_fn(fn_decl) {
+                    *has_user_main = true;
+                }
+            }
+        }
+        ModuleDecl::ExportDefaultDecl(default) => {
+            if let DefaultDecl::Fn(fn_expr) = &default.decl {
+                if let Some(ident) = &fn_expr.ident {
+                    if ident.sym == "main" {
+                        *has_user_main = true;
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_main_fn(fn_decl: &FnDecl) -> bool {
+    fn_decl.ident.sym == "main"
 }
 
 impl Visit for LintVisitor {
+    fn visit_module(&mut self, n: &Module) {
+        self.check_ambiguous_main(&ModuleItemsView::Module(&n.body));
+        n.visit_children_with(self);
+    }
+
+    fn visit_script(&mut self, n: &Script) {
+        self.check_ambiguous_main(&ModuleItemsView::Script(&n.body));
+        n.visit_children_with(self);
+    }
+
     fn visit_var_decl(&mut self, n: &VarDecl) {
         if n.kind == VarDeclKind::Var {
             self.errors.push(TyrusError::UseOfVar {
@@ -103,5 +211,131 @@ impl Visit for LintVisitor {
             span: self.create_span(n.span),
         });
         n.visit_children_with(self);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use swc_common::sync::Lrc;
+    use swc_common::{FileName, SourceMap};
+    use swc_ecma_ast::Program;
+    use swc_ecma_parser::{Parser, StringInput, Syntax, TsSyntax};
+
+    fn parse_module(source: &str) -> Module {
+        let cm: Lrc<SourceMap> = Default::default();
+        let fm = cm.new_source_file(FileName::Anon.into(), source.to_string());
+        let mut parser = Parser::new(
+            Syntax::Typescript(TsSyntax::default()),
+            StringInput::from(&*fm),
+            None,
+        );
+        parser.parse_module().expect("parse_module")
+    }
+
+    fn run_lints(source: &str) -> Vec<TyrusError> {
+        let module = parse_module(source);
+        let program = Program::Module(module);
+        let mut visitor = LintVisitor::new(source.to_string(), "test.ts".to_string());
+        program.visit_with(&mut visitor);
+        visitor.errors
+    }
+
+    #[test]
+    fn d1_reports_when_user_main_and_top_level_stmt_coexist() {
+        let errors = run_lints(
+            r#"
+function main(): void {
+    console.log("user main");
+}
+console.log("orphan top level");
+"#,
+        );
+        let has_d1 = errors
+            .iter()
+            .any(|e| matches!(e, TyrusError::AmbiguousMainEntrypoint { .. }));
+        assert!(has_d1, "expected AmbiguousMainEntrypoint, got: {errors:?}");
+    }
+
+    #[test]
+    fn d1_silent_when_only_user_main() {
+        let errors = run_lints(
+            r#"
+function main(): void {
+    console.log("just main");
+}
+"#,
+        );
+        let has_d1 = errors
+            .iter()
+            .any(|e| matches!(e, TyrusError::AmbiguousMainEntrypoint { .. }));
+        assert!(!has_d1, "no diagnostic expected, got: {errors:?}");
+    }
+
+    #[test]
+    fn d1_silent_when_only_top_level_stmts() {
+        let errors = run_lints(
+            r#"
+console.log("hello");
+"#,
+        );
+        let has_d1 = errors
+            .iter()
+            .any(|e| matches!(e, TyrusError::AmbiguousMainEntrypoint { .. }));
+        assert!(!has_d1, "no diagnostic expected, got: {errors:?}");
+    }
+
+    #[test]
+    fn d1_silent_when_only_decls() {
+        let errors = run_lints(
+            r#"
+interface User { name: string; }
+function helper(): number { return 42; }
+function main(): void { console.log("ok"); }
+"#,
+        );
+        let has_d1 = errors
+            .iter()
+            .any(|e| matches!(e, TyrusError::AmbiguousMainEntrypoint { .. }));
+        assert!(!has_d1, "no diagnostic expected, got: {errors:?}");
+    }
+
+    #[test]
+    fn d1_reports_when_exported_main_and_top_level_stmt_coexist() {
+        let errors = run_lints(
+            r#"
+export function main(): void {
+    console.log("exported main");
+}
+console.log("orphan");
+"#,
+        );
+        let has_d1 = errors
+            .iter()
+            .any(|e| matches!(e, TyrusError::AmbiguousMainEntrypoint { .. }));
+        assert!(
+            has_d1,
+            "expected AmbiguousMainEntrypoint for exported main, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn d1_reports_when_export_default_main_and_top_level_stmt_coexist() {
+        let errors = run_lints(
+            r#"
+export default function main(): void {
+    console.log("default main");
+}
+console.log("orphan");
+"#,
+        );
+        let has_d1 = errors
+            .iter()
+            .any(|e| matches!(e, TyrusError::AmbiguousMainEntrypoint { .. }));
+        assert!(
+            has_d1,
+            "expected AmbiguousMainEntrypoint for export default main, got: {errors:?}"
+        );
     }
 }

--- a/crates/tyrus_codegen/src/convert/interface.rs
+++ b/crates/tyrus_codegen/src/convert/interface.rs
@@ -150,7 +150,8 @@ impl Visit for RustGenerator {
     }
 
     fn visit_stmt(&mut self, n: &swc_ecma_ast::Stmt) {
-        // This is called for top-level statements via process_module_item -> visit_with(self)
+        // Called directly from process_module_item via self.visit_stmt(stmt)
+        // (also fires from visit_children_with in nested function/class bodies).
         match n {
             swc_ecma_ast::Stmt::Decl(swc_ecma_ast::Decl::Fn(_))
             | swc_ecma_ast::Stmt::Decl(swc_ecma_ast::Decl::Class(_))

--- a/crates/tyrus_codegen/src/convert/module.rs
+++ b/crates/tyrus_codegen/src/convert/module.rs
@@ -1,5 +1,5 @@
 use swc_ecma_ast::{ImportSpecifier, ModuleDecl, ModuleItem};
-use swc_ecma_visit::VisitWith;
+use swc_ecma_visit::{Visit, VisitWith};
 
 use super::interface::RustGenerator;
 
@@ -59,7 +59,10 @@ impl RustGenerator {
     pub(crate) fn process_module_item(&mut self, n: &ModuleItem) {
         match n {
             ModuleItem::ModuleDecl(decl) => self.process_module_decl(decl),
-            ModuleItem::Stmt(stmt) => stmt.visit_with(self),
+            // `visit_with` traverses children only — bypassing the custom
+            // `visit_stmt` override at `interface.rs`. Direct dispatch ensures
+            // top-level statements route into `main_body` instead of being dropped.
+            ModuleItem::Stmt(stmt) => self.visit_stmt(stmt),
         }
     }
 

--- a/crates/tyrus_codegen/src/lib.rs
+++ b/crates/tyrus_codegen/src/lib.rs
@@ -3,6 +3,8 @@ pub(crate) mod decorators;
 pub mod stdlib;
 
 use convert::interface::RustGenerator;
+use proc_macro2::TokenStream;
+use std::str::FromStr;
 use swc_ecma_ast::Program;
 use swc_ecma_visit::VisitWith;
 
@@ -22,10 +24,10 @@ pub fn generate(program: &Program, is_index: bool) -> GeneratedCode {
     program.visit_with(&mut generator);
 
     if !generator.main_body.is_empty() && !generator.has_declared_main {
-        // Wrap top-level statements in fn main() only if no main function already declared.
-        generator.code.push_str("\nfn main() {\n");
-        generator.code.push_str(&generator.main_body);
-        generator.code.push_str("}\n");
+        generator.code.push('\n');
+        generator
+            .code
+            .push_str(&wrap_top_level_in_main(&generator.main_body));
     }
 
     let code = if generator.needs_int_serde.get() {
@@ -38,6 +40,27 @@ pub fn generate(program: &Program, is_index: bool) -> GeneratedCode {
         code,
         controllers: generator.controllers,
     }
+}
+
+/// Wraps top-level script statements in `fn main() { ... }`.
+///
+/// Per Power of Ten Rule 7, code emission goes through `quote!` rather
+/// than string concatenation. Statements arrive already converted to
+/// Rust syntax (via `convert_stmt`), so we parse them as a TokenStream
+/// and embed under a function header. Parse failure surfaces via
+/// `compile_error!` rather than silent body drop.
+fn wrap_top_level_in_main(body: &str) -> String {
+    let body_tokens = TokenStream::from_str(body).unwrap_or_else(|_| {
+        quote::quote! {
+            compile_error!("Tyrus: internal error — top-level statement TokenStream parse failed");
+        }
+    });
+    let wrapped = quote::quote! {
+        fn main() {
+            #body_tokens
+        }
+    };
+    format!("{wrapped}\n")
 }
 
 /// Module emitted at the top of any generated file that uses the
@@ -56,3 +79,40 @@ mod __tyrus_int_serde {
     }
 }
 "#;
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::wrap_top_level_in_main;
+
+    #[test]
+    fn wrap_emits_fn_main_for_valid_body() {
+        let out = wrap_top_level_in_main("println!(\"hi\");");
+        assert!(out.contains("fn main"), "expected fn main: {out}");
+        assert!(out.contains("println"), "expected println in body: {out}");
+    }
+
+    #[test]
+    fn wrap_fallback_emits_compile_error_on_unbalanced_tokens() {
+        // Token-level parse failure (unpaired delimiters) hits the
+        // unwrap_or_else fallback and must surface via compile_error!.
+        let out = wrap_top_level_in_main("fn { invalid {{{{");
+        assert!(
+            out.contains("compile_error"),
+            "fallback should emit compile_error!, got: {out}"
+        );
+        assert!(
+            out.contains("Tyrus:"),
+            "fallback message should carry Tyrus prefix: {out}"
+        );
+    }
+
+    #[test]
+    fn wrap_emits_empty_main_for_empty_body() {
+        let out = wrap_top_level_in_main("");
+        assert!(
+            out.contains("fn main"),
+            "even empty body still gets fn main wrapper: {out}"
+        );
+    }
+}

--- a/crates/tyrus_diagnostics/src/lib.rs
+++ b/crates/tyrus_diagnostics/src/lib.rs
@@ -55,6 +55,20 @@ pub enum TyrusError {
         span: SourceSpan,
     },
 
+    #[error(
+        "Lint Error: Ambiguous main entrypoint — file declares `function main()` AND \
+         contains top-level executable statements. Tyrus would either drop the \
+         statements or duplicate the main function. Choose one: either move the \
+         statements inside `main()`, or remove the user-declared `main` function."
+    )]
+    #[diagnostic(code(tyrus::lint::ambiguous_main_entrypoint))]
+    AmbiguousMainEntrypoint {
+        #[source_code]
+        src: NamedSource<String>,
+        #[label("first top-level statement here")]
+        span: SourceSpan,
+    },
+
     #[error("Formatting Error: {0}")]
     #[diagnostic(code(tyrus::fmt_error))]
     FormattingError(String),

--- a/tests/fixtures/uat/forbidden.ts
+++ b/tests/fixtures/uat/forbidden.ts
@@ -1,0 +1,12 @@
+// Tyrus UAT fixture — intentionally uses syntax the analyzer rejects.
+// Used by Lane L8 (Forbidden TS).
+
+var legacy: any = "this should be rejected";
+
+const obj: { foo: string; bar: number } = { foo: "x", bar: 1 };
+for (const key in obj) {
+    console.log(key);
+}
+
+const result: any = eval("1 + 1");
+console.log(result);

--- a/tests/fixtures/uat/main.js
+++ b/tests/fixtures/uat/main.js
@@ -1,0 +1,8 @@
+// Tyrus UAT fixture — vanilla JavaScript (not TypeScript).
+// Used by Lane L7 (JS, not TS).
+
+function greet(name) {
+    return "Hello, " + name + "!";
+}
+
+console.log(greet("World"));

--- a/tests/fixtures/uat/nest-mini/src/app.controller.ts
+++ b/tests/fixtures/uat/nest-mini/src/app.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Get, Post } from "@nestjs/common";
+import { AppService } from "./app.service";
+import { CreateItemDto, Item } from "./dto";
+
+@Controller("/items")
+export class AppController {
+    constructor(private readonly appService: AppService) {}
+
+    @Get("/")
+    findAll(): Item[] {
+        return this.appService.findAll();
+    }
+
+    @Post("/")
+    create(@Body() dto: CreateItemDto): Item {
+        return this.appService.create(dto);
+    }
+}

--- a/tests/fixtures/uat/nest-mini/src/app.module.ts
+++ b/tests/fixtures/uat/nest-mini/src/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { AppController } from "./app.controller";
+import { AppService } from "./app.service";
+
+@Module({
+    imports: [],
+    controllers: [AppController],
+    providers: [AppService],
+})
+export class AppModule {}

--- a/tests/fixtures/uat/nest-mini/src/app.service.ts
+++ b/tests/fixtures/uat/nest-mini/src/app.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from "@nestjs/common";
+import { CreateItemDto, Item } from "./dto";
+
+@Injectable()
+export class AppService {
+    private items: Item[];
+    private nextId: number;
+
+    constructor() {
+        this.items = [];
+        this.nextId = 1;
+    }
+
+    findAll(): Item[] {
+        return this.items;
+    }
+
+    create(dto: CreateItemDto): Item {
+        const item: Item = {
+            id: this.nextId,
+            name: dto.name,
+            quantity: dto.quantity,
+        };
+        this.items.push(item);
+        this.nextId = this.nextId + 1;
+        return item;
+    }
+}

--- a/tests/fixtures/uat/nest-mini/src/dto.ts
+++ b/tests/fixtures/uat/nest-mini/src/dto.ts
@@ -1,0 +1,10 @@
+export interface CreateItemDto {
+    name: string;
+    quantity: number;
+}
+
+export interface Item {
+    id: number;
+    name: string;
+    quantity: number;
+}

--- a/tests/fixtures/uat/nest-mini/src/index.ts
+++ b/tests/fixtures/uat/nest-mini/src/index.ts
@@ -1,0 +1,3 @@
+import { AppModule } from "./app.module";
+
+export { AppModule };

--- a/tests/fixtures/uat/quick.ts
+++ b/tests/fixtures/uat/quick.ts
@@ -1,0 +1,51 @@
+// Tyrus UAT fixture — single-file Tier 1 + 2 sample.
+// Used by Lane L4 (Single-file Hacker).
+
+interface User {
+    id: number;
+    name: string;
+    email: string;
+    active: boolean;
+}
+
+function isAdult(age: number): boolean {
+    return age >= 18;
+}
+
+function classify(score: number): string {
+    if (score >= 90) {
+        return "excellent";
+    } else if (score >= 70) {
+        return "good";
+    } else if (score >= 50) {
+        return "passing";
+    } else {
+        return "failing";
+    }
+}
+
+function sumPositive(nums: number[]): number {
+    let total: number = 0;
+    for (const n of nums) {
+        if (n > 0) {
+            total = total + n;
+        }
+    }
+    return total;
+}
+
+function greetUser(user: User): string {
+    return `Hello, ${user.name}! Your id is ${user.id}.`;
+}
+
+const alice: User = {
+    id: 1,
+    name: "Alice",
+    email: "alice@example.com",
+    active: true,
+};
+
+console.log(greetUser(alice));
+console.log("isAdult(20):", isAdult(20));
+console.log("classify(85):", classify(85));
+console.log("sumPositive([1,-2,3,-4,5]):", sumPositive([1, -2, 3, -4, 5]));

--- a/tests/src/equivalence/top_level.rs
+++ b/tests/src/equivalence/top_level.rs
@@ -1,4 +1,4 @@
-use crate::helpers::assert_output_equivalent;
+use crate::helpers::{assert_output_equivalent, transpile};
 
 #[test]
 fn test_equivalence_top_level_const() {
@@ -36,5 +36,94 @@ function greet(name: string): string {
 const message: string = greet("World");
 console.log(message);
 "#,
+    );
+}
+
+/// Regression test for #186 (UAT-C1): ExprStmt at module level was silently
+/// dropped because `process_module_item` used `stmt.visit_with(self)`
+/// (children-only traversal) instead of `self.visit_stmt(stmt)`.
+#[test]
+fn test_equivalence_top_level_bare_expr_stmt() {
+    assert_output_equivalent(
+        r#"
+console.log(1 + 1);
+"#,
+    );
+}
+
+/// Regression test for #186: top-level if/else statement (non-decl Stmt
+/// variant) must reach `main_body`.
+#[test]
+fn test_equivalence_top_level_if_stmt() {
+    assert_output_equivalent(
+        r#"
+const score: number = 85;
+if (score >= 70) {
+    console.log("pass");
+} else {
+    console.log("fail");
+}
+"#,
+    );
+}
+
+/// Regression test for #186: top-level for-loop must reach `main_body`.
+#[test]
+fn test_equivalence_top_level_for_loop() {
+    assert_output_equivalent(
+        r#"
+let total: number = 0;
+for (const n of [1, 2, 3, 4, 5]) {
+    total = total + n;
+}
+console.log(total);
+"#,
+    );
+}
+
+/// Regression test for #186: full UAT quick.ts scenario — interface +
+/// multiple function decls + top-level object construction + console.log.
+#[test]
+fn test_equivalence_top_level_uat_quick_scenario() {
+    assert_output_equivalent(
+        r#"
+interface User {
+    id: number;
+    name: string;
+    active: boolean;
+}
+
+function isAdult(age: number): boolean {
+    return age >= 18;
+}
+
+const alice: User = {
+    id: 1,
+    name: "Alice",
+    active: true,
+};
+
+console.log(alice.name);
+console.log("isAdult(20):", isAdult(20));
+"#,
+    );
+}
+
+/// R7-incidental verification: the `fn main()` wrapper is emitted via
+/// `quote!` (not `push_str`). Verifies generated code structure.
+#[test]
+fn test_top_level_main_wrapper_is_present() {
+    let rust_code = transpile(
+        r#"
+console.log("hello");
+"#,
+    );
+    assert!(
+        rust_code.contains("fn main()"),
+        "expected fn main() wrapper, got:\n{rust_code}"
+    );
+    assert!(
+        rust_code.contains("println"),
+        "expected println! emission, got:\n{rust_code}"
     );
 }

--- a/tests/src/snapshot/mod.rs
+++ b/tests/src/snapshot/mod.rs
@@ -2,3 +2,4 @@ mod tier1;
 mod tier2;
 mod tier3;
 mod tier4_nestjs;
+mod top_level_emit;

--- a/tests/src/snapshot/snapshots/integration_tests__snapshot__top_level_emit__snapshot_top_level_uat_quick.snap
+++ b/tests/src/snapshot/snapshots/integration_tests__snapshot__top_level_emit__snapshot_top_level_uat_quick.snap
@@ -1,0 +1,64 @@
+---
+source: tests/src/snapshot/top_level_emit.rs
+expression: rust
+---
+mod __tyrus_int_serde {
+    use serde::{Deserialize, Deserializer, Serializer};
+    pub fn serialize<S: Serializer>(value: &f64, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_i64(*value as i64)
+    }
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<f64, D::Error> {
+        let v = serde_json::Value::deserialize(d)?;
+        v.as_f64().ok_or_else(|| serde::de::Error::custom("expected a number"))
+    }
+}
+#[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct User {
+    #[serde(with = "__tyrus_int_serde")]
+    pub id: f64,
+    pub name: String,
+    pub email: String,
+    pub active: bool,
+}
+fn is_adult(mut age: f64) -> bool {
+    return age >= 18f64;
+}
+fn classify(mut score: f64) -> String {
+    if score >= 90f64 {
+        return String::from("excellent");
+    } else if score >= 70f64 {
+        return String::from("good");
+    } else if score >= 50f64 {
+        return String::from("passing");
+    } else {
+        return String::from("failing");
+    }
+}
+fn sum_positive(mut nums: Vec<f64>) -> f64 {
+    let mut total = 0f64;
+    for n in nums {
+        if n > 0f64 {
+            total = total + n;
+        }
+    }
+    return total;
+}
+fn greet_user(mut user: User) -> String {
+    return format!("Hello, {}! Your id is {}.", user.name, user.id);
+}
+fn main() {
+    let alice = User {
+        id: 1f64,
+        name: String::from("Alice"),
+        email: String::from("alice@example.com"),
+        active: true,
+    };
+    println!("{}", greet_user(alice));
+    println!("{} {}", String::from("isAdult(20):"), is_adult(20f64));
+    println!("{} {}", String::from("classify(85):"), classify(85f64));
+    println!(
+        "{} {}", String::from("sumPositive([1,-2,3,-4,5]):"), sum_positive(vec![1f64, -
+        (2f64), 3f64, - (4f64), 5f64])
+    );
+}

--- a/tests/src/snapshot/top_level_emit.rs
+++ b/tests/src/snapshot/top_level_emit.rs
@@ -1,0 +1,11 @@
+use crate::helpers::transpile_fixture;
+
+/// Snapshot of the full UAT quick.ts scenario — interface + multiple
+/// function decls + top-level object construction + console.log block.
+/// Verifies #186 fix produces a complete `fn main()` wrapper with all
+/// top-level statements lifted in source order.
+#[test]
+fn test_snapshot_top_level_uat_quick() {
+    let rust = transpile_fixture("uat/quick");
+    insta::assert_snapshot!(rust);
+}


### PR DESCRIPTION
## Summary

Closes #186 (UAT-C1: top-level statements silently dropped). One-line semantic fix in `convert/module.rs:64`, plus three collateral changes per the validated UAT bug-fixes plan.

## What changed

### 1. The actual #186 fix (1-line)

`process_module_item` was calling `stmt.visit_with(self)` which traverses the **children** of `Stmt`, bypassing the custom `visit_stmt` override at `interface.rs:152`. As a result, top-level executable statements (ExprStmt, IfStmt, loops, etc.) silently disappeared instead of being lifted into `main_body` for the `fn main()` wrapper.

```diff
-ModuleItem::Stmt(stmt) => stmt.visit_with(self),
+// visit_with traverses children only — bypassing the custom
+// visit_stmt override at interface.rs. Direct dispatch ensures
+// top-level statements route into main_body instead of being dropped.
+ModuleItem::Stmt(stmt) => self.visit_stmt(stmt),
```

### 2. R7 incidental — \`fn main()\` wrapper migrated to \`quote!\`

\`crates/tyrus_codegen/src/lib.rs:24-28\` previously assembled the wrapper via three \`push_str\` calls of literal Rust syntax (Power of Ten Rule 7 violation: string concat for codegen). Migrated to a \`quote!\`-based \`wrap_top_level_in_main\` helper. Token-level parse failure on a malformed body falls through \`unwrap_or_else\` to a \`compile_error!(\"Tyrus: ...\")\` token stream — total, R6-compliant, fail-loud.

### 3. D1 analyzer diagnostic — \`AmbiguousMainEntrypoint\`

Without D1, fixing #186 would re-introduce the gap-analyst's landmine where \`has_declared_main\` suppresses the \`fn main()\` wrapper, silently dropping \`main_body\`. D1 catches files that both declare \`function main()\` AND contain top-level non-decl statements.

Coverage spans **all three TS forms** codegen recognises (after reviewer feedback caught the exported-form blind spot):
- bare \`function main()\`
- \`export function main()\`
- \`export default function main()\`

### 4. D9 fixture migration

UAT fixtures moved from gitignored \`.claude/plan/uat-fixtures/\` to versioned \`tests/fixtures/uat/\`, enabling CI reproducibility of UAT regression tests.

## Validation (anti-rubber-stamp protocol per plan D10)

Both reviewers were dispatched in parallel and **independently identified the same HIGH issue**: D1 was missing the exported-main case. Fixed before merge.

- **\`tyrus-reviewer\`** ✅ APPROVED (after HIGH fixes) — flagged 1 HIGH (export-main coverage), 1 HIGH (swc_ecma_parser version drift), 2 MEDIUM (stale comment, R6 fallback)
- **\`code-reviewer\`** ✅ APPROVED (after HIGH fix) — independently flagged the same export-main HIGH; verified all greps clean

All HIGH + MEDIUM issues addressed:
- Extended D1 to cover \`ModuleDecl::ExportDecl\` and \`ModuleDecl::ExportDefaultDecl\` (helper enum \`ModuleItemsView\` for uniform Module/Script handling)
- Pinned \`swc_ecma_parser = \"39.0.2\"\` (matches \`tyrus_parser\`)
- Updated stale comment in \`interface.rs:153\`
- Added 3 unit tests for the \`wrap_top_level_in_main\` fallback path

## Test plan

- [x] \`cargo fmt -- --check\` ✅
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` ✅
- [x] \`cargo nextest run --workspace\` ✅ **274 passed**, 1 skipped (was 259 on main, **+15 new tests**)
  - 5 equivalence tests for top-level (bare ExprStmt, IfStmt, ForLoop, full UAT scenario, emission shape)
  - 1 insta snapshot for the UAT \`quick.ts\` scenario
  - 6 D1 unit tests (positive: bare/export/export-default; negative: only-main, only-stmt, only-decls)
  - 3 \`wrap_top_level_in_main\` unit tests (valid body, fallback path, empty body)
- [x] \`cargo deny check\` ✅
- [x] \`cargo audit\` ✅
- [x] Direct e2e: \`tyrus build tests/fixtures/uat/quick.ts\` produces \`fn main()\` with all 4 console.log → println!() calls (verified)

## File sizes (R4 compliance)

| File | LOC | Ceiling |
|------|-----|---------|
| \`tyrus_codegen/src/lib.rs\` | 117 | 400 |
| \`tyrus_analyzer/src/lints.rs\` | 327 | 400 |
| \`tyrus_diagnostics/src/lib.rs\` | 83 | 400 |
| \`tyrus_codegen/src/convert/module.rs\` | 185 | 400 |

## Closes

- #186 (UAT-C1)

Refs: \`.claude/plan/uat-bug-fixes-2026-05-07.md\` (PR-1, D1, D9)