### PR TITLE
docs: normalize ADR language to English and record rejected tooling

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -196,6 +196,7 @@ The project enforces strict correctness via:
 
 Numbered ADRs under [`docs/architecture/decisions/`](architecture/decisions/) are the binding record of architectural choices. Most-recent-first:
 
+- [ADR 0015 — Tooling Evaluated and Rejected](architecture/decisions/0015-rejected-tooling.md) — Ferrocene, Miri, sanitizers, cargo-vet/crev, restriction-as-group: why not, and what would reopen each.
 - [ADR 0014 — Development Flow Rules (F1–F10)](architecture/decisions/0014-development-flow-rules.md) — process standard companion to the Power of Ten; see [DEVELOPMENT_FLOW.md](standards/DEVELOPMENT_FLOW.md).
 - [ADR 0013 — Power of Ten v2](architecture/decisions/0013-power-of-ten-v2.md) — R13 (forbid unsafe), R14 (stable error codes), amendments to R4/R5/R6/R9/R12, Consortium traceability annex.
 - [ADR 0012 — Array Method Dispatch — Ownership](architecture/decisions/0012-array-method-dispatch-split.md) — boundary between IR-context array calls (`call_array.rs`) and pure Vec ops (`stdlib/array.rs`).

--- a/docs/architecture/decisions/0000-use-markdown-adr.md
+++ b/docs/architecture/decisions/0000-use-markdown-adr.md
@@ -1,29 +1,29 @@
-# 0. Uso de Architecture Decision Records (ADR)
+# 0. Use of Architecture Decision Records (ADR)
 
-Data: 2025-11-22
-Status: Aceito
+Date: 2025-11-22
+Status: Accepted
 
-## Contexto
-Precisamos registrar decisões arquiteturais significativas para o projeto Tyrus.
-Como este projeto visa ser uma ferramenta de engenharia complexa (compilador) e um artefato acadêmico, é crucial manter um histórico do "porquê" e "como" as decisões foram tomadas.
-A falta de documentação sobre decisões de design pode levar a retrabalho, perda de contexto e dificuldade na defesa da tese de mestrado.
+## Context
+We need to record significant architectural decisions for the Tyrus project.
+Since this project aims to be both a complex engineering tool (compiler) and an academic artifact, it is crucial to keep a history of the "why" and "how" behind decisions.
+Lack of documentation about design decisions can lead to rework, loss of context, and difficulty defending the master's thesis.
 
-## Decisão
-Adotaremos o formato **Architecture Decision Records (ADR)**.
-Usaremos arquivos Markdown numerados sequencialmente na pasta `docs/architecture/decisions`.
+## Decision
+We will adopt the **Architecture Decision Records (ADR)** format.
+We will use sequentially numbered Markdown files in the `docs/architecture/decisions` folder.
 
-Cada ADR deve seguir esta estrutura:
-1. **Título:** Curto e descritivo.
-2. **Status:** Proposto, Aceito, Depreciado ou Rejeitado.
-3. **Contexto:** Qual é o problema que estamos tentando resolver? Quais são as restrições?
-4. **Decisão:** O que vamos fazer? (Tecnologia, Padrão, Algoritmo).
-5. **Consequências:** O que ganhamos (pros) e o que perdemos/pagamos (contras) com essa decisão.
+Each ADR must follow this structure:
+1. **Title:** Short and descriptive.
+2. **Status:** Proposed, Accepted, Deprecated, or Rejected.
+3. **Context:** What problem are we trying to solve? What are the constraints?
+4. **Decision:** What will we do? (Technology, Pattern, Algorithm).
+5. **Consequences:** What we gain (pros) and what we lose/pay (cons) with this decision.
 
-## Consequências
-### Positivas
-- Histórico claro da evolução do projeto.
-- Facilita o onboarding de novos contribuidores (Open Source).
-- Material pronto para a escrita da dissertação de mestrado.
+## Consequences
+### Positive
+- Clear history of the project's evolution.
+- Eases onboarding of new contributors (Open Source).
+- Ready-made material for writing the master's dissertation.
 
-### Negativas
-- Requer disciplina para escrever o documento antes ou durante a implementação.
+### Negative
+- Requires discipline to write the document before or during implementation.

--- a/docs/architecture/decisions/0001-stack-and-monorepo.md
+++ b/docs/architecture/decisions/0001-stack-and-monorepo.md
@@ -1,49 +1,49 @@
-# 1. Stack Tecnológica e Estrutura de Monorepo
+# 1. Technology Stack and Monorepo Structure
 
-Data: 2025-11-22
-Status: Aceito
+Date: 2025-11-22
+Status: Accepted
 
-## Contexto
-O objetivo é criar o **Tyrus**, uma ferramenta que analisa código TypeScript e o transpila para Rust idiomático.
-Os requisitos principais são:
-1. **Performance:** A ferramenta deve processar grandes projetos rapidamente.
-2. **Confiabilidade:** O código gerado deve ser seguro e a ferramenta não deve falhar inesperadamente.
-3. **Manutenibilidade:** O projeto deve ser modular para permitir testes isolados de parser, analyzer e codegen.
-4. **Ecossistema:** Precisamos de ferramentas robustas para parsing de JS/TS, já que escrever um parser do zero é inviável para o escopo.
+## Context
+The goal is to build **Tyrus**, a tool that analyzes TypeScript code and transpiles it into idiomatic Rust.
+The main requirements are:
+1. **Performance:** The tool must process large projects quickly.
+2. **Reliability:** The generated code must be safe, and the tool must not fail unexpectedly.
+3. **Maintainability:** The project must be modular to allow isolated testing of the parser, analyzer, and codegen.
+4. **Ecosystem:** We need robust tooling for JS/TS parsing, since writing a parser from scratch is infeasible for this scope.
 
-## Decisão
-Decidimos utilizar a linguagem **Rust** para desenvolver o compilador, organizado em um **Cargo Workspace (Monorepo)**.
+## Decision
+We decided to use the **Rust** language to build the compiler, organized as a **Cargo Workspace (Monorepo)**.
 
-### Stack Selecionada:
-- **Linguagem:** Rust (Segurança de memória, Sistema de Tipos, Performance).
-- **Parsing:** `swc_ecma_parser` (Biblioteca padrão da indústria, escrita em Rust, extremamente rápida).
-- **AST Traversal:** `swc_ecma_visit` (Implementação do padrão Visitor para navegação eficiente na árvore).
-- **Code Generation:** `quote!` e `proc_macro2` (Geração higiênica de tokens Rust).
-- **CLI:** `clap` v4 (Padrão para interfaces de linha de comando).
-- **Error Reporting:** `miette` (Diagnósticos ricos com suporte visual ao código fonte).
-- **Testes:** `insta` (Snapshot testing) e `trybuild` (Compilation testing).
+### Selected Stack:
+- **Language:** Rust (memory safety, type system, performance).
+- **Parsing:** `swc_ecma_parser` (industry-standard library, written in Rust, extremely fast).
+- **AST Traversal:** `swc_ecma_visit` (Visitor pattern implementation for efficient tree navigation).
+- **Code Generation:** `quote!` and `proc_macro2` (hygienic Rust token generation).
+- **CLI:** `clap` v4 (standard for command-line interfaces).
+- **Error Reporting:** `miette` (rich diagnostics with visual source code support).
+- **Testing:** `insta` (snapshot testing) and `trybuild` (compilation testing).
 
-### Estrutura de Módulos (Crates):
-O projeto é dividido em crates isoladas para garantir a separação de responsabilidades (SoC):
-- `tyrus_cli`: Interface de entrada (clap).
-- `tyrus_parser`: Wrapper sobre o SWC (`swc_ecma_parser`).
-- `tyrus_analyzer`: Validação semântica (`LintVisitor` + `DecoratorVisitor`).
-- `tyrus_codegen`: Transformação de AST para Tokens Rust (`quote!`).
-- `tyrus_orchestrator`: Orquestração do pipeline multi-arquivo.
-- `tyrus_di`: Motor de Injeção de Dependência (petgraph).
-- `tyrus_diagnostics`: Erros centralizados (`TyrusError` + miette).
-- `tyrus_common`: Tipos compartilhados (`FilePath`, utilitários).
-- `tyrus_ast`: Reservado para IR futuro (AST do SWC usado diretamente).
-- `tyrus_test_utils`: Helpers de teste (`assert_rust_compiles()`).
+### Module (Crate) Structure:
+The project is split into isolated crates to ensure separation of concerns (SoC):
+- `tyrus_cli`: Entry point interface (clap).
+- `tyrus_parser`: Wrapper over SWC (`swc_ecma_parser`).
+- `tyrus_analyzer`: Semantic validation (`LintVisitor` + `DecoratorVisitor`).
+- `tyrus_codegen`: AST-to-Rust-tokens transformation (`quote!`).
+- `tyrus_orchestrator`: Multi-file pipeline orchestration.
+- `tyrus_di`: Dependency Injection engine (petgraph).
+- `tyrus_diagnostics`: Centralized errors (`TyrusError` + miette).
+- `tyrus_common`: Shared types (`FilePath`, utilities).
+- `tyrus_ast`: Reserved for a future IR (SWC AST used directly for now).
+- `tyrus_test_utils`: Test helpers (`assert_rust_compiles()`).
 
-## Consequências
+## Consequences
 
-### Positivas
-- **Performance Nativa:** O uso de Rust e SWC garante velocidade superior a ferramentas escritas em JS/TS.
-- **Modularidade:** O Monorepo permite compilar e testar o *Analyzer* sem precisar rodar o *Codegen*.
-- **Tipagem Forte:** O sistema de tipos do Rust previne erros de lógica interna no compilador.
-- **Rigor Acadêmico:** A arquitetura de pipeline (Parse -> Analyze -> Generate) é clássica em teoria de compiladores.
+### Positive
+- **Native Performance:** Using Rust and SWC guarantees speed superior to tools written in JS/TS.
+- **Modularity:** The Monorepo allows building and testing the *Analyzer* without needing to run the *Codegen*.
+- **Strong Typing:** Rust's type system prevents internal logic errors in the compiler.
+- **Academic Rigor:** The pipeline architecture (Parse -> Analyze -> Generate) is classic in compiler theory.
 
-### Negativas
-- **Curva de Aprendizado:** A API do SWC é complexa e pouco documentada.
-- **Tempo de Compilação:** Rust tem tempos de compilação lentos, o que pode afetar o ciclo de feedback (mitigado pelo uso de crates separadas).
+### Negative
+- **Learning Curve:** The SWC API is complex and poorly documented.
+- **Compile Time:** Rust has slow compile times, which can affect the feedback cycle (mitigated by using separate crates).

--- a/docs/architecture/decisions/0002-async-transpilation.md
+++ b/docs/architecture/decisions/0002-async-transpilation.md
@@ -1,48 +1,48 @@
-# 2. Estratégia de Transpilação de Async/Await
+# 2. Async/Await Transpilation Strategy
 
-Data: 2026-02-10
-Status: Aceito
+Date: 2026-02-10
+Status: Accepted
 
-## Contexto
+## Context
 
-TypeScript e Rust possuem modelos de concorrência diferentes.
+TypeScript and Rust have different concurrency models.
 
 - **TS:** Single-threaded Event Loop, `Promise<T>`.
-- **Rust:** Multi-threaded (potencialmente), `Future<Output=T>`, requer Runtime (Tokio).
+- **Rust:** Multi-threaded (potentially), `Future<Output=T>`, requires a Runtime (Tokio).
 
-Precisamos definir como transformar funções `async` do TS para Rust de forma que sejam compatíveis com o ecossistema `axum`/`tokio`.
+We need to define how to transform `async` functions from TS into Rust in a way that is compatible with the `axum`/`tokio` ecosystem.
 
-## Decisão
+## Decision
 
-Mapearemos `async/await` do TypeScript diretamente para a sintaxe `async/.await` do Rust, utilizando o crate `tokio` como runtime.
+We will map TypeScript's `async/await` directly to Rust's `async/.await` syntax, using the `tokio` crate as the runtime.
 
-### Regras de Mapeamento:
+### Mapping Rules:
 
-1.  **Assinatura de Função:**
+1.  **Function Signature:**
     - TS: `async function foo(): Promise<string>`
     - Rust: `pub async fn foo() -> Result<String, AppError>`
-    - _Nota:_ Todas as funções async devem retornar `Result` para propagação de erros (`?`), mesmo que no TS não lancem exceções explicitamente.
+    - _Note:_ All async functions must return `Result` for error propagation (`?`), even if the TS version does not explicitly throw exceptions.
 
-2.  **Unwrapping de Promises:**
-    - O tipo de retorno `Promise<T>` é "desembrulhado" para `T` (dentro do `Result`).
+2.  **Promise Unwrapping:**
+    - The `Promise<T>` return type is "unwrapped" to `T` (inside the `Result`).
 
 3.  **Await Expression:**
     - TS: `await foo()`
     - Rust: `foo().await?`
-    - _Nota:_ O operador `?` é adicionado automaticamente para tratar erros, assumindo que qualquer Future pode falhar (padrão em I/O).
+    - _Note:_ The `?` operator is added automatically to handle errors, assuming any Future can fail (standard for I/O).
 
 4.  **Runtime:**
-    - O binário gerado dependerá de `#[tokio::main]`.
+    - The generated binary will depend on `#[tokio::main]`.
 
-## Consequências
+## Consequences
 
-### Positivas
+### Positive
 
-- Código gerado é altamente idiomático e legível.
-- Integração nativa com crates como `reqwest` e `sqlx` que são `async`.
-- Performance superior ao Event Loop do Node.js para tarefas I/O bound.
+- Generated code is highly idiomatic and readable.
+- Native integration with crates like `reqwest` and `sqlx`, which are `async`.
+- Superior performance to Node.js's Event Loop for I/O-bound tasks.
 
-### Negativas
+### Negative
 
-- Obriga o uso de `tokio` (aumenta o tamanho do binário).
-- `async` em traits (Rust) ainda é complexo (embora resolvido no Rust 1.75+ com RPITIT, ainda pode ter edge cases).
+- Forces the use of `tokio` (increases binary size).
+- `async` in traits (Rust) is still complex (although solved in Rust 1.75+ with RPITIT, edge cases may still exist).

--- a/docs/architecture/decisions/0003-generics-mapping.md
+++ b/docs/architecture/decisions/0003-generics-mapping.md
@@ -1,44 +1,44 @@
-# 3. Mapeamento de Generics (TypeScript -> Rust)
+# 3. Generics Mapping (TypeScript -> Rust)
 
-Data: 2026-02-10
-Status: Aceito
+Date: 2026-02-10
+Status: Accepted
 
-## Contexto
+## Context
 
-TypeScript possui um sistema de tipos estrutural com generics muito flexíveis (`any`, restrições parciais). Rust possui um sistema nominal e monomorfização.
-Precisamos permitir que usuários definam classes e funções genéricas em TS que compilem em Rust.
+TypeScript has a structural type system with very flexible generics (`any`, partial constraints). Rust has a nominal system with monomorphization.
+We need to let users define generic classes and functions in TS that compile to Rust.
 
-## Decisão
+## Decision
 
-Mapearemos Generics do TS para Generics do Rust com Restrições de Trait (Trait Bounds) padrão.
+We will map TS Generics to Rust Generics with default Trait Bounds.
 
-### Regras de Mapeamento:
+### Mapping Rules:
 
-1.  **Declaração:**
+1.  **Declaration:**
     - TS: `class Box<T> { ... }`
     - Rust: `struct Box<T> { ... }`
 
-2.  **Trait Bounds Automáticos:**
-    - Todo parâmetro genérico `T` em Rust receberá automaticamente:
+2.  **Automatic Trait Bounds:**
+    - Every generic parameter `T` in Rust will automatically receive:
       `T: serde::Serialize + serde::Deserialize + Clone + Debug + Default`
-    - _Justificativa:_ Backends precisam serializar dados (JSON), clonar estados e debugar. Sem esses traits, o uso de `T` seria muito restrito.
+    - _Rationale:_ Backends need to serialize data (JSON), clone state, and debug. Without these traits, using `T` would be too restricted.
 
 3.  **PhantomData:**
-    - Se um parâmetro `T` é declarado mas não usado nos campos da struct:
-    - Rust: Adicionar campo `_phantom: std::marker::PhantomData<T>`.
-    - _Justificativa:_ O compilador Rust rejeita parâmetros genéricos não utilizados.
+    - If a `T` parameter is declared but not used in the struct's fields:
+    - Rust: Add a `_phantom: std::marker::PhantomData<T>` field.
+    - _Rationale:_ The Rust compiler rejects unused generic parameters.
 
-4.  **Herança de Generics:**
-    - Não suportaremos restrições complexas do TS (`T extends keyof U`) na v1. Elas serão tratadas como `T` simples.
+4.  **Generics Inheritance:**
+    - We will not support complex TS constraints (`T extends keyof U`) in v1. They will be treated as plain `T`.
 
-## Consequências
+## Consequences
 
-### Positivas
+### Positive
 
-- Permite criar DTOs reutilizáveis (`ApiResponse<T>`).
-- Garante que os tipos genéricos sejam úteis (serializáveis).
+- Enables reusable DTOs (`ApiResponse<T>`).
+- Ensures generic types are useful (serializable).
 
-### Negativas
+### Negative
 
-- Restrição excessiva: Nem todo `T` precisa ser `Default`, mas estamos forçando. Isso pode impedir o uso de tipos que não implementam `Default`.
-- _Mitigação:_ No futuro, podemos analisar o uso do tipo para relaxar os bounds.
+- Excessive restriction: not every `T` needs to be `Default`, but we are forcing it. This may prevent the use of types that don't implement `Default`.
+- _Mitigation:_ In the future, we could analyze type usage to relax the bounds.

--- a/docs/architecture/decisions/0004-nestjs-to-axum.md
+++ b/docs/architecture/decisions/0004-nestjs-to-axum.md
@@ -1,36 +1,36 @@
-# 4. Mapeamento NestJS para Axum
+# 4. NestJS to Axum Mapping
 
-Data: 2026-02-10
-Status: Aceito
+Date: 2026-02-10
+Status: Accepted
 
-## Contexto
+## Context
 
-O framework alvo do projeto é o **NestJS** (TypeScript). Queremos que o código Rust gerado utilize um framework web robusto.
-Escolhemos **Axum 0.7** (do ecosistema Tokio) por sua performance, ergonomia e compatibilidade com async.
+The project's target framework is **NestJS** (TypeScript). We want the generated Rust code to use a robust web framework.
+We chose **Axum 0.7** (from the Tokio ecosystem) for its performance, ergonomics, and async compatibility.
 
-## Decisão
+## Decision
 
-Transformaremos Decorators do NestJS em rotas e extratores do Axum.
+We will transform NestJS Decorators into Axum routes and extractors.
 
-### Regras de Mapeamento:
+### Mapping Rules:
 
 1.  **Controllers:**
     - TS: `@Controller('users') class UsersController`
-    - Rust: Uma função `pub fn router() -> Router` que agrupa as rotas.
+    - Rust: A `pub fn router() -> Router` function that groups the routes.
 
-2.  **Handlers (Métodos):**
+2.  **Handlers (Methods):**
     - TS: `@Get(':id') findOne(...)`
     - Rust: `pub async fn find_one(...)`
-    - A rota é registrada no Router: `.route("/:id", get(find_one))`
+    - The route is registered in the Router: `.route("/:id", get(find_one))`
 
 3.  **Extractors (@Body, @Param, @Query):**
     - TS: `create(@Body() user: UserDto)` → Rust: `create(Json(user): Json<UserDto>)`
     - TS: `findOne(@Param('id') id: string)` → Rust: `find_one(Path(id): Path<String>)`
     - TS: `search(@Query('q') q: string)` → Rust: `search(Query(q): Query<String>)`
 
-4.  **Injeção de Dependência:**
-    - O `Dependency Injection` do NestJS é simulado via `State<Arc<Self>>` nos handlers.
-    - O `Service` é instanciado no `main.rs` e passado via `.with_state(Arc::new(service))`.
+4.  **Dependency Injection:**
+    - NestJS `Dependency Injection` is simulated via `State<Arc<Self>>` in the handlers.
+    - The `Service` is instantiated in `main.rs` and passed via `.with_state(Arc::new(service))`.
 
 5.  **Response Configuration:**
     - TS: `@HttpCode(201)` → Rust: `Result<(StatusCode, Json<T>), AppError>`
@@ -40,16 +40,16 @@ Transformaremos Decorators do NestJS em rotas e extratores do Axum.
     - TS: `@UseGuards(AuthGuard)` → Rust: `.layer(axum::middleware::from_fn(auth_guard_middleware))`
     - `canActivate(): boolean` → async middleware function
 
-## Consequências
+## Consequences
 
-### Positivas
+### Positive
 
-- Axum é extremamente rápido.
-- O modelo de Extractors do Axum mapeia limpo para Decorators.
-- Guards NestJS mapeiam para `axum::middleware::from_fn()` (tower middleware).
-- `State<Arc<Self>>` permite compartilhar estado entre handlers sem `&mut self`.
+- Axum is extremely fast.
+- Axum's Extractor model maps cleanly onto Decorators.
+- NestJS Guards map to `axum::middleware::from_fn()` (tower middleware).
+- `State<Arc<Self>>` allows sharing state across handlers without `&mut self`.
 
-### Negativas
+### Negative
 
-- Interceptors e Pipes complexos do NestJS precisarão de mapeamentos adicionais.
-- Dynamic modules (`forRoot`/`forAsync`) não suportados ainda.
+- Complex NestJS Interceptors and Pipes will need additional mappings.
+- Dynamic modules (`forRoot`/`forAsync`) are not yet supported.

--- a/docs/architecture/decisions/0015-rejected-tooling.md
+++ b/docs/architecture/decisions/0015-rejected-tooling.md
@@ -1,0 +1,37 @@
+# 15. Tooling Evaluated and Rejected
+
+Date: 2026-08-04
+Status: Accepted
+
+## Context
+
+The 2026-08 standardization campaign (ADRs 0013/0014) included a research pass over current Rust quality tooling: Rust API Guidelines, the Safety-Critical Rust Consortium's coding guidelines, clippy lint groups, property/mutation/fuzz testing practice, and supply-chain tooling. Several well-regarded tools were evaluated and deliberately **not** adopted.
+
+Recording rejections matters as much as recording adoptions: without this ADR, every future audit or contributor re-litigates the same decisions from scratch. Each rejection below states its condition for reopening — a rejection is only valid while its premise holds.
+
+## Decision
+
+The following tools are rejected for this project. Reopening any of them requires a new ADR citing a changed premise.
+
+| Tool | Rejected because | Reopen when |
+|---|---|---|
+| **Ferrocene** (qualified toolchain) | Its value is the certification paper trail (ISO 26262 / IEC 61508) for regulated industries. Tyrus is an academic transpiler; no certification target exists. | The project targets a certified/regulated deployment. |
+| **Miri** | Detects undefined behavior in `unsafe` code. With R13 (`#![forbid(unsafe_code)]` workspace-wide, ADR 0013) there is structurally nothing for Miri to find; runs cost 10–100× test time. | Any crate legitimately needs `unsafe` (which itself requires an ADR amending R13). |
+| **Sanitizers (ASan/TSan/MSan)** | Same premise as Miri: they target memory/thread bugs that safe Rust prevents. The workspace has no `unsafe` and no exotic concurrency (single Mutex protocol, ADR 0009). | `unsafe` enters the workspace, or concurrency grows beyond the ADR 0009 pattern. |
+| **cargo-careful** | Marginal UB-adjacent checking on top of safe Rust; same premise as Miri, weaker payoff. | Same as Miri. |
+| **cargo-vet / cargo-crev** | Audit-trail systems designed for organizations with regulatory supply-chain requirements and audit-sharing networks. For a single-maintainer project, `cargo-deny` (licenses/bans/sources) + `cargo-audit` + Dependabot + `--locked` (R12) cover the realistic threat model; maintaining `audits.toml` would be ceremony without a second consumer. | The project gains external contributors/consumers with supply-chain requirements. |
+| **clippy `restriction` as a group** | The restriction group is explicitly not designed to be enabled wholesale — it contains mutually contradictory lints. Individual restriction lints are cherry-picked instead (R6: `unwrap_used`, `expect_used`, `panic`, `todo`, `unimplemented`, `indexing_slicing`, `string_slice`, `unwrap_in_result`; plus `dbg_macro`, `print_stdout`/`print_stderr`, `exit`, `mem_forget` via #215). | Never as a group; individual lints may be added anytime via the `[workspace.lints]` table. |
+| **quickcheck** (vs proptest) | Semi-maintained; weaker shrinking and no composable strategies. The planned property-testing work (post-RFC testing phase) standardizes on **proptest**. | proptest becomes unmaintained. |
+
+## Consequences
+
+- Future audits check this table before proposing tooling; proposals that ignore it are returned with a pointer here.
+- The rejections tied to R13 make the `forbid(unsafe_code)` rule load-bearing beyond style: it is the premise that keeps the verification toolchain small. Weakening R13 invalidates three rows of this table and requires revisiting them in the same ADR.
+- The project accepts the residual risks explicitly: no UB detection (mitigated structurally by R13), no distributed dependency audits (mitigated by R12's audit stack).
+
+## References
+
+- [ADR 0013](0013-power-of-ten-v2.md) — R13 and the amendment campaign this decision belongs to.
+- [ADR 0011](0011-supply-chain-hygiene.md) — the adopted supply-chain stack.
+- [clippy lint groups](https://doc.rust-lang.org/stable/clippy/lints.html) — restriction-group guidance.
+- Microsoft Rust engineering practices (Miri/sanitizers applicability), Rust Project Primer (audit tooling) — research inputs to the campaign.


### PR DESCRIPTION
## Summary
- Translates ADRs 0000–0004 to English (content, dates, numbering, filenames preserved) — closes the language inconsistency with STANDARDIZATION_PLAN §3 and ADRs 0005+. Spot-checked: zero Portuguese residue.
- Adds **ADR 0015 — Tooling Evaluated and Rejected**: Ferrocene, Miri, sanitizers, cargo-careful, cargo-vet/crev, clippy restriction-as-group, quickcheck — each with rationale and its condition for reopening. Referenced by ADR 0013 (R13 consequence).
- ADR index updated.

Unit U3 of the standardization RFC. Closes #219

## Test plan
- [x] Docs-only; code tree identical to gates-green main (F4 staged-gates provision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQnQN7MkJEqWy75YZH7dNJ