### PR TITLE
docs: amend Power of Ten to v2 — rules 13-14, honest enforcement status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with this repository.
 
 ## STRICT RULES (NEVER VIOLATE)
 
-**Canonical authority:** [`docs/standards/POWER_OF_TEN.md`](docs/standards/POWER_OF_TEN.md) — 12 rules adapted from NASA/JPL Power of Ten. Adopted via [ADR 0008](docs/architecture/decisions/0008-tyrus-strict-rules.md). The table below is a quick reference; the doc is the binding spec.
+**Canonical authority:** [`docs/standards/POWER_OF_TEN.md`](docs/standards/POWER_OF_TEN.md) — 14 rules adapted from NASA/JPL Power of Ten. Adopted via [ADR 0008](docs/architecture/decisions/0008-tyrus-strict-rules.md), amended by [ADR 0013](docs/architecture/decisions/0013-power-of-ten-v2.md). Process rules live in [`docs/standards/DEVELOPMENT_FLOW.md`](docs/standards/DEVELOPMENT_FLOW.md) (F1–F10, ADR 0014). The table below is a quick reference; the docs are the binding spec.
 
 | # | Rule | Severity | Enforced by |
 |---|------|----------|-------------|
@@ -23,7 +23,9 @@ This file provides guidance to Claude Code when working with this repository.
 | 9 | Local-first validation parity (hook == CI via `scripts/gates.sh`) | CRITICAL | shared script |
 | 10 | ADR for architectural decisions | HIGH | PR template |
 | 11 | One branch = one concern + Conventional Commits | HIGH | PR title regex |
-| 12 | Warnings-clean + daily audited (`--all-targets`, `cargo deny`, `cargo audit`) | CRITICAL | CI workflow |
+| 12 | Warnings-clean + daily audited (`--all-targets`, `--locked`, `cargo deny`, `cargo audit`, `cargo machete`, MSRV job) | CRITICAL | CI workflow |
+| 13 | `#![forbid(unsafe_code)]` in every crate | CRITICAL | crate-root attribute + grep gate (wiring: #214) |
+| 14 | Stable error codes `TYRUS-EXXXX` + category per `TyrusError` variant | HIGH | exhaustiveness test + JSON contract (wiring: #216) |
 
 ## Build & Dev Commands
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -197,6 +197,7 @@ The project enforces strict correctness via:
 Numbered ADRs under [`docs/architecture/decisions/`](architecture/decisions/) are the binding record of architectural choices. Most-recent-first:
 
 - [ADR 0014 — Development Flow Rules (F1–F10)](architecture/decisions/0014-development-flow-rules.md) — process standard companion to the Power of Ten; see [DEVELOPMENT_FLOW.md](standards/DEVELOPMENT_FLOW.md).
+- [ADR 0013 — Power of Ten v2](architecture/decisions/0013-power-of-ten-v2.md) — R13 (forbid unsafe), R14 (stable error codes), amendments to R4/R5/R6/R9/R12, Consortium traceability annex.
 - [ADR 0012 — Array Method Dispatch — Ownership](architecture/decisions/0012-array-method-dispatch-split.md) — boundary between IR-context array calls (`call_array.rs`) and pure Vec ops (`stdlib/array.rs`).
 - [ADR 0011 — Supply-Chain Hygiene Policy](architecture/decisions/0011-supply-chain-hygiene.md) — license allowlist, advisory ignore list, dependabot grouping, CODEOWNERS (PR #126 backfill).
 - [ADR 0010 — Formatter Contract](architecture/decisions/0010-formatter-contract.md) — idempotence, error-propagation, no-bypass guarantees for `tyrus_orchestrator::format` (PR #142 backfill).

--- a/docs/architecture/decisions/0013-power-of-ten-v2.md
+++ b/docs/architecture/decisions/0013-power-of-ten-v2.md
@@ -1,0 +1,78 @@
+# 13. Power of Ten v2 — Rules 13–14 and Amendments
+
+Date: 2026-08-04
+Status: Accepted (amends ADR 0008)
+
+## Context
+
+The Power of Ten (ADR 0008) has been binding since 2026-05-03. Three months of enforcement exposed gaps between what the document says and what the project does, plus two classes of defect no existing rule covers:
+
+1. **R9 divergence in the wild.** The `filesize` gate existed in `scripts/gates.sh` and ran in the pre-commit hook, but had no corresponding CI step — exactly the hook/CI divergence R9 calls a CRITICAL bug, sitting inside R9's own enforcement stack. The mandated gate list in the rule text was also stale (missing `filesize` and `coverage`).
+2. **R5 said 80%, the gate enforced 73%.** The rule text claimed a coverage threshold the project does not enforce, which teaches readers that rule text is aspirational — corrosive to the whole document's authority.
+3. **Panicking indexing is not covered by R6.** `x[i]`, `&s[a..b]` and `.unwrap()` inside `Result`-returning functions panic exactly like the constructs R6 bans, but none of the enforced lints caught them.
+4. **No rule prevents `unsafe`.** Nothing stops an `unsafe` block from entering a codebase that structurally never needs one.
+5. **No error identity.** `TyrusError` variants have no stable codes; the `--json` envelope (#198) exposes message strings, which consumers will match on and which break with every wording change.
+6. **R4 forces artificial splits.** In `quote!`-heavy emission functions, the 50-line limit sometimes fragments one coherent template into pieces that are harder to review than the original.
+
+Independent research (Rust API Guidelines; Safety-Critical Rust Consortium coding guidelines, draft v0.1; clippy lint taxonomy; mutation-testing practice) was conducted to align the amendments with current industry standards rather than invent project-local dogma.
+
+## Decision
+
+Amend `docs/standards/POWER_OF_TEN.md` from 12 to 14 rules:
+
+**New rules**
+
+- **R13 — Forbid Unsafe Code (CRITICAL).** `#![forbid(unsafe_code)]` in every crate root, grep-gated. `forbid` (non-overridable), not `deny`. Consequence: Miri, sanitizers and `cargo-careful` are *structurally* unnecessary and are rejected as tooling — recorded in ADR 0015, the companion decision of this amendment campaign.
+- **R14 — Stable Error Codes (HIGH).** Every `TyrusError` variant carries a unique `TYRUS-EXXXX` code and a category; JSON output exposes codes; tests assert codes, not messages.
+
+**Amendments**
+
+- **R4:** targeted `#[expect(clippy::too_many_lines, reason = "…")]` escape hatch for coherent `quote!` templates; `#[expect]` mandated over `#[allow]`; per-PR exception count reported.
+- **R5:** coverage text now states the *enforced* threshold (73%) with a +1 pp/sprint ramp to 80% (issue #163), naming `gates.sh`/CI as source of truth; `cargo mutants --in-diff` added as the coverage-emptiness check.
+- **R6:** forbidden-construct list extended with `clippy::indexing_slicing`, `clippy::string_slice`, `clippy::unwrap_in_result`.
+- **R9:** "every gate in `gates.sh` has a CI step" is now the rule's literal text; gate list updated to the real seven (fmt, clippy, filesize, test, coverage, deny, audit); `--locked` mandated for CI; staged-gates provision cross-referenced to DEVELOPMENT_FLOW.md F4.
+- **R12:** `--locked` on all CI cargo invocations; `cargo machete` for dead dependencies; MSRV declared in `[workspace.package] rust-version` plus a CI job compiling on it.
+
+**Annex.** A chapter-level traceability table maps R1–R14 to the Safety-Critical Rust Coding Guidelines (Rust Foundation / Consortium). Chapter-level, not guideline-ID-level, because the guideline IDs are draft-unstable (v0.1); rules with no counterpart are marked project-specific rather than force-fitted.
+
+## Consequences
+
+**Positive**
+
+- The document's claims match the project's enforcement again — restoring the "rule text is binding" property ADR 0008 depends on.
+- Panic surface shrinks: indexing/slicing panics become compile errors; `unsafe` becomes impossible rather than reviewed.
+- Error codes turn the `--json` envelope into a real contract and unblock `--explain`-style documentation later.
+- External traceability (Consortium annex) grounds the standard in recognized industry work — relevant for the project's academic positioning.
+
+**Negative / accepted costs**
+
+- Enforcing the R6 additions and R13 requires code changes across the workspace (lint fixes, crate-root attributes) — scheduled as dedicated units (CI hardening, workspace lints, error taxonomy) in the standardization RFC; until those land, the amended rules are binding for *new* code and tracked for existing code.
+- The R4 escape hatch can be abused; the per-PR `#[expect]` count report is the counterweight.
+- MSRV declaration adds one more CI job (~2 min) per PR.
+
+## Enforcement status at adoption
+
+Rule text marks each not-yet-wired mechanism with its tracking issue, so the standard never silently overstates enforcement:
+
+| Amendment | Wiring | Tracked in |
+|---|---|---|
+| R9 filesize CI step, `--locked` | CI workflow | #213 |
+| R13 `forbid(unsafe_code)` + grep gate | crate roots + `gates.sh` | #214 |
+| R6 indexing/slicing lints | `[workspace.lints]` migration | #215 |
+| R14 error codes | `tyrus_diagnostics` + JSON envelope | #216 |
+| R5 mutation testing | CI + local tooling | #217 |
+| R12 machete / MSRV | CI workflow | #213 |
+
+## Alternatives rejected
+
+- **Relax R4 to clippy's default 100 lines** — rejected: the 50-line JPL-heritage limit is the document's identity; an audited escape hatch preserves rigor without forcing artificial fragmentation.
+- **Guideline-ID-level Consortium mapping** — rejected while upstream IDs are draft-unstable; chapter-level mapping is honest and maintainable.
+- **Encode R14 as message-format conventions instead of codes** — rejected: formats drift; opaque stable codes are the only identity that survives rewording.
+
+## References
+
+- [POWER_OF_TEN.md](../../standards/POWER_OF_TEN.md) — the amended standard.
+- [ADR 0008](0008-tyrus-strict-rules.md) — original adoption.
+- [ADR 0014](0014-development-flow-rules.md) — process companion (F-rules).
+- [Safety-Critical Rust Coding Guidelines](https://coding-guidelines.arewesafetycriticalyet.org/) — Rust Foundation / Safety-Critical Rust Consortium.
+- [cargo-mutants](https://mutants.rs/) — mutation testing used as the R5 emptiness check.

--- a/docs/standards/POWER_OF_TEN.md
+++ b/docs/standards/POWER_OF_TEN.md
@@ -2,7 +2,7 @@
 
 > **Strict rules for Tyrus development.** Inspired by the NASA/JPL "Power of Ten Rules for Developing Safety-Critical Code" (Holzmann, 2006), adapted to Rust + transpiler context.
 >
-> **Status:** Accepted (ADR 0008 / 2026-05-03). Binding for all contributions to `main`.
+> **Status:** Accepted (ADR 0008 / 2026-05-03). Amended to 14 rules by ADR 0013 (2026-08-04). Binding for all contributions to `main`.
 
 ---
 
@@ -19,7 +19,7 @@ The rules are **enforced**, not aspirational: clippy lints, CI gates, pre-commit
 
 ---
 
-## The 12 rules
+## The 14 rules
 
 ### Rule 1 — Bounded Control Flow
 
@@ -61,6 +61,8 @@ The rules are **enforced**, not aspirational: clippy lints, CI gates, pre-commit
 
 **Rule.** Functions ≤ 50 lines. ≤ 5 parameters. ≤ 4 nesting levels. Files ≤ 400 lines (800 absolute hard cap). No function may both mutate `self` **and** emit a `TokenStream` longer than 30 lines without being split.
 
+*Escape hatch (ADR 0013).* When splitting a `quote!`-heavy emission function would fragment one coherent template into artificial pieces, a targeted `#[expect(clippy::too_many_lines, reason = "…")]` with a written justification is permitted. `#[expect]` — never `#[allow]` — so the compiler flags the exception the day it stops being needed. The total count of such exceptions is reported per PR; growth without justification is a review finding.
+
 **Why.** Every file split during Phases 1-8 surfaced bugs. Shape constraints are objective, machine-checkable code-review currency.
 
 **Enforce.** `clippy::too_many_lines`, `clippy::too_many_arguments`, `clippy::cognitive_complexity` — denied via `.cargo/config.toml`. CI line-count check in `scripts/gates.sh`.
@@ -77,7 +79,7 @@ The rules are **enforced**, not aspirational: clippy lints, CI gates, pre-commit
 
 **Why.** Replaces NASA's "≥ 2 asserts/function" with the Rust-idiomatic, transpiler-specific equivalent: behavior parity is the only assertion that matters here. A passing unit test on a mismatched-semantics codegen is worse than no test.
 
-**Enforce.** PR template checkbox "equivalence test added or N/A justified"; `cargo nextest run -p integration_tests` in CI; coverage threshold ≥ 80% workspace via `cargo-llvm-cov`.
+**Enforce.** PR template checkbox "equivalence test added or N/A justified"; `cargo nextest run -p integration_tests` in CI; line-coverage gate via `cargo-llvm-cov` at the current enforced threshold (73%, ramping +1 pp per sprint to the 80% target — tracked in issue #163; the gate value in `scripts/gates.sh`/CI is the source of truth). Coverage emptiness is checked with `cargo mutants --in-diff` on PR diffs: lines that are executed but never asserted count as uncovered for review purposes (adoption tracked in issue #217 — until it lands, this check is a review-time expectation, not a CI gate).
 
 **Severity.** CRITICAL.
 
@@ -87,11 +89,11 @@ The rules are **enforced**, not aspirational: clippy lints, CI gates, pre-commit
 
 ### Rule 6 — Total Error Handling
 
-**Rule.** No `.unwrap()`, `.expect()`, `panic!()`, `todo!()`, `unimplemented!()` in production code. Fallible operations return `Result<T, TyrusError>`. Generated Rust uses `compile_error!("Tyrus: …")` for unsupported constructs — never `todo!()`. Test code (in `#[cfg(test)] mod` or under `tests/`) may use `.expect("descriptive msg")`, but must be explicitly marked with `#[allow(clippy::expect_used)]` at the test-module level.
+**Rule.** No `.unwrap()`, `.expect()`, `panic!()`, `todo!()`, `unimplemented!()` in production code. No panicking indexing either: `x[i]` on slices/`Vec`s, string slicing `&s[a..b]`, and `unwrap()` inside functions that already return `Result` are forbidden — use `.get()`, `.get(a..b)`, and `?` respectively. Fallible operations return `Result<T, TyrusError>`. Generated Rust uses `compile_error!("Tyrus: …")` for unsupported constructs — never `todo!()`. Test code (in `#[cfg(test)] mod` or under `tests/`) may use `.expect("descriptive msg")`, but must be explicitly marked with `#[allow(clippy::expect_used)]` at the test-module level.
 
 **Why.** Codified project rule. A `.unwrap()` in a transpiler is a denial-of-service vector when the input triggers it.
 
-**Enforce.** `clippy::unwrap_used`, `clippy::expect_used`, `clippy::panic`, `clippy::todo`, `clippy::unimplemented` — all `-W` (effectively `-D` with `-Dwarnings`). Verified by `cargo clippy --workspace --all-targets -- -D warnings`.
+**Enforce.** `clippy::unwrap_used`, `clippy::expect_used`, `clippy::panic`, `clippy::todo`, `clippy::unimplemented` — all `-W` (effectively `-D` with `-Dwarnings`), verified by `cargo clippy --workspace --all-targets -- -D warnings`. The three indexing/slicing lints added by ADR 0013 (`indexing_slicing`, `string_slice`, `unwrap_in_result`) are wired by the `[workspace.lints]` migration tracked in issue #215; until that lands they bind new code at review time.
 
 **Severity.** CRITICAL.
 
@@ -127,17 +129,21 @@ The rules are **enforced**, not aspirational: clippy lints, CI gates, pre-commit
 
 ### Rule 9 — Local-First Validation Parity
 
-**Rule.** The pre-commit hook and CI run *the same gates with the same flags*. Single source of truth: `scripts/gates.sh`. Any divergence between hook and CI is a CRITICAL bug.
+**Rule.** The pre-commit hook and CI run *the same gates with the same flags*. Single source of truth: `scripts/gates.sh` — **every gate defined there has a corresponding CI step**, and any divergence between hook and CI is a CRITICAL bug (ADR 0013: this sentence exists because the `filesize` gate has run locally for months with no CI step — a live divergence being closed by issue #213). All CI cargo invocations pass `--locked` (also #213).
 
-The mandated gate set:
+The mandated gate set (as named in `gates.sh`):
 
 ```bash
-cargo fmt --all -- --check
-cargo clippy --workspace --all-targets -- -D warnings
-cargo nextest run --workspace --all-targets
-cargo deny check
-cargo audit --deny warnings
+fmt       # cargo fmt --all -- --check
+clippy    # cargo clippy --workspace --all-targets -- -D warnings
+filesize  # Rule 4 line caps: soft 400 / hard 800 per .rs under crates/
+test      # cargo nextest run --workspace
+coverage  # cargo llvm-cov, --fail-under-lines at the enforced threshold
+deny      # cargo deny check
+audit     # cargo audit --deny warnings
 ```
+
+When the monolithic `gates.sh all` run is impractical on a dev machine (resource limits), gates may be run staged — but all of them must pass on the exact tree being pushed, documented in the commit body (see DEVELOPMENT_FLOW.md Rule F4).
 
 **Why.** PR #142 broke `--all-targets` because the hook didn't include it; CI also didn't include it; the PR merged with three `expect_used` violations and one `items_after_test_module` violation. This rule prevents repeats by removing the divergence at the source.
 
@@ -179,7 +185,7 @@ cargo audit --deny warnings
 
 ### Rule 12 — Warnings-Clean, Daily Audited
 
-**Rule.** All code compiles with `-D warnings` across the workspace including `--all-targets`. `cargo deny check`, `cargo audit`, and `cargo clippy --workspace --all-targets` run on every PR and on a nightly schedule. Any new advisory has 7 days to be triaged via tracked issue.
+**Rule.** All code compiles with `-D warnings` across the workspace including `--all-targets`. `cargo deny check`, `cargo audit`, and `cargo clippy --workspace --all-targets` run on every PR and on a nightly schedule. Any new advisory has 7 days to be triaged via tracked issue. Additionally (ADR 0013): every CI cargo invocation uses `--locked` so builds resolve exactly the committed `Cargo.lock`; `cargo machete` guards against dead dependencies; and the MSRV is declared in `[workspace.package] rust-version` with a dedicated CI job compiling on it.
 
 **Why.** Direct port of NASA Rule 10. Rust's compiler + clippy + supply-chain audit replaces C-era static analyzers.
 
@@ -188,6 +194,34 @@ cargo audit --deny warnings
 **Severity.** CRITICAL.
 
 **Origin.** Phase E hygiene work (PR #126) introduced `cargo deny` + `cargo audit` + dependabot.
+
+---
+
+### Rule 13 — Forbid Unsafe Code
+
+**Rule.** Every crate in the workspace declares `#![forbid(unsafe_code)]`. Not `deny` — `forbid`, which cannot be overridden by an inner `#[allow]`. A transpiler has no legitimate need for `unsafe`: it reads text, walks ASTs, and emits tokens.
+
+**Why.** With zero `unsafe` in the workspace, whole classes of tooling (Miri, sanitizers) become unnecessary rather than merely passing — the strongest possible safety argument is structural absence, not audited presence. This also makes the safety posture legible to outside reviewers in one grep.
+
+**Enforce.** `#![forbid(unsafe_code)]` attribute in every crate root; grep gate in `scripts/gates.sh` failing if any crate root lacks the attribute or any production source contains `unsafe`. Wiring tracked in issue #214 — binding for new crates immediately.
+
+**Severity.** CRITICAL.
+
+**Origin.** ADR 0013. Safety-Critical Rust Coding Guidelines (Unsafety chapter) — the guideline set's central premise applied at maximum strength.
+
+---
+
+### Rule 14 — Stable Error Codes
+
+**Rule.** Every `TyrusError` variant carries a stable, unique code (`TYRUS-EXXXX`) and a category (`Parse` / `Analyze` / `Codegen` / `Io` / `Format`). Codes never change meaning or get reused. Machine-readable output (`tyrus check --json`) exposes the code on every error and diagnostic; tests assert on codes, never on message text.
+
+**Why.** Message strings are presentation, not identity — they change with wording improvements and break every consumer that matched on them. Stable codes are what let the JSON envelope be a real contract (schemaVersion 1) and what make diagnostics documentable (`rustc --explain`-style) later.
+
+**Enforce.** Exhaustiveness unit test in `tyrus_diagnostics` (every variant has a code; codes are unique); `miette::Diagnostic::code()` wired for every variant; CLI tests assert codes. Implementation tracked in issue #216.
+
+**Severity.** HIGH.
+
+**Origin.** ADR 0013. The `--json` envelope work (#198) made the missing error taxonomy visible.
 
 ---
 
@@ -205,18 +239,43 @@ cargo audit --deny warnings
 - **NASA Rule 5 (≥ 2 asserts/function)** is **replaced by Rule 5 (equivalence-test density)**. C-style `assert!` density is not Rust culture; behavior-parity tests are the load-bearing artifact for a transpiler.
 - **NASA Rule 8 (preprocessor restriction)** is **subsumed into Rule 7**. Rust has no preprocessor — the analogous risk is unhygienic codegen, addressed directly by mandating `quote!`.
 - **NASA Rule 9 (≤ 1 level of pointer deref)** is **dropped**. Rust's borrow checker + `clippy::needless_borrow` already cover the underlying intent. A hard count rule would conflict with idiomatic `Rc<RefCell<…>>` patterns.
-- **Added (no NASA equivalent):** Rules 8 (two-layer arch), 9 (local/CI parity), 10 (ADR), 11 (branch hygiene). These encode lessons specific to a multi-crate transpiler with ML-agent contributors and a stacked-PR workflow.
+- **Added (no NASA equivalent):** Rules 8 (two-layer arch), 9 (local/CI parity), 10 (ADR), 11 (branch hygiene), 13 (forbid unsafe), 14 (stable error codes). These encode lessons specific to a multi-crate transpiler with ML-agent contributors and a stacked-PR workflow.
+
+---
+
+## Annex — Traceability to the Safety-Critical Rust Coding Guidelines
+
+The [Safety-Critical Rust Coding Guidelines](https://coding-guidelines.arewesafetycriticalyet.org/) (Rust Foundation / Safety-Critical Rust Consortium, draft v0.1) organize their guidance in chapters mirroring the Ferrocene Language Specification. Individual guideline IDs are still draft-unstable, so this table maps at chapter level; it exists to show each Tyrus rule has a recognized industry counterpart (or is deliberately project-specific).
+
+| Tyrus rule | Consortium chapter(s) | Notes |
+|---|---|---|
+| R1 Bounded Control Flow | Expressions; Functions | Recursion bounds / termination reasoning |
+| R2 Bounded Loops | Expressions | Loop bound requirements |
+| R3 Minimal Scope | Types and Traits; Statements | Narrowest-scope bindings |
+| R4 Function Size and Shape | — | Project-specific (NASA Rule 4 heritage); no direct chapter |
+| R5 Test Equivalence Density | — | Project-specific verification strategy for a transpiler |
+| R6 Total Error Handling | Exceptions and Errors | No-panic discipline in production paths |
+| R7 Macros, Not Strings | Macros | Hygienic generation over textual assembly |
+| R8 Two-Layer Architecture | — | Project-specific (ADR 0007) |
+| R9 Local/CI Parity | — | Process rule; Consortium scope is language-level |
+| R10 ADR Required | — | Process rule; matches the Consortium's own deviation-record practice |
+| R11 One Branch = One Concern | — | Process rule |
+| R12 Warnings-Clean, Audited | Program Structure and Compilation | Warnings-as-errors, dependency auditing |
+| R13 Forbid Unsafe Code | Unsafety | Applied at maximum strength (`forbid`, workspace-wide) |
+| R14 Stable Error Codes | Exceptions and Errors | Diagnostic identity and machine-readable contracts |
 
 ---
 
 ## How to use this document
 
-- **Contributors:** before opening a PR, walk the 12 rules. The PR template references this file.
+- **Contributors:** before opening a PR, walk the 14 rules. The PR template references this file.
 - **Reviewers:** the merge bar is rule compliance, not opinion. If a PR violates a rule and the violation is justified, the rule must either be amended (separate ADR) or the PR rejected.
-- **Maintainers:** propose rule changes via ADR superseding ADR 0008. Never amend this document silently.
+- **Maintainers:** propose rule changes via ADR superseding ADR 0008/0013. Never amend this document silently.
 
 ## References
 
 - Holzmann, G. J. (2006). [The Power of 10: Rules for Developing Safety-Critical Code](https://web.eecs.umich.edu/~imarkov/10rules.pdf). *IEEE Computer*, 39(6), 95–97.
+- [Safety-Critical Rust Coding Guidelines](https://coding-guidelines.arewesafetycriticalyet.org/) — Rust Foundation / Safety-Critical Rust Consortium (draft).
+- ADR 0013 — Power of Ten v2 amendment (R13, R14, and rule amendments).
 - ADR 0007 — Decorator Registry (precedent for Rule 8).
 - Memory rules: `feedback_architecture_principles`, `feedback_compiler_fundamentals`, `feedback_code_quality_strict`, `feedback_local_first_validation`, `feedback_branch_workflow`, `feedback_commit_convention`, `feedback_semantic_equivalence`.


### PR DESCRIPTION
## Summary
- **R13 — Forbid Unsafe Code (CRITICAL)** and **R14 — Stable Error Codes (HIGH)** added; standard goes 12 → 14 rules.
- Amendments: R4 gains the `#[expect(clippy::too_many_lines, reason)]` escape hatch (audited, counted per PR); R5 now states the *enforced* 73% threshold with the ramp to 80% (#163) instead of the false 80% claim; R6 adds the panicking-indexing lints; R9's gate list matches the real seven gates and mandates a 1:1 CI step per gate (the live `filesize` divergence is #213); R12 adds `--locked`, cargo-machete and MSRV.
- **Honest-enforcement rule**: every mechanism not yet wired cites its tracking issue (#213–#217) inline — direct response to the fresh-context adversarial review, which flagged that the amended text was recreating the exact 'aspirational rule text' disease this ADR exists to cure.
- Annex: chapter-level traceability to the Safety-Critical Rust Coding Guidelines (Rust Foundation / Consortium).
- ADR 0013 (with enforcement-status table), ADR index, and CLAUDE.md quick reference updated.

Unit U2 of the standardization RFC. Closes #212

## Test plan
- [x] Docs-only; code tree identical to gates-green main (F4 staged-gates provision)
- [x] Fresh-context adversarial review (F5): all CRITICAL/HIGH findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQnQN7MkJEqWy75YZH7dNJ