### PR TITLE
chore: forbid unsafe_code in every crate root (Rule 13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
       # Rule 4 file ceiling — same gate the pre-commit hook runs (Rule 9:
       # every gates.sh gate has a 1:1 CI step; this one was hook-only, #213).
       - run: ./scripts/gates.sh filesize
+      # Rule 13: every crate root declares #![forbid(unsafe_code)] (#214).
+      - run: ./scripts/gates.sh unsafe
 
   # MSRV — the workspace must keep compiling on the declared minimum
   # supported Rust version ([workspace.package] rust-version).

--- a/crates/tyrus_analyzer/src/lib.rs
+++ b/crates/tyrus_analyzer/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 // Visitor modules are crate-private — only `Analyzer::analyze` should
 // instantiate them. `report` and `severity` are exposed because the CLI
 // and orchestrator format diagnostics for end users.

--- a/crates/tyrus_ast/src/lib.rs
+++ b/crates/tyrus_ast/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 pub mod decl;
 pub mod expr;
 pub mod ident;

--- a/crates/tyrus_cli/src/main.rs
+++ b/crates/tyrus_cli/src/main.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use clap::{Parser, Subcommand};
 use miette::Result;
 use std::path::PathBuf;

--- a/crates/tyrus_codegen/src/lib.rs
+++ b/crates/tyrus_codegen/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 pub mod convert;
 pub(crate) mod decorators;
 pub mod stdlib;

--- a/crates/tyrus_common/src/lib.rs
+++ b/crates/tyrus_common/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 pub mod config;
 pub mod fs;
 pub mod util;

--- a/crates/tyrus_decorator_kinds/src/lib.rs
+++ b/crates/tyrus_decorator_kinds/src/lib.rs
@@ -13,6 +13,7 @@
 //! assert_eq!(DecoratorKind::from_name("UnknownDecorator"), None);
 //! ```
 
+#![forbid(unsafe_code)]
 #![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::todo)]
 
 /// Where in the AST a decorator can appear.

--- a/crates/tyrus_di/src/lib.rs
+++ b/crates/tyrus_di/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 pub mod graph;
 pub mod module;
 pub mod provider;

--- a/crates/tyrus_diagnostics/src/lib.rs
+++ b/crates/tyrus_diagnostics/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![allow(unused_assignments)]
 use miette::{Diagnostic, NamedSource, SourceSpan};
 use thiserror::Error;

--- a/crates/tyrus_orchestrator/src/lib.rs
+++ b/crates/tyrus_orchestrator/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use std::path::Path;
 
 use tyrus_common::fs::FilePath;

--- a/crates/tyrus_parser/src/lib.rs
+++ b/crates/tyrus_parser/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use miette::{NamedSource, SourceSpan};
 use std::path::Path;
 use tyrus_diagnostics::TyrusError;

--- a/crates/tyrus_test_utils/src/lib.rs
+++ b/crates/tyrus_test_utils/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 use std::fs;
 use std::path::PathBuf;

--- a/scripts/gates.sh
+++ b/scripts/gates.sh
@@ -20,6 +20,7 @@
 #   ./scripts/gates.sh deny        # cargo deny check
 #   ./scripts/gates.sh audit       # cargo audit --deny warnings
 #   ./scripts/gates.sh machete     # cargo machete (unused dependencies)
+#   ./scripts/gates.sh unsafe      # Rule 13: forbid(unsafe_code) in every crate root
 #
 # Environment variables:
 #   TYRUS_SKIP_DENY=1      Skip cargo deny check (use only when tool unavailable).
@@ -170,6 +171,27 @@ gate_filesize() {
     return "$fail"
 }
 
+gate_unsafe() {
+    echo "=== gate: unsafe ==="
+    # Rule 13 (POWER_OF_TEN.md, ADR 0013): every crate root must declare
+    # #![forbid(unsafe_code)]. `forbid` cannot be overridden by inner
+    # allows, so the compiler is the real enforcement — this gate only
+    # guarantees the attribute never silently disappears (or is missing
+    # from a newly added crate).
+    fail=0
+    for root in crates/*/src/lib.rs crates/*/src/main.rs tests/src/lib.rs; do
+        [ -f "$root" ] || continue
+        if ! grep -q '^#!\[forbid(unsafe_code)\]' "$root"; then
+            echo "FAIL: missing #![forbid(unsafe_code)] in $root"
+            fail=1
+        fi
+    done
+    if [ "$fail" -eq 0 ]; then
+        echo "All crate roots forbid unsafe_code."
+    fi
+    return "$fail"
+}
+
 gate_machete() {
     if [ "${TYRUS_SKIP_MACHETE:-0}" = "1" ]; then
         echo "=== gate: machete (SKIPPED via TYRUS_SKIP_MACHETE=1) ==="
@@ -223,10 +245,12 @@ case "$cmd" in
     deny)     gate_deny ;;
     audit)    gate_audit ;;
     machete)  gate_machete ;;
+    unsafe)   gate_unsafe ;;
     all)
         gate_fmt
         gate_clippy
         gate_filesize
+        gate_unsafe
         gate_test
         gate_coverage
         gate_deny

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![allow(
     clippy::unwrap_used,
     clippy::expect_used,


### PR DESCRIPTION
## Summary
Implements R13 (ADR 0013, #214): `#![forbid(unsafe_code)]` in all 11 lib roots + `tyrus_cli` main.rs + `integration_tests`, plus a new `unsafe` gate in gates.sh with its 1:1 CI step (R9). `forbid` cannot be overridden by inner allows — the compiler is the enforcement; the gate only guards against the attribute disappearing or missing from new crates.

**Stacked on #220** (both touch gates.sh/ci.yml). Retargets to main automatically when #220 merges. Closes #214

## Test plan
- [x] Gate verified both directions: passes with all roots annotated; fails when one attribute removed (negative test, observed)
- [x] Full gates staged: fmt, clippy --locked, filesize, unsafe, machete, deny, audit, nextest 306/306, coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQnQN7MkJEqWy75YZH7dNJ