### PR TITLE
refactor: migrate lint policy to workspace.lints with clippy pedantic

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,16 +1,5 @@
 # .cargo/config.toml
-# Strict linting rules for TypeRust workspace.
-# All violations are compile errors. No exceptions.
-
-[target.'cfg(all())']
-rustflags = [
-    "-Dwarnings",
-    "-Wclippy::unwrap_used",
-    "-Wclippy::expect_used",
-    "-Wclippy::panic",
-    "-Wclippy::todo",
-    "-Wclippy::unimplemented",
-    "-Wclippy::needless_pass_by_value",
-    "-Wclippy::redundant_closure_for_method_calls",
-    "-Wclippy::implicit_clone",
-]
+# Lint policy moved to `[workspace.lints]` in the root Cargo.toml (#215),
+# the idiomatic mechanism since Rust 1.74. This file intentionally keeps no
+# rustflags: duplicating lints here would apply them to third-party
+# dependencies too and fight the workspace tables.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,47 @@ description = "Tyrus — TypeScript-to-Rust transpiler targeting NestJS → Axum
 
 [profile.release]
 lto = true
+
+# Single source of truth for lint policy (Rule 6/12/13, ADR 0013, #215).
+# Replaces the old .cargo/config.toml rustflags block. Every member opts in
+# via `[lints] workspace = true`. `warnings = "deny"` keeps the historical
+# "-Dwarnings" semantics: any warn-level lint below is a hard error in
+# `cargo clippy`/`cargo build`.
+[workspace.lints.rust]
+warnings = "deny"
+unsafe_code = "forbid"
+unreachable_pub = "warn"
+missing_debug_implementations = "warn"
+
+[workspace.lints.clippy]
+# Broad safety net; individual noisy lints are allowed explicitly below.
+pedantic = { level = "warn", priority = -1 }
+
+# Rule 6 — total error handling (panics are compile errors).
+unwrap_used = "warn"
+expect_used = "warn"
+panic = "warn"
+todo = "warn"
+unimplemented = "warn"
+indexing_slicing = "warn"
+string_slice = "warn"
+unwrap_in_result = "warn"
+
+# Historical strict set (ADR 0006).
+needless_pass_by_value = "warn"
+redundant_closure_for_method_calls = "warn"
+implicit_clone = "warn"
+
+# Debug/process hygiene (restriction cherry-picks, ADR 0013).
+dbg_macro = "warn"
+print_stdout = "warn"
+print_stderr = "warn"
+exit = "warn"
+mem_forget = "warn"
+
+# Curated pedantic allows: noisy for this codebase, low signal.
+# must_use_candidate/missing_errors_doc: revisited by #216/doc work.
+must_use_candidate = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"

--- a/crates/tyrus_analyzer/Cargo.toml
+++ b/crates/tyrus_analyzer/Cargo.toml
@@ -21,3 +21,6 @@ console = "0.15"
 
 [dev-dependencies]
 swc_ecma_parser = "39.0.2"
+
+[lints]
+workspace = true

--- a/crates/tyrus_analyzer/src/decorators.rs
+++ b/crates/tyrus_analyzer/src/decorators.rs
@@ -1,4 +1,7 @@
-use swc_ecma_ast::*;
+use swc_ecma_ast::{
+    ArrayLit, BindingIdent, Callee, Class, ClassDecl, ClassMember, Decorator, Expr, ExprOrSpread,
+    ObjectLit, ParamOrTsParamProp, Pat, Prop, PropName, PropOrSpread, TsParamPropParam,
+};
 use swc_ecma_visit::{Visit, VisitWith};
 use tyrus_decorator_kinds::DecoratorKind;
 use tyrus_di::graph::DiGraph;
@@ -24,7 +27,7 @@ impl Default for DecoratorVisitor {
 }
 
 impl DecoratorVisitor {
-    fn extract_decorator_args(&self, decorator: &Decorator) -> Option<ObjectLit> {
+    fn extract_decorator_args(decorator: &Decorator) -> Option<ObjectLit> {
         if let Expr::Call(call_expr) = &*decorator.expr {
             if let Some(arg) = call_expr.args.first() {
                 if let Expr::Object(obj_lit) = &*arg.expr {
@@ -37,7 +40,7 @@ impl DecoratorVisitor {
 
     /// Parses an `@Module({ imports, providers, controllers, exports })`
     /// decorator into a [`Module`] for the DI graph.
-    fn parse_module_metadata(&self, class_name: &str, decorator: &Decorator) -> Module {
+    fn parse_module_metadata(class_name: &str, decorator: &Decorator) -> Module {
         let mut module = Module {
             name: class_name.to_string(),
             imports: vec![],
@@ -45,7 +48,7 @@ impl DecoratorVisitor {
             controllers: vec![],
             exports: vec![],
         };
-        let Some(obj) = self.extract_decorator_args(decorator) else {
+        let Some(obj) = Self::extract_decorator_args(decorator) else {
             return module;
         };
         for prop in obj.props {
@@ -86,6 +89,39 @@ fn collect_ident_array(arr: &ArrayLit) -> Vec<String> {
         .collect()
 }
 
+/// Extracts the type-reference name from a typed binding ident, if any.
+fn type_ref_name(ident: &BindingIdent) -> Option<String> {
+    let type_ann = ident.type_ann.as_ref()?;
+    let type_ref = type_ann.type_ann.as_ts_type_ref()?;
+    Some(type_ref.type_name.as_ident()?.sym.to_string())
+}
+
+/// Collects constructor parameter type names as DI dependencies.
+fn collect_constructor_deps(class: &Class) -> Vec<String> {
+    let mut deps = vec![];
+    for member in &class.body {
+        let ClassMember::Constructor(cons) = member else {
+            continue;
+        };
+        for param in &cons.params {
+            let ident = match param {
+                ParamOrTsParamProp::TsParamProp(prop) => match &prop.param {
+                    TsParamPropParam::Ident(ident) => Some(ident),
+                    TsParamPropParam::Assign(_) => None,
+                },
+                ParamOrTsParamProp::Param(param) => match &param.pat {
+                    Pat::Ident(ident) => Some(ident),
+                    _ => None,
+                },
+            };
+            if let Some(name) = ident.and_then(type_ref_name) {
+                deps.push(name);
+            }
+        }
+    }
+    deps
+}
+
 /// Wraps each ident name in a `Provider` (singleton, deps filled later).
 fn values_to_providers(values: Vec<String>) -> Vec<Provider> {
     values
@@ -122,7 +158,7 @@ impl Visit for DecoratorVisitor {
             };
             match kind {
                 DecoratorKind::Module => {
-                    let module = self.parse_module_metadata(&class_name, decorator);
+                    let module = Self::parse_module_metadata(&class_name, decorator);
                     self.graph.add_module(module);
                 }
                 DecoratorKind::Injectable | DecoratorKind::Controller => {
@@ -133,44 +169,10 @@ impl Visit for DecoratorVisitor {
         }
 
         if is_injectable {
-            // Extract dependencies from constructor
-            let mut deps = vec![];
-            for member in &n.class.body {
-                if let ClassMember::Constructor(cons) = member {
-                    for param in &cons.params {
-                        match param {
-                            ParamOrTsParamProp::TsParamProp(prop) => {
-                                if let TsParamPropParam::Ident(ident) = &prop.param {
-                                    if let Some(type_ann) = &ident.type_ann {
-                                        if let Some(type_ref) = type_ann.type_ann.as_ts_type_ref() {
-                                            if let Some(type_name) = type_ref.type_name.as_ident() {
-                                                deps.push(type_name.sym.to_string());
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            ParamOrTsParamProp::Param(param) => {
-                                if let Pat::Ident(ident) = &param.pat {
-                                    if let Some(type_ann) = &ident.type_ann {
-                                        if let Some(type_ref) = type_ann.type_ann.as_ts_type_ref() {
-                                            if let Some(type_name) = type_ref.type_name.as_ident() {
-                                                deps.push(type_name.sym.to_string());
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Add to graph as definition
             self.graph
                 .add_injectable(tyrus_di::provider::InjectableDefinition {
                     name: class_name.clone(),
-                    dependencies: deps,
+                    dependencies: collect_constructor_deps(&n.class),
                     scope: InjectionScope::Singleton,
                 });
         }

--- a/crates/tyrus_analyzer/src/lib.rs
+++ b/crates/tyrus_analyzer/src/lib.rs
@@ -17,8 +17,10 @@ use swc_ecma_visit::VisitWith;
 use tyrus_di::graph::DiGraph;
 use tyrus_diagnostics::TyrusError;
 
+#[derive(Debug)]
 pub struct Analyzer;
 
+#[derive(Debug)]
 pub struct AnalysisResult {
     pub errors: Vec<TyrusError>,
     pub diagnostics: Vec<severity::Diagnostic>,

--- a/crates/tyrus_analyzer/src/lints.rs
+++ b/crates/tyrus_analyzer/src/lints.rs
@@ -23,7 +23,7 @@ impl LintVisitor {
         }
     }
 
-    fn create_span(&self, span: swc_common::Span) -> SourceSpan {
+    fn create_span(span: swc_common::Span) -> SourceSpan {
         let start = span.lo.0 as usize - 1;
         let end = span.hi.0 as usize - 1;
         let len = end - start;
@@ -41,7 +41,7 @@ impl LintVisitor {
         if let (true, Some(span)) = (has_user_main, first_top_stmt_span) {
             self.errors.push(TyrusError::AmbiguousMainEntrypoint {
                 src: NamedSource::new(self.file_name.clone(), self.source_code.clone()),
-                span: self.create_span(span),
+                span: Self::create_span(span),
             });
         }
     }
@@ -142,7 +142,7 @@ impl Visit for LintVisitor {
         if n.kind == VarDeclKind::Var {
             self.errors.push(TyrusError::UseOfVar {
                 src: NamedSource::new(self.file_name.clone(), self.source_code.clone()),
-                span: self.create_span(n.span),
+                span: Self::create_span(n.span),
             });
         }
         n.visit_children_with(self);
@@ -152,7 +152,7 @@ impl Visit for LintVisitor {
         if n.kind == TsKeywordTypeKind::TsAnyKeyword {
             self.errors.push(TyrusError::UseOfAny {
                 src: NamedSource::new(self.file_name.clone(), self.source_code.clone()),
-                span: self.create_span(n.span),
+                span: Self::create_span(n.span),
             });
         }
         n.visit_children_with(self);
@@ -164,7 +164,7 @@ impl Visit for LintVisitor {
                 if ident.sym == "eval" {
                     self.errors.push(TyrusError::UseOfEval {
                         src: NamedSource::new(self.file_name.clone(), self.source_code.clone()),
-                        span: self.create_span(n.span),
+                        span: Self::create_span(n.span),
                     });
                 }
             }
@@ -179,7 +179,7 @@ impl Visit for LintVisitor {
         self.errors.push(TyrusError::UnsupportedFeature {
             feature: "for-in loops".to_string(),
             src: NamedSource::new(self.file_name.clone(), self.source_code.clone()),
-            span: self.create_span(n.span),
+            span: Self::create_span(n.span),
         });
         n.visit_children_with(self);
     }
@@ -189,7 +189,7 @@ impl Visit for LintVisitor {
             self.errors.push(TyrusError::UnsupportedFeature {
                 feature: "delete operator".to_string(),
                 src: NamedSource::new(self.file_name.clone(), self.source_code.clone()),
-                span: self.create_span(n.span),
+                span: Self::create_span(n.span),
             });
         }
         n.visit_children_with(self);
@@ -199,7 +199,7 @@ impl Visit for LintVisitor {
         self.errors.push(TyrusError::UnsupportedFeature {
             feature: "with statement".to_string(),
             src: NamedSource::new(self.file_name.clone(), self.source_code.clone()),
-            span: self.create_span(n.span),
+            span: Self::create_span(n.span),
         });
         n.visit_children_with(self);
     }
@@ -208,7 +208,7 @@ impl Visit for LintVisitor {
         self.errors.push(TyrusError::UnsupportedFeature {
             feature: "labeled statements".to_string(),
             src: NamedSource::new(self.file_name.clone(), self.source_code.clone()),
-            span: self.create_span(n.span),
+            span: Self::create_span(n.span),
         });
         n.visit_children_with(self);
     }

--- a/crates/tyrus_analyzer/src/lints/tests.rs
+++ b/crates/tyrus_analyzer/src/lints/tests.rs
@@ -10,7 +10,7 @@ use swc_ecma_ast::Program;
 use swc_ecma_parser::{Parser, StringInput, Syntax, TsSyntax};
 
 fn parse_module(source: &str) -> Module {
-    let cm: Lrc<SourceMap> = Default::default();
+    let cm: Lrc<SourceMap> = Lrc::default();
     let fm = cm.new_source_file(FileName::Anon.into(), source.to_string());
     let mut parser = Parser::new(
         Syntax::Typescript(TsSyntax::default()),
@@ -169,10 +169,10 @@ fn rejects_eval_call() {
 #[test]
 fn rejects_for_in() {
     let errors = run_lints(
-        r#"
+        r"
 const obj = { a: 1 };
 for (const k in obj) { console.log(k); }
-"#,
+",
     );
     let has = errors.iter().any(|e| {
         matches!(
@@ -214,11 +214,11 @@ fn rejects_with_statement() {
 #[test]
 fn rejects_labeled_statement() {
     let errors = run_lints(
-        r#"
+        r"
 outer: for (let i = 0; i < 3; i++) {
     if (i === 1) break outer;
 }
-"#,
+",
     );
     let has = errors.iter().any(|e| {
         matches!(
@@ -232,13 +232,13 @@ outer: for (let i = 0; i < 3; i++) {
 #[test]
 fn clean_program_has_no_errors() {
     let errors = run_lints(
-        r#"
+        r"
 function add(a: number, b: number): number {
     return a + b;
 }
 const result = add(1, 2);
 console.log(result);
-"#,
+",
     );
     assert!(
         errors.is_empty(),

--- a/crates/tyrus_analyzer/src/report.rs
+++ b/crates/tyrus_analyzer/src/report.rs
@@ -1,6 +1,7 @@
 use console::style;
 use miette::Diagnostic as MietteDiagnostic;
 use serde_json::{json, Value};
+use std::fmt::Write;
 use tyrus_diagnostics::TyrusError;
 
 use crate::severity::{Diagnostic, Severity};
@@ -42,31 +43,27 @@ pub fn format_pretty(diagnostics: &[Diagnostic]) -> String {
             Severity::Info => style("ℹ").blue().bold().to_string(),
         };
 
-        out.push_str(&format!(
-            "  {} {} [{}]\n",
-            icon,
-            d.message,
-            style(&d.code).dim()
-        ));
+        let _ = writeln!(out, "  {} {} [{}]", icon, d.message, style(&d.code).dim());
 
         if let Some(span) = &d.span {
-            out.push_str(&format!(
-                "    at {}:{}..{}\n",
+            let _ = writeln!(
+                out,
+                "    at {}:{}..{}",
                 style(&span.file).underlined(),
                 span.start,
                 span.end,
-            ));
+            );
         }
 
         if let Some(suggestion) = &d.suggestion {
-            out.push_str(&format!("    {} {}\n", style("->").cyan(), suggestion));
+            let _ = writeln!(out, "    {} {}", style("->").cyan(), suggestion);
         }
     }
 
-    out.push_str(&format!(
-        "\n  {} error(s), {} warning(s), {} info(s)\n",
-        errors, warnings, infos,
-    ));
+    let _ = writeln!(
+        out,
+        "\n  {errors} error(s), {warnings} warning(s), {infos} info(s)",
+    );
 
     out
 }
@@ -77,8 +74,7 @@ pub fn format_pretty(diagnostics: &[Diagnostic]) -> String {
 pub(crate) fn error_to_json_value(err: &TyrusError) -> Value {
     let code = err
         .code()
-        .map(|c| c.to_string())
-        .unwrap_or_else(|| "tyrus::unknown".to_string());
+        .map_or_else(|| "tyrus::unknown".to_string(), |c| c.to_string());
     json!({
         "code": code,
         "message": format!("{err}"),
@@ -135,6 +131,10 @@ pub fn format_json_failure(error: &TyrusError) -> String {
 
 #[cfg(test)]
 #[allow(clippy::expect_used)]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "serde_json::Value indexing is total: missing keys yield Value::Null"
+)]
 mod tests {
     use super::*;
     use crate::severity::Diagnostic;

--- a/crates/tyrus_analyzer/src/report.rs
+++ b/crates/tyrus_analyzer/src/report.rs
@@ -133,7 +133,7 @@ pub fn format_json_failure(error: &TyrusError) -> String {
 #[allow(clippy::expect_used)]
 #[expect(
     clippy::indexing_slicing,
-    reason = "serde_json::Value indexing is total: missing keys yield Value::Null"
+    reason = "Value key indexing is total (missing keys yield Null); array element access is guarded by len asserts immediately before"
 )]
 mod tests {
     use super::*;

--- a/crates/tyrus_analyzer/src/severity.rs
+++ b/crates/tyrus_analyzer/src/severity.rs
@@ -60,6 +60,7 @@ impl Diagnostic {
         }
     }
 
+    #[must_use]
     pub fn with_span(mut self, start: usize, end: usize, file: &str) -> Self {
         self.span = Some(DiagnosticSpan {
             start,
@@ -69,6 +70,7 @@ impl Diagnostic {
         self
     }
 
+    #[must_use]
     pub fn with_suggestion(mut self, suggestion: &str) -> Self {
         self.suggestion = Some(suggestion.to_string());
         self

--- a/crates/tyrus_analyzer/src/unsupported.rs
+++ b/crates/tyrus_analyzer/src/unsupported.rs
@@ -83,7 +83,7 @@ impl UnsupportedApiVisitor {
         }
     }
 
-    fn span_to_range(&self, span: swc_common::Span) -> (usize, usize) {
+    fn span_to_range(span: swc_common::Span) -> (usize, usize) {
         (span.lo.0 as usize, span.hi.0 as usize)
     }
 }
@@ -94,7 +94,7 @@ impl Visit for UnsupportedApiVisitor {
             let name = ident.sym.as_ref();
             for (global, code, msg) in BLOCKED_GLOBALS {
                 if name == *global {
-                    let (start, end) = self.span_to_range(n.span);
+                    let (start, end) = Self::span_to_range(n.span);
                     self.diagnostics
                         .push(Diagnostic::error(code, msg).with_span(start, end, &self.file_name));
                 }
@@ -109,7 +109,7 @@ impl Visit for UnsupportedApiVisitor {
                 let name = ident.sym.as_ref();
                 for (func, code, msg, suggestion) in BLOCKED_FUNCTIONS {
                     if name == *func {
-                        let (start, end) = self.span_to_range(n.span);
+                        let (start, end) = Self::span_to_range(n.span);
                         self.diagnostics.push(
                             Diagnostic::error(code, msg)
                                 .with_span(start, end, &self.file_name)

--- a/crates/tyrus_ast/Cargo.toml
+++ b/crates/tyrus_ast/Cargo.toml
@@ -11,3 +11,6 @@ repository.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 swc_ecma_ast = "23.0.0"
 swc_common = { version = "21.0.1", features = ["tty-emitter"] }
+
+[lints]
+workspace = true

--- a/crates/tyrus_ast/src/lower_type.rs
+++ b/crates/tyrus_ast/src/lower_type.rs
@@ -94,9 +94,11 @@ fn lower_union(union: &swc_ecma_ast::TsUnionType) -> TyrusType {
         })
         .collect();
 
-    if non_undefined.len() == 1 && non_undefined.len() < union.types.len() {
-        let inner = lower_ts_type_inner(non_undefined[0]);
-        TyrusType::Option(Box::new(inner))
+    if let ([only], true) = (
+        non_undefined.as_slice(),
+        non_undefined.len() < union.types.len(),
+    ) {
+        TyrusType::Option(Box::new(lower_ts_type_inner(only)))
     } else {
         TyrusType::Inferred
     }

--- a/crates/tyrus_cli/Cargo.toml
+++ b/crates/tyrus_cli/Cargo.toml
@@ -21,3 +21,6 @@ tyrus_analyzer = { path = "../tyrus_analyzer" }
 tyrus_diagnostics = { path = "../tyrus_diagnostics" }
 console = "0.15"
 indicatif = "0.17"
+
+[lints]
+workspace = true

--- a/crates/tyrus_cli/src/commands/build.rs
+++ b/crates/tyrus_cli/src/commands/build.rs
@@ -29,7 +29,7 @@ fn execute_project(path: &Path, output: Option<PathBuf>) -> Result<()> {
     pipeline.start_step("Creating Cargo project");
 
     tyrus_orchestrator::build_project(path, &output_dir)?;
-    pipeline.finish_success(&format!(
+    Pipeline::finish_success(&format!(
         "Project built → {}",
         colors::file_path(&output_dir.display().to_string()),
     ));
@@ -53,7 +53,7 @@ fn execute_single(path: &Path, output: Option<PathBuf>) -> Result<()> {
         }
         std::fs::write(&output_path, &output_code)
             .map_err(|e| miette::miette!("Failed to write output file: {e}"))?;
-        pipeline.finish_success(&format!(
+        Pipeline::finish_success(&format!(
             "Built → {}",
             colors::file_path(&output_path.display().to_string()),
         ));

--- a/crates/tyrus_cli/src/commands/check.rs
+++ b/crates/tyrus_cli/src/commands/check.rs
@@ -53,13 +53,13 @@ pub(crate) fn execute(path: &Path, json: bool, strict: bool) -> Result<()> {
     }
 
     if total_fatal == 0 {
-        pipeline.finish_success(&format!(
+        Pipeline::finish_success(&format!(
             "File is Oxidizable — {} statements parsed",
             result.statement_count,
         ));
         Ok(())
     } else {
-        pipeline.finish_error(&format!("{total_fatal} issue(s) found"));
+        Pipeline::finish_error(&format!("{total_fatal} issue(s) found"));
         // Per plan D5 — exit code primary signal even in --json mode.
         // Aggregate message only; per-error details already printed above.
         Err(TyrusError::Validation(format!("{total_fatal} oxidizable check(s) failed")).into())

--- a/crates/tyrus_cli/src/commands/compile.rs
+++ b/crates/tyrus_cli/src/commands/compile.rs
@@ -36,13 +36,13 @@ pub(crate) fn execute(path: &Path, output: Option<PathBuf>, release: bool) -> Re
 
     if !status.status.success() {
         let stderr = String::from_utf8_lossy(&status.stderr);
-        pipeline.finish_error("Compilation failed");
+        Pipeline::finish_error("Compilation failed");
         eprintln!("{stderr}");
         return Err(miette::miette!("cargo build failed"));
     }
 
     let mode = if release { "release" } else { "debug" };
-    pipeline.finish_success(&format!(
+    Pipeline::finish_success(&format!(
         "Compiled → {}/target/{mode}/tyrus_app",
         colors::file_path(&output_dir.display().to_string()),
     ));

--- a/crates/tyrus_cli/src/commands/run.rs
+++ b/crates/tyrus_cli/src/commands/run.rs
@@ -32,7 +32,7 @@ pub(crate) fn execute(path: &Path, output: Option<PathBuf>) -> Result<()> {
 
     if !build_output.status.success() {
         let stderr = String::from_utf8_lossy(&build_output.stderr);
-        pipeline.finish_error("Compilation failed");
+        Pipeline::finish_error("Compilation failed");
         eprintln!("{stderr}");
         return Err(miette::miette!("cargo build failed"));
     }
@@ -54,10 +54,10 @@ pub(crate) fn execute(path: &Path, output: Option<PathBuf>) -> Result<()> {
     }
 
     if run_output.status.success() {
-        pipeline.finish_success("Execution complete");
+        Pipeline::finish_success("Execution complete");
     } else {
         let code = run_output.status.code().unwrap_or(-1);
-        pipeline.finish_error(&format!("Process exited with code {code}"));
+        Pipeline::finish_error(&format!("Process exited with code {code}"));
     }
 
     Ok(())

--- a/crates/tyrus_cli/src/main.rs
+++ b/crates/tyrus_cli/src/main.rs
@@ -1,4 +1,9 @@
 #![forbid(unsafe_code)]
+#![expect(
+    clippy::print_stdout,
+    clippy::print_stderr,
+    reason = "the CLI's job is printing to the terminal"
+)]
 
 use clap::{Parser, Subcommand};
 use miette::Result;
@@ -42,7 +47,7 @@ enum Commands {
     Build {
         /// Input file or directory path
         path: PathBuf,
-        /// Output directory (default: ./tyrus_output)
+        /// Output directory (default: ./`tyrus_output`)
         #[arg(short, long)]
         output: Option<PathBuf>,
     },
@@ -50,7 +55,7 @@ enum Commands {
     Compile {
         /// Input file or directory path
         path: PathBuf,
-        /// Output directory (default: ./tyrus_output)
+        /// Output directory (default: ./`tyrus_output`)
         #[arg(short, long)]
         output: Option<PathBuf>,
         /// Build in release mode with optimizations
@@ -61,7 +66,7 @@ enum Commands {
     Run {
         /// Input file or directory path
         path: PathBuf,
-        /// Output directory (default: ./tyrus_output)
+        /// Output directory (default: ./`tyrus_output`)
         #[arg(short, long)]
         output: Option<PathBuf>,
     },

--- a/crates/tyrus_cli/src/ui/progress.rs
+++ b/crates/tyrus_cli/src/ui/progress.rs
@@ -16,8 +16,7 @@ impl Pipeline {
     }
 
     pub(crate) fn start_step(&mut self, detail: &str) {
-        if self.current < self.steps.len() {
-            let label = &self.steps[self.current];
+        if let Some(label) = self.steps.get(self.current) {
             eprintln!(
                 "  {} {} {}",
                 style(format!("[{}/{}]", self.current + 1, self.steps.len())).dim(),
@@ -28,7 +27,7 @@ impl Pipeline {
         self.current += 1;
     }
 
-    pub(crate) fn finish_success(&self, msg: &str) {
+    pub(crate) fn finish_success(msg: &str) {
         eprintln!(
             "\n  {} {}\n",
             style("✓").green().bold(),
@@ -36,7 +35,7 @@ impl Pipeline {
         );
     }
 
-    pub(crate) fn finish_error(&self, msg: &str) {
+    pub(crate) fn finish_error(msg: &str) {
         eprintln!(
             "\n  {} {}\n",
             style("✗").red().bold(),

--- a/crates/tyrus_codegen/Cargo.toml
+++ b/crates/tyrus_codegen/Cargo.toml
@@ -15,3 +15,6 @@ swc_ecma_visit = "23.0.0"
 swc_common = { version = "21.0.1", features = ["tty-emitter"] }
 tyrus_common = { path = "../tyrus_common" }
 tyrus_decorator_kinds = { path = "../tyrus_decorator_kinds" }
+
+[lints]
+workspace = true

--- a/crates/tyrus_codegen/src/convert/class/constructor/di.rs
+++ b/crates/tyrus_codegen/src/convert/class/constructor/di.rs
@@ -77,9 +77,8 @@ fn build_di_ts_param(
     di_field_inits: &mut Vec<TokenStream>,
     di_initialized: &mut HashSet<String>,
 ) {
-    let ident = match &prop.param {
-        swc_ecma_ast::TsParamPropParam::Ident(id) => id,
-        _ => return,
+    let swc_ecma_ast::TsParamPropParam::Ident(ident) = &prop.param else {
+        return;
     };
 
     let param_name_str = ident.sym.to_string();
@@ -108,9 +107,8 @@ fn build_di_plain_param(
     di_field_inits: &mut Vec<TokenStream>,
     di_initialized: &mut HashSet<String>,
 ) {
-    let ident = match &pat_param.pat {
-        Pat::Ident(id) => id,
-        _ => return,
+    let Pat::Ident(ident) = &pat_param.pat else {
+        return;
     };
 
     let param_name_str = ident.sym.to_string();

--- a/crates/tyrus_codegen/src/convert/class/constructor/field_init.rs
+++ b/crates/tyrus_codegen/src/convert/class/constructor/field_init.rs
@@ -34,15 +34,16 @@ pub(super) fn extract_field_inits(
     field_inits: &mut Vec<TokenStream>,
     initialized_fields: &mut HashSet<String>,
 ) {
-    let body = match &constructor.body {
-        Some(b) => b,
-        None => return,
+    let Some(body) = &constructor.body else {
+        return;
     };
 
     for stmt in &body.stmts {
-        let expr_stmt = match stmt {
-            Stmt::Expr(ExprStmt { expr, .. }) => expr,
-            _ => continue,
+        let Stmt::Expr(ExprStmt {
+            expr: expr_stmt, ..
+        }) = stmt
+        else {
+            continue;
         };
 
         if let Expr::Call(call) = &**expr_stmt {
@@ -77,14 +78,11 @@ fn extract_super_call(
         .map(|(n, _)| n)
         .collect();
 
-    for (idx, arg) in call.args.iter().enumerate() {
-        if idx < parent_fields.len() {
-            let field_name_str = parent_fields[idx];
-            let field_name = format_ident!("{}", to_snake_case(field_name_str));
-            let value = generator.convert_expr(&arg.expr);
-            field_inits.push(quote! { #field_name: #value });
-            initialized_fields.insert(field_name_str.clone());
-        }
+    for (arg, field_name_str) in call.args.iter().zip(parent_fields) {
+        let field_name = format_ident!("{}", to_snake_case(field_name_str));
+        let value = generator.convert_expr(&arg.expr);
+        field_inits.push(quote! { #field_name: #value });
+        initialized_fields.insert(field_name_str.clone());
     }
 }
 
@@ -95,17 +93,15 @@ fn extract_this_assign(
     field_inits: &mut Vec<TokenStream>,
     initialized_fields: &mut HashSet<String>,
 ) {
-    let simple = match &assign.left {
-        AssignTarget::Simple(s) => s,
-        _ => return,
+    let AssignTarget::Simple(simple) = &assign.left else {
+        return;
     };
     let member = match simple.as_member() {
         Some(m) if m.obj.is_this() => m,
         _ => return,
     };
-    let prop_ident = match member.prop.as_ident() {
-        Some(id) => id,
-        None => return,
+    let Some(prop_ident) = member.prop.as_ident() else {
+        return;
     };
 
     let field_name_str = prop_ident.sym.to_string();
@@ -116,8 +112,7 @@ fn extract_this_assign(
         .class_fields
         .iter()
         .find(|(n, _)| n == &field_name_str)
-        .map(|(_, opt)| *opt)
-        .unwrap_or(false);
+        .is_some_and(|(_, opt)| *opt);
 
     let value = if is_optional {
         quote! { Some(#value) }

--- a/crates/tyrus_codegen/src/convert/class/constructor/mod.rs
+++ b/crates/tyrus_codegen/src/convert/class/constructor/mod.rs
@@ -35,18 +35,16 @@ pub(crate) struct ConstructorCtx<'a> {
     pub(crate) is_service_or_controller: bool,
 }
 
-/// Check whether a type annotation refers to a dependency (non-primitive TypeRef).
+/// Check whether a type annotation refers to a dependency (non-primitive `TypeRef`).
 pub(crate) fn is_dependency_type(
     type_ann: Option<&swc_ecma_ast::TsTypeAnn>,
     generic_params: &HashSet<String>,
 ) -> bool {
-    let ann = match type_ann {
-        Some(a) => a,
-        None => return false,
+    let Some(ann) = type_ann else {
+        return false;
     };
-    let type_ref = match ann.type_ann.as_ts_type_ref() {
-        Some(r) => r,
-        None => return false,
+    let Some(type_ref) = ann.type_ann.as_ts_type_ref() else {
+        return false;
     };
     match type_ref.type_name.as_ident() {
         Some(ident) => {
@@ -101,7 +99,13 @@ impl RustGenerator {
         let params = &extracted.params;
         let field_inits = &extracted.field_inits;
 
-        if !field_inits.is_empty() {
+        if field_inits.is_empty() {
+            quote! {
+                pub fn new(#(#params),*) -> Self {
+                    compile_error!("Tyrus: complex constructor pattern not yet supported")
+                }
+            }
+        } else {
             let di_tokens = build_di_constructor(ctx.constructor, ctx);
             quote! {
                 pub fn new(#(#params),*) -> Self {
@@ -111,12 +115,6 @@ impl RustGenerator {
                 }
 
                 #di_tokens
-            }
-        } else {
-            quote! {
-                pub fn new(#(#params),*) -> Self {
-                    compile_error!("Tyrus: complex constructor pattern not yet supported")
-                }
             }
         }
     }

--- a/crates/tyrus_codegen/src/convert/class/constructor/params.rs
+++ b/crates/tyrus_codegen/src/convert/class/constructor/params.rs
@@ -60,9 +60,8 @@ fn extract_ts_param_prop(
     is_service_or_controller: bool,
     result: &mut ExtractedParams,
 ) {
-    let ident = match &prop.param {
-        swc_ecma_ast::TsParamPropParam::Ident(id) => id,
-        _ => return,
+    let swc_ecma_ast::TsParamPropParam::Ident(ident) = &prop.param else {
+        return;
     };
 
     let param_name_str = ident.sym.to_string();
@@ -88,9 +87,8 @@ fn extract_plain_param(
     is_service_or_controller: bool,
     result: &mut ExtractedParams,
 ) {
-    let ident = match &pat_param.pat {
-        Pat::Ident(id) => id,
-        _ => return,
+    let Pat::Ident(ident) = &pat_param.pat else {
+        return;
     };
 
     let param_name = format_ident!("{}", to_snake_case(ident.sym.as_ref()));

--- a/crates/tyrus_codegen/src/convert/class/frame.rs
+++ b/crates/tyrus_codegen/src/convert/class/frame.rs
@@ -33,7 +33,7 @@ pub(super) struct ClassMembers<'a> {
 /// Aggregated field information collected from properties and constructor params.
 pub(super) struct ClassFields {
     pub fields: Vec<TokenStream>,
-    pub class_fields_meta: Vec<(String, bool)>,
+    pub fields_meta: Vec<(String, bool)>,
     pub own_field_names: Vec<(String, TokenStream, bool)>,
     pub dependency_fields: HashSet<String>,
 }
@@ -116,9 +116,8 @@ pub(super) fn compute_class_generics(
     let params_use = params_struct.clone();
 
     if !params_use.is_empty() {
-        let phantom_type = if params_use.len() == 1 {
-            let p = &params_use[0];
-            quote! { #p }
+        let phantom_type = if let [only] = params_use.as_slice() {
+            quote! { #only }
         } else {
             quote! { (#(#params_use),*) }
         };

--- a/crates/tyrus_codegen/src/convert/class/method.rs
+++ b/crates/tyrus_codegen/src/convert/class/method.rs
@@ -17,6 +17,10 @@ struct MethodDecorators {
 }
 
 /// Context flags computed from decorators and method properties.
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "independent orthogonal flags derived from the TS method signature"
+)]
 struct MethodContext {
     is_handler: bool,
     is_static: bool,
@@ -96,8 +100,10 @@ fn convert_single_param(param: &swc_ecma_ast::Param) -> Option<proc_macro2::Toke
     let tokens = registry
         .first_param_decorator_kind(param)
         .and_then(|kind| registry.param_handler(kind))
-        .map(|handler| handler.emit_extractor(param, &param_name, &param_type))
-        .unwrap_or_else(|| quote! { #param_name: #param_type });
+        .map_or_else(
+            || quote! { #param_name: #param_type },
+            |handler| handler.emit_extractor(param, &param_name, &param_type),
+        );
 
     Some(tokens)
 }
@@ -161,16 +167,16 @@ fn compute_base_return_type(
     }
 }
 
-/// Wraps a handler return type in Json<T> and optionally (StatusCode, T).
+/// Wraps a handler return type in Json<T> and optionally (`StatusCode`, T).
 fn wrap_handler_return_type(
     base: &proc_macro2::TokenStream,
     http_code: Option<u16>,
 ) -> proc_macro2::TokenStream {
     let return_type_str = base.to_string();
-    let inner_type = if return_type_str != "String" {
-        quote! { axum::Json<#base> }
-    } else {
+    let inner_type = if return_type_str == "String" {
         quote! { String }
+    } else {
+        quote! { axum::Json<#base> }
     };
 
     if http_code.is_some() {
@@ -182,7 +188,7 @@ fn wrap_handler_return_type(
 
 use super::routing::{build_doc_comment, map_status_code};
 
-/// Builds a handler return expression with Json wrapping and optional StatusCode.
+/// Builds a handler return expression with Json wrapping and optional `StatusCode`.
 fn build_handler_return(
     expr: &proc_macro2::TokenStream,
     return_type: &proc_macro2::TokenStream,
@@ -320,7 +326,8 @@ impl RustGenerator {
             quote! { fn }
         };
 
-        let doc_comment = build_doc_comment(&decorators.http_method, &decorators.route_path);
+        let doc_comment =
+            build_doc_comment(decorators.http_method.as_ref(), &decorators.route_path);
 
         let tokens = quote! {
             #doc_comment

--- a/crates/tyrus_codegen/src/convert/class/mod.rs
+++ b/crates/tyrus_codegen/src/convert/class/mod.rs
@@ -106,7 +106,7 @@ impl RustGenerator {
     ) -> ClassFields {
         let mut acc = ClassFields {
             fields: Vec::new(),
-            class_fields_meta: Vec::new(),
+            fields_meta: Vec::new(),
             own_field_names: Vec::new(),
             dependency_fields: HashSet::new(),
         };
@@ -130,7 +130,7 @@ impl RustGenerator {
             let fname = format_ident!("{}", to_snake_case(field_name));
             let ftype = field_type.clone();
             acc.fields.push(quote! { pub #fname: #ftype });
-            acc.class_fields_meta.push((field_name.clone(), *is_opt));
+            acc.fields_meta.push((field_name.clone(), *is_opt));
             acc.own_field_names
                 .push((field_name.clone(), ftype, *is_opt));
         }
@@ -150,7 +150,7 @@ impl RustGenerator {
                 continue;
             };
             acc.fields.push(field_tokens);
-            acc.class_fields_meta.push((name.clone(), is_opt));
+            acc.fields_meta.push((name.clone(), is_opt));
             let raw_type_tokens = map_ts_type(prop.type_ann.as_ref());
             acc.own_field_names
                 .push((name.clone(), raw_type_tokens, is_opt));
@@ -276,7 +276,7 @@ impl RustGenerator {
         if let Some(cons) = frame.members.constructor {
             let ctx = constructor::ConstructorCtx {
                 constructor: cons,
-                class_fields: &frame.fields.class_fields_meta,
+                class_fields: &frame.fields.fields_meta,
                 has_generics: frame.decl.class.type_params.is_some(),
                 generic_params: &frame.meta.generic_params,
                 dependency_fields: &frame.fields.dependency_fields,

--- a/crates/tyrus_codegen/src/convert/class/routing.rs
+++ b/crates/tyrus_codegen/src/convert/class/routing.rs
@@ -197,11 +197,11 @@ pub(crate) fn map_status_code(code: u16) -> proc_macro2::TokenStream {
 
 /// Builds the doc comment for a handler method.
 pub(crate) fn build_doc_comment(
-    http_method: &Option<String>,
+    http_method: Option<&String>,
     route_path: &str,
 ) -> proc_macro2::TokenStream {
     use quote::quote;
-    let Some(m) = http_method.as_ref() else {
+    let Some(m) = http_method else {
         return quote! {};
     };
     let method_str = m.to_uppercase();

--- a/crates/tyrus_codegen/src/convert/expr/arrow.rs
+++ b/crates/tyrus_codegen/src/convert/expr/arrow.rs
@@ -4,7 +4,7 @@
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use swc_ecma_ast::*;
+use swc_ecma_ast::{ArrowExpr, BlockStmtOrExpr, Pat};
 
 use crate::convert::helpers::to_snake_case;
 use crate::convert::interface::RustGenerator;

--- a/crates/tyrus_codegen/src/convert/expr/binary.rs
+++ b/crates/tyrus_codegen/src/convert/expr/binary.rs
@@ -6,7 +6,7 @@
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use swc_ecma_ast::*;
+use swc_ecma_ast::{BinExpr, BinaryOp, Expr};
 
 use crate::convert::helpers::is_string_expr;
 use crate::convert::interface::RustGenerator;
@@ -14,42 +14,39 @@ use crate::convert::interface::RustGenerator;
 impl RustGenerator {
     // Bound: SWC AST is finite; recursion depth ≤ AST depth (Rule 1, POWER_OF_TEN.md).
     pub(crate) fn convert_bin_expr(&self, bin: &BinExpr) -> TokenStream {
-        match bin.op {
-            BinaryOp::Add => {
-                if is_string_expr(&bin.left) || is_string_expr(&bin.right) {
-                    // Flatten chained string concatenation into a single format!()
-                    let mut parts = Vec::new();
-                    collect_string_concat_parts(self, &Expr::Bin(bin.clone()), &mut parts);
-                    let fmt_str = "{}".repeat(parts.len());
-                    quote! { format!(#fmt_str, #(#parts),*) }
-                } else {
-                    let left = self.convert_expr(&bin.left);
-                    let right = self.convert_expr(&bin.right);
-                    quote! { #left + #right }
-                }
-            }
-            _ => {
+        if bin.op == BinaryOp::Add {
+            if is_string_expr(&bin.left) || is_string_expr(&bin.right) {
+                // Flatten chained string concatenation into a single format!()
+                let mut parts = Vec::new();
+                collect_string_concat_parts(self, &Expr::Bin(bin.clone()), &mut parts);
+                let fmt_str = "{}".repeat(parts.len());
+                quote! { format!(#fmt_str, #(#parts),*) }
+            } else {
                 let left = self.convert_expr(&bin.left);
                 let right = self.convert_expr(&bin.right);
-                match bin.op {
-                    BinaryOp::EqEq | BinaryOp::EqEqEq => quote! { #left == #right },
-                    BinaryOp::NotEq | BinaryOp::NotEqEq => quote! { #left != #right },
-                    BinaryOp::Sub => quote! { #left - #right },
-                    BinaryOp::Mul => quote! { #left * #right },
-                    BinaryOp::Div => quote! { #left / #right },
-                    BinaryOp::Mod => quote! { #left % #right },
-                    BinaryOp::Exp => quote! { (#left as f64).powf(#right as f64) },
-                    BinaryOp::Lt => quote! { #left < #right },
-                    BinaryOp::LtEq => quote! { #left <= #right },
-                    BinaryOp::Gt => quote! { #left > #right },
-                    BinaryOp::GtEq => quote! { #left >= #right },
-                    BinaryOp::LogicalOr => quote! { #left || #right },
-                    BinaryOp::LogicalAnd => quote! { #left && #right },
-                    BinaryOp::NullishCoalescing => quote! { #left.unwrap_or(#right) },
-                    _ => {
-                        let op_str = format!("{:?}", bin.op);
-                        quote! { compile_error!(concat!("Tyrus: unsupported binary operator: ", #op_str)) }
-                    }
+                quote! { #left + #right }
+            }
+        } else {
+            let left = self.convert_expr(&bin.left);
+            let right = self.convert_expr(&bin.right);
+            match bin.op {
+                BinaryOp::EqEq | BinaryOp::EqEqEq => quote! { #left == #right },
+                BinaryOp::NotEq | BinaryOp::NotEqEq => quote! { #left != #right },
+                BinaryOp::Sub => quote! { #left - #right },
+                BinaryOp::Mul => quote! { #left * #right },
+                BinaryOp::Div => quote! { #left / #right },
+                BinaryOp::Mod => quote! { #left % #right },
+                BinaryOp::Exp => quote! { (#left as f64).powf(#right as f64) },
+                BinaryOp::Lt => quote! { #left < #right },
+                BinaryOp::LtEq => quote! { #left <= #right },
+                BinaryOp::Gt => quote! { #left > #right },
+                BinaryOp::GtEq => quote! { #left >= #right },
+                BinaryOp::LogicalOr => quote! { #left || #right },
+                BinaryOp::LogicalAnd => quote! { #left && #right },
+                BinaryOp::NullishCoalescing => quote! { #left.unwrap_or(#right) },
+                _ => {
+                    let op_str = format!("{:?}", bin.op);
+                    quote! { compile_error!(concat!("Tyrus: unsupported binary operator: ", #op_str)) }
                 }
             }
         }

--- a/crates/tyrus_codegen/src/convert/expr/call.rs
+++ b/crates/tyrus_codegen/src/convert/expr/call.rs
@@ -7,7 +7,7 @@
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use swc_ecma_ast::*;
+use swc_ecma_ast::{CallExpr, Callee, Expr, Lit, MemberExpr};
 
 use crate::convert::helpers::to_snake_case;
 use crate::convert::interface::RustGenerator;
@@ -39,13 +39,11 @@ impl RustGenerator {
 
     /// Handles member-expression calls: static methods, axios, and stdlib methods.
     fn try_convert_member_call(&self, call: &CallExpr) -> Option<TokenStream> {
-        let expr = match &call.callee {
-            Callee::Expr(expr) => expr,
-            _ => return None,
+        let Callee::Expr(expr) = &call.callee else {
+            return None;
         };
-        let member = match &**expr {
-            Expr::Member(m) => m,
-            _ => return None,
+        let Expr::Member(member) = &**expr else {
+            return None;
         };
 
         if let Some(tokens) = self.try_convert_static_call(member, call) {
@@ -67,9 +65,8 @@ impl RustGenerator {
 
     /// Converts `ClassName.method(args)` to `ClassName::method(args)`.
     fn try_convert_static_call(&self, member: &MemberExpr, call: &CallExpr) -> Option<TokenStream> {
-        let obj_ident = match &*member.obj {
-            Expr::Ident(id) => id,
-            _ => return None,
+        let Expr::Ident(obj_ident) = &*member.obj else {
+            return None;
         };
         let class_name = obj_ident.sym.as_ref();
         let static_set = self.static_methods.get(class_name)?;
@@ -92,33 +89,32 @@ impl RustGenerator {
 
     /// Fallback: array/string method check, then plain callee + args.
     fn convert_general_call(&self, call: &CallExpr) -> TokenStream {
-        let callee = match &call.callee {
-            Callee::Expr(expr) => {
-                if let Expr::Member(member) = &**expr {
-                    if let Some(tokens) = self.try_convert_array_method(member, call) {
-                        return tokens;
-                    }
-                    // this.method(args) → self.method(args)
-                    if member.obj.is_this() {
-                        if let Some(prop) = member.prop.as_ident() {
-                            let method = format_ident!("{}", to_snake_case(prop.sym.as_ref()));
-                            let args: Vec<_> = call
-                                .args
-                                .iter()
-                                .map(|a| self.convert_expr(&a.expr))
-                                .collect();
-                            let receiver = if self.use_state_for_this.get() {
-                                quote! { state }
-                            } else {
-                                quote! { self }
-                            };
-                            return quote! { #receiver.#method(#(#args),*) };
-                        }
+        let callee = if let Callee::Expr(expr) = &call.callee {
+            if let Expr::Member(member) = &**expr {
+                if let Some(tokens) = self.try_convert_array_method(member, call) {
+                    return tokens;
+                }
+                // this.method(args) → self.method(args)
+                if member.obj.is_this() {
+                    if let Some(prop) = member.prop.as_ident() {
+                        let method = format_ident!("{}", to_snake_case(prop.sym.as_ref()));
+                        let args: Vec<_> = call
+                            .args
+                            .iter()
+                            .map(|a| self.convert_expr(&a.expr))
+                            .collect();
+                        let receiver = if self.use_state_for_this.get() {
+                            quote! { state }
+                        } else {
+                            quote! { self }
+                        };
+                        return quote! { #receiver.#method(#(#args),*) };
                     }
                 }
-                self.convert_expr(expr)
             }
-            _ => quote! { compile_error!("Tyrus: unsupported call expression") },
+            self.convert_expr(expr)
+        } else {
+            quote! { compile_error!("Tyrus: unsupported call expression") }
         };
         let args: Vec<_> = call
             .args
@@ -137,8 +133,7 @@ impl RustGenerator {
                         let url = call
                             .args
                             .first()
-                            .map(|a| self.convert_expr(&a.expr))
-                            .unwrap_or_else(|| quote! { "" });
+                            .map_or_else(|| quote! { "" }, |a| self.convert_expr(&a.expr));
                         let method_fn = format_ident!("{}", method_name);
                         return Some(quote! { reqwest::Client::new().#method_fn(#url).send() });
                     }
@@ -155,8 +150,7 @@ impl RustGenerator {
                     let url = call
                         .args
                         .first()
-                        .map(|a| self.convert_expr(&a.expr))
-                        .unwrap_or_else(|| quote! { "" });
+                        .map_or_else(|| quote! { "" }, |a| self.convert_expr(&a.expr));
                     let method = call.args.get(1).and_then(|opts| {
                         if let Expr::Object(obj) = &*opts.expr {
                             for prop in &obj.props {

--- a/crates/tyrus_codegen/src/convert/expr/call_array.rs
+++ b/crates/tyrus_codegen/src/convert/expr/call_array.rs
@@ -1,7 +1,7 @@
 //! Array (and a couple of string) method-call code generation.
 //!
 //! Extracted from `convert/expr/call.rs` to keep that file under the Rule 4
-//! 400-line ceiling (POWER_OF_TEN.md). The dispatch entry point
+//! 400-line ceiling (`POWER_OF_TEN.md`). The dispatch entry point
 //! [`RustGenerator::try_convert_array_method`] is invoked from
 //! `convert/expr/call.rs::convert_general_call`. All handlers live in this
 //! module because they share the same dispatch + helper surface
@@ -9,7 +9,7 @@
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use swc_ecma_ast::*;
+use swc_ecma_ast::{CallExpr, Expr, MemberExpr, Pat};
 
 use crate::convert::helpers::to_snake_case;
 use crate::convert::interface::RustGenerator;
@@ -36,7 +36,7 @@ impl RustGenerator {
             "forEach" => self.convert_for_each_call(&obj, call),
             "some" => Some(self.convert_iter_adaptor_call(&obj, call, "any")),
             "every" => Some(self.convert_iter_adaptor_call(&obj, call, "all")),
-            "reduce" => self.convert_reduce_call(&obj, call),
+            "reduce" => Some(self.convert_reduce_call(&obj, call)),
             "push" => Some(self.convert_push_call(member, call)),
             "replace" => Some(self.convert_replace_call(member, call)),
             _ => None,
@@ -47,8 +47,8 @@ impl RustGenerator {
     fn convert_map_call(&self, obj: &TokenStream, call: &CallExpr) -> Option<TokenStream> {
         let args = self.convert_call_args(call);
 
-        if self.has_index_callback_arg(call) {
-            let closure = &args[0];
+        if Self::has_index_callback_arg(call) {
+            let closure = args.first()?;
             return Some(quote! {
                 #obj.iter().cloned()
                     .enumerate()
@@ -64,8 +64,8 @@ impl RustGenerator {
     fn convert_filter_call(&self, obj: &TokenStream, call: &CallExpr) -> Option<TokenStream> {
         let args = self.convert_call_args(call);
 
-        if self.has_index_callback_arg(call) {
-            let closure = &args[0];
+        if Self::has_index_callback_arg(call) {
+            let closure = args.first()?;
             return Some(quote! {
                 #obj.iter().cloned()
                     .enumerate()
@@ -79,7 +79,7 @@ impl RustGenerator {
             return Some(tokens);
         }
 
-        let closure = &args[0];
+        let closure = args.first()?;
         Some(quote! {
             #obj.iter().cloned()
                 .filter(|__v| (#closure)(__v.clone()))
@@ -91,8 +91,8 @@ impl RustGenerator {
     fn convert_for_each_call(&self, obj: &TokenStream, call: &CallExpr) -> Option<TokenStream> {
         let args = self.convert_call_args(call);
 
-        if self.has_index_callback_arg(call) {
-            let closure = &args[0];
+        if Self::has_index_callback_arg(call) {
+            let closure = args.first()?;
             return Some(quote! {
                 #obj.iter().cloned()
                     .enumerate()
@@ -116,20 +116,19 @@ impl RustGenerator {
     }
 
     /// `arr.reduce(callback, initial?)` -> `fold` or `reduce`.
-    fn convert_reduce_call(&self, obj: &TokenStream, call: &CallExpr) -> Option<TokenStream> {
-        let closure = call
-            .args
-            .first()
-            .map(|a| self.convert_expr(&a.expr))
-            .unwrap_or_else(|| {
+    fn convert_reduce_call(&self, obj: &TokenStream, call: &CallExpr) -> TokenStream {
+        let closure = call.args.first().map_or_else(
+            || {
                 quote! { compile_error!("Tyrus: reduce requires a callback") }
-            });
+            },
+            |a| self.convert_expr(&a.expr),
+        );
 
-        if call.args.len() >= 2 {
-            let initial = self.convert_expr(&call.args[1].expr);
-            Some(quote! { #obj.iter().cloned().fold(#initial, #closure) })
+        if let Some(second) = call.args.get(1) {
+            let initial = self.convert_expr(&second.expr);
+            quote! { #obj.iter().cloned().fold(#initial, #closure) }
         } else {
-            Some(quote! { #obj.iter().cloned().reduce(#closure) })
+            quote! { #obj.iter().cloned().reduce(#closure) }
         }
     }
 
@@ -141,7 +140,7 @@ impl RustGenerator {
             .collect()
     }
 
-    fn has_index_callback_arg(&self, call: &CallExpr) -> bool {
+    fn has_index_callback_arg(call: &CallExpr) -> bool {
         if let Some(arg) = call.args.first() {
             if let Expr::Arrow(arrow) = &*arg.expr {
                 return arrow.params.len() == 2;

--- a/crates/tyrus_codegen/src/convert/expr/literal.rs
+++ b/crates/tyrus_codegen/src/convert/expr/literal.rs
@@ -1,17 +1,17 @@
 //! Literal expression code generation.
 //!
-//! Handles: number/string/bool/null literals, object literals (→ serde_json::json!),
+//! Handles: number/string/bool/null literals, object literals (→ `serde_json::json`!),
 //! array literals (→ vec![]), and template literals (→ format!).
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use swc_ecma_ast::*;
+use swc_ecma_ast::{Expr, Lit};
 
 use crate::convert::helpers::to_snake_case;
 use crate::convert::interface::RustGenerator;
 
 impl RustGenerator {
-    pub(crate) fn convert_lit(&self, lit: &Lit) -> TokenStream {
+    pub(crate) fn convert_lit(lit: &Lit) -> TokenStream {
         match lit {
             Lit::Num(num) => {
                 let value = num.value;
@@ -101,13 +101,14 @@ impl RustGenerator {
             chains.push(quote! { vec![#(#items),*].into_iter() });
         }
 
-        // Chain all iterators together
-        if chains.len() == 1 {
-            let first = &chains[0];
+        // Chain all iterators together. `chains` is non-empty here: has_spread
+        // guarantees at least one spread element was pushed.
+        let Some((first, rest)) = chains.split_first() else {
+            return quote! { vec![] };
+        };
+        if rest.is_empty() {
             quote! { #first.collect::<Vec<_>>() }
         } else {
-            let first = &chains[0];
-            let rest = &chains[1..];
             quote! { #first #(.chain(#rest))* .collect::<Vec<_>>() }
         }
     }
@@ -123,9 +124,9 @@ impl RustGenerator {
                 fmt_str.push_str(quasi.raw.as_str());
             }
 
-            if i < tpl.exprs.len() {
+            if let Some(expr) = tpl.exprs.get(i) {
                 fmt_str.push_str("{}");
-                args.push(self.convert_expr(&tpl.exprs[i]));
+                args.push(self.convert_expr(expr));
             }
         }
 
@@ -134,7 +135,7 @@ impl RustGenerator {
 
     /// Try to convert an object literal with a known type annotation into a struct constructor.
     /// e.g., `const x: User = { id: 1, name: "foo" }` → `User { id: 1f64, name: String::from("foo") }`
-    /// Returns None if type annotation can't be extracted (falls back to serde_json::json!).
+    /// Returns None if type annotation can't be extracted (falls back to `serde_json::json`!).
     pub(crate) fn try_convert_typed_object_lit(
         &self,
         ts_type: &swc_ecma_ast::TsType,

--- a/crates/tyrus_codegen/src/convert/expr/member.rs
+++ b/crates/tyrus_codegen/src/convert/expr/member.rs
@@ -5,7 +5,7 @@
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use swc_ecma_ast::*;
+use swc_ecma_ast::{ComputedPropName, Expr, IdentName, Lit, MemberExpr, MemberProp};
 
 use crate::convert::helpers::to_snake_case;
 use crate::convert::interface::RustGenerator;
@@ -22,7 +22,9 @@ impl RustGenerator {
         match &member.prop {
             MemberProp::Ident(ident) => self.convert_ident_member(&member.obj, &obj, ident),
             MemberProp::Computed(computed) => Self::convert_computed_member(&obj, computed, self),
-            _ => quote! { compile_error!("Tyrus: unsupported member expression") },
+            MemberProp::PrivateName(_) => {
+                quote! { compile_error!("Tyrus: unsupported member expression") }
+            }
         }
     }
 
@@ -127,7 +129,7 @@ impl RustGenerator {
         }
     }
 
-    /// Detects PascalCase identifiers that map to Rust enum/static access (`Foo::Bar`).
+    /// Detects `PascalCase` identifiers that map to Rust enum/static access (`Foo::Bar`).
     fn is_enum_or_static_access(obj: &TokenStream) -> bool {
         let obj_str = obj.to_string();
         obj_str.chars().next().is_some_and(char::is_uppercase)
@@ -147,6 +149,11 @@ impl RustGenerator {
         }
 
         if let Expr::Lit(Lit::Num(n)) = expr {
+            #[expect(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "TS index literals are non-negative integers; float cast saturates"
+            )]
             let idx = n.value as usize;
             quote! { #obj[#idx].clone() }
         } else {

--- a/crates/tyrus_codegen/src/convert/expr/misc.rs
+++ b/crates/tyrus_codegen/src/convert/expr/misc.rs
@@ -5,7 +5,10 @@
 
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
-use swc_ecma_ast::*;
+use swc_ecma_ast::{
+    AssignExpr, AssignOp, AssignTarget, Expr, MemberExpr, SimpleAssignTarget, UnaryExpr, UnaryOp,
+    UpdateExpr, UpdateOp,
+};
 
 use crate::convert::helpers::to_snake_case;
 use crate::convert::interface::RustGenerator;
@@ -29,10 +32,10 @@ impl RustGenerator {
         let right = self.convert_expr(&assign.right);
         match self.resolve_assign_lhs(&assign.left, assign.op) {
             AssignLhs::StateField { receiver, field } => {
-                self.emit_state_field_assign(&receiver, &field, assign.op, &right)
+                Self::emit_state_field_assign(&receiver, &field, assign.op, &right)
             }
             AssignLhs::Setter { obj, setter } => quote! { #obj.#setter(#right) },
-            AssignLhs::Plain(lhs) => self.emit_assign_op(assign.op, &lhs, &right),
+            AssignLhs::Plain(lhs) => Self::emit_assign_op(assign.op, &lhs, &right),
             AssignLhs::Invalid(err) => err,
         }
     }
@@ -44,7 +47,6 @@ impl RustGenerator {
     /// is dropped at its statement's `;`, so the two locks never coexist —
     /// preventing `std::sync::Mutex` re-entrance deadlocks.
     fn emit_state_field_assign(
-        &self,
         receiver: &TokenStream,
         field: &Ident,
         op: AssignOp,
@@ -118,13 +120,10 @@ impl RustGenerator {
     }
 
     fn resolve_assign_lhs(&self, target: &AssignTarget, op: AssignOp) -> AssignLhs {
-        let simple = match target {
-            AssignTarget::Simple(simple) => simple,
-            _ => {
-                return AssignLhs::Invalid(
-                    quote! { compile_error!("Tyrus: unsupported assignment pattern") },
-                );
-            }
+        let AssignTarget::Simple(simple) = target else {
+            return AssignLhs::Invalid(
+                quote! { compile_error!("Tyrus: unsupported assignment pattern") },
+            );
         };
         match simple {
             SimpleAssignTarget::Member(member) => self.resolve_member_lhs(member, op),
@@ -142,13 +141,10 @@ impl RustGenerator {
         if member.obj.is_this() {
             return self.resolve_this_member_lhs(member);
         }
-        let prop_ident = match member.prop.as_ident() {
-            Some(ident) => ident,
-            None => {
-                return AssignLhs::Invalid(
-                    quote! { compile_error!("Tyrus: unsupported member assignment pattern") },
-                );
-            }
+        let Some(prop_ident) = member.prop.as_ident() else {
+            return AssignLhs::Invalid(
+                quote! { compile_error!("Tyrus: unsupported member assignment pattern") },
+            );
         };
         let prop_name = to_snake_case(prop_ident.sym.as_ref());
         let obj = self.convert_expr(&member.obj);
@@ -161,13 +157,10 @@ impl RustGenerator {
     }
 
     fn resolve_this_member_lhs(&self, member: &MemberExpr) -> AssignLhs {
-        let prop_ident = match member.prop.as_ident() {
-            Some(ident) => ident,
-            None => {
-                return AssignLhs::Invalid(
-                    quote! { compile_error!("Tyrus: unsupported self member assignment") },
-                );
-            }
+        let Some(prop_ident) = member.prop.as_ident() else {
+            return AssignLhs::Invalid(
+                quote! { compile_error!("Tyrus: unsupported self member assignment") },
+            );
         };
         let prop_name = to_snake_case(prop_ident.sym.as_ref());
         let field = format_ident!("{}", prop_name);
@@ -186,7 +179,7 @@ impl RustGenerator {
         }
     }
 
-    fn emit_assign_op(&self, op: AssignOp, lhs: &TokenStream, rhs: &TokenStream) -> TokenStream {
+    fn emit_assign_op(op: AssignOp, lhs: &TokenStream, rhs: &TokenStream) -> TokenStream {
         match op {
             AssignOp::Assign => quote! { #lhs = #rhs },
             AssignOp::AddAssign => quote! { #lhs += #rhs },
@@ -221,7 +214,7 @@ impl RustGenerator {
                 UpdateOp::PlusPlus => AssignOp::AddAssign,
                 UpdateOp::MinusMinus => AssignOp::SubAssign,
             };
-            return self.emit_state_field_assign(&receiver, &field, op, &quote! { 1.0 });
+            return Self::emit_state_field_assign(&receiver, &field, op, &quote! { 1.0 });
         }
 
         let arg = self.convert_expr(&update.arg);

--- a/crates/tyrus_codegen/src/convert/expr/mod.rs
+++ b/crates/tyrus_codegen/src/convert/expr/mod.rs
@@ -27,7 +27,7 @@ fn convert_ident(ident: &swc_ecma_ast::Ident) -> TokenStream {
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use swc_ecma_ast::*;
+use swc_ecma_ast::{Expr, ExprOrSpread, NewExpr};
 
 use super::interface::RustGenerator;
 
@@ -45,7 +45,7 @@ impl RustGenerator {
                 }
             }
             Expr::Ident(ident) => convert_ident(ident),
-            Expr::Lit(lit) => self.convert_lit(lit),
+            Expr::Lit(lit) => Self::convert_lit(lit),
             Expr::Member(member) => self.convert_member_expr(member),
             Expr::Call(call) => self.convert_call_expr(call),
             Expr::Object(obj) => self.convert_object_lit(obj),
@@ -81,10 +81,10 @@ impl RustGenerator {
     }
 
     // Bound: SWC AST is finite; recursion depth ≤ AST depth (Rule 1, POWER_OF_TEN.md).
-    fn convert_cond_expr(&self, cond: &swc_ecma_ast::CondExpr) -> TokenStream {
-        let test = self.convert_expr(&cond.test);
-        let cons = self.convert_expr(&cond.cons);
-        let alt = self.convert_expr(&cond.alt);
+    fn convert_cond_expr(&self, ternary: &swc_ecma_ast::CondExpr) -> TokenStream {
+        let test = self.convert_expr(&ternary.test);
+        let cons = self.convert_expr(&ternary.cons);
+        let alt = self.convert_expr(&ternary.alt);
         quote! { if #test { #cons } else { #alt } }
     }
 

--- a/crates/tyrus_codegen/src/convert/fn_decl.rs
+++ b/crates/tyrus_codegen/src/convert/fn_decl.rs
@@ -107,7 +107,7 @@ impl RustGenerator {
         super::type_mapper::is_void_or_promise_void(function.return_type.as_deref())
     }
 
-    /// Convert the function body statements, wrapping returns in Ok() for async.
+    /// Convert the function body statements, wrapping returns in `Ok()` for async.
     fn build_fn_body(
         &self,
         function: &Function,
@@ -129,7 +129,7 @@ impl RustGenerator {
             .collect()
     }
 
-    /// Produce the return expression for a single ReturnStmt.
+    /// Produce the return expression for a single `ReturnStmt`.
     fn convert_return(
         &self,
         ret_stmt: &swc_ecma_ast::ReturnStmt,

--- a/crates/tyrus_codegen/src/convert/helpers.rs
+++ b/crates/tyrus_codegen/src/convert/helpers.rs
@@ -4,7 +4,7 @@
 //!   `tyrus_common::util` (single source of truth across the workspace)
 //! - Expression type detection (`is_string_expr`)
 
-use swc_ecma_ast::*;
+use swc_ecma_ast::{BinaryOp, Callee, Expr, Lit};
 
 pub use tyrus_common::util::{to_pascal_case, to_snake_case};
 
@@ -12,8 +12,7 @@ pub use tyrus_common::util::{to_pascal_case, to_snake_case};
 /// Used to choose `format!` over `+` for string concatenation.
 pub(crate) fn is_string_expr(expr: &Expr) -> bool {
     match expr {
-        Expr::Lit(Lit::Str(_)) => true,
-        Expr::Tpl(_) => true,
+        Expr::Lit(Lit::Str(_)) | Expr::Tpl(_) => true,
         Expr::Call(call) => {
             if let Callee::Expr(callee) = &call.callee {
                 if let Expr::Member(member) = &**callee {

--- a/crates/tyrus_codegen/src/convert/interface.rs
+++ b/crates/tyrus_codegen/src/convert/interface.rs
@@ -8,7 +8,11 @@ use super::type_mapper::map_ts_type;
 
 use crate::ControllerMetadata;
 
-#[derive(Default)]
+#[derive(Debug, Default)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "independent visitor-state flags; grouping into an enum would change the public API"
+)]
 pub struct RustGenerator {
     pub code: String,
     pub is_exporting: bool,
@@ -21,15 +25,15 @@ pub struct RustGenerator {
     /// Class fields for inheritance (parent fields flattened into child)
     pub(crate) class_fields:
         std::collections::HashMap<String, Vec<(String, proc_macro2::TokenStream, bool)>>,
-    /// Static methods per class (ClassName → method_names)
+    /// Static methods per class (`ClassName` → `method_names`)
     pub(crate) static_methods: std::collections::HashMap<String, std::collections::HashSet<String>>,
-    /// When true, Expr::This generates `state` instead of `self`
+    /// When true, `Expr::This` generates `state` instead of `self`
     pub(crate) use_state_for_this: std::cell::Cell<bool>,
     /// Variables with `: string` annotation (stdlib disambiguation)
     pub(crate) string_vars: std::cell::RefCell<std::collections::HashSet<String>>,
-    /// Getter property names (call-site: obj.prop → obj.prop())
+    /// Getter property names (call-site: obj.prop → `obj.prop()`)
     pub(crate) getter_names: std::collections::HashSet<String>,
-    /// Setter property names (call-site: obj.prop = v → obj.set_prop(v))
+    /// Setter property names (call-site: obj.prop = v → `obj.set_prop(v)`)
     pub(crate) setter_names: std::collections::HashSet<String>,
     /// Variables with Map type annotation (stdlib disambiguation)
     pub(crate) map_vars: std::cell::RefCell<std::collections::HashSet<String>>,
@@ -152,21 +156,21 @@ impl Visit for RustGenerator {
     fn visit_stmt(&mut self, n: &swc_ecma_ast::Stmt) {
         // Called directly from process_module_item via self.visit_stmt(stmt)
         // (also fires from visit_children_with in nested function/class bodies).
-        match n {
-            swc_ecma_ast::Stmt::Decl(swc_ecma_ast::Decl::Fn(_))
-            | swc_ecma_ast::Stmt::Decl(swc_ecma_ast::Decl::Class(_))
-            | swc_ecma_ast::Stmt::Decl(swc_ecma_ast::Decl::TsInterface(_))
-            | swc_ecma_ast::Stmt::Decl(swc_ecma_ast::Decl::TsTypeAlias(_))
-            | swc_ecma_ast::Stmt::Decl(swc_ecma_ast::Decl::TsEnum(_)) => {
-                // Top-level declarations: let visitor handle them (writes to self.code)
-                n.visit_children_with(self);
-            }
-            _ => {
-                // Script statements (ExprStmt, VarDecl, If, Loop, etc.): write to self.main_body
-                let stmt_code = self.convert_stmt(n);
-                self.main_body.push_str(&stmt_code.to_string());
-                self.main_body.push('\n');
-            }
+        if let swc_ecma_ast::Stmt::Decl(
+            swc_ecma_ast::Decl::Fn(_)
+            | swc_ecma_ast::Decl::Class(_)
+            | swc_ecma_ast::Decl::TsInterface(_)
+            | swc_ecma_ast::Decl::TsTypeAlias(_)
+            | swc_ecma_ast::Decl::TsEnum(_),
+        ) = n
+        {
+            // Top-level declarations: let visitor handle them (writes to self.code)
+            n.visit_children_with(self);
+        } else {
+            // Script statements (ExprStmt, VarDecl, If, Loop, etc.): write to self.main_body
+            let stmt_code = self.convert_stmt(n);
+            self.main_body.push_str(&stmt_code.to_string());
+            self.main_body.push('\n');
         }
     }
 }

--- a/crates/tyrus_codegen/src/convert/module.rs
+++ b/crates/tyrus_codegen/src/convert/module.rs
@@ -5,7 +5,7 @@ use super::interface::RustGenerator;
 
 /// Convert a TS name to its Rust equivalent.
 /// Uppercase-leading names are preserved (Class/Type);
-/// lowercase-leading names are converted to snake_case.
+/// lowercase-leading names are converted to `snake_case`.
 fn to_rust_name(name: &str) -> String {
     if name.chars().next().is_some_and(char::is_uppercase) {
         name.to_string()
@@ -23,7 +23,7 @@ fn sanitize_path(p: &str) -> String {
 }
 
 /// Return `true` if this import source should be silently skipped
-/// (NestJS framework imports, axios HTTP client, etc.).
+/// (`NestJS` framework imports, axios HTTP client, etc.).
 fn is_skipped_import(src: &str) -> bool {
     src.starts_with("@nestjs") || src == "axios"
 }
@@ -108,7 +108,7 @@ impl RustGenerator {
                     self.process_fn_decl(&fn_decl);
                 }
             }
-            _ => {}
+            swc_ecma_ast::DefaultDecl::TsInterfaceDecl(_) => {}
         }
         self.is_exporting = false;
     }

--- a/crates/tyrus_codegen/src/convert/stmt/loops.rs
+++ b/crates/tyrus_codegen/src/convert/stmt/loops.rs
@@ -2,12 +2,12 @@
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use swc_ecma_ast::*;
+use swc_ecma_ast::{Decl, DoWhileStmt, ForInStmt, ForOfStmt, ForStmt, Pat, Stmt, WhileStmt};
 
 use super::super::helpers::to_snake_case;
 use super::super::interface::RustGenerator;
 
-/// Extract loop variable ident from a ForHead declaration.
+/// Extract loop variable ident from a `ForHead` declaration.
 fn extract_loop_var(left: &swc_ecma_ast::ForHead, fallback: &str) -> proc_macro2::Ident {
     match left {
         swc_ecma_ast::ForHead::VarDecl(var_decl) => {
@@ -25,7 +25,7 @@ fn extract_loop_var(left: &swc_ecma_ast::ForHead, fallback: &str) -> proc_macro2
                 format_ident!("{}", fallback)
             }
         }
-        _ => format_ident!("{}", fallback),
+        swc_ecma_ast::ForHead::UsingDecl(_) => format_ident!("{}", fallback),
     }
 }
 
@@ -80,8 +80,7 @@ impl RustGenerator {
         let test = for_stmt
             .test
             .as_ref()
-            .map(|t| self.convert_expr(t))
-            .unwrap_or_else(|| quote! { true });
+            .map_or_else(|| quote! { true }, |t| self.convert_expr(t));
         let update = for_stmt
             .update
             .as_ref()

--- a/crates/tyrus_codegen/src/convert/stmt/mod.rs
+++ b/crates/tyrus_codegen/src/convert/stmt/mod.rs
@@ -1,7 +1,7 @@
 //! Statement-level code generation.
 //!
 //! Converts TypeScript statements (variable declarations, if/else, loops,
-//! return, throw, switch) to Rust TokenStreams.
+//! return, throw, switch) to Rust `TokenStreams`.
 
 mod loops;
 mod switch;
@@ -10,11 +10,11 @@ mod var_decl;
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use swc_ecma_ast::*;
+use swc_ecma_ast::{Decl, IfStmt, Stmt};
 
 use super::interface::RustGenerator;
 
-/// Map NestJS exception class names to AppError variant names.
+/// Map `NestJS` exception class names to `AppError` variant names.
 fn nestjs_exception_to_app_error(class_name: &str) -> Option<&'static str> {
     match class_name {
         "NotFoundException" => Some("NotFound"),
@@ -23,14 +23,14 @@ fn nestjs_exception_to_app_error(class_name: &str) -> Option<&'static str> {
         "ForbiddenException" => Some("Forbidden"),
         "ConflictException" => Some("Conflict"),
         "InternalServerErrorException" => Some("Internal"),
-        "Error" => None, // generic Error, use default handling
+        // Generic `Error` (and any unrecognized class) uses default handling.
         _ => None,
     }
 }
 
 impl RustGenerator {
     /// Recursively convert statements with a custom return handler.
-    /// Used by process_fn_decl to inject Result wrapping for async functions.
+    /// Used by `process_fn_decl` to inject Result wrapping for async functions.
     // Bound: SWC AST is finite; recursion depth ≤ AST depth (Rule 1, POWER_OF_TEN.md).
     pub fn convert_stmt_recursive<F>(&self, stmt: &Stmt, return_handler: &mut F) -> TokenStream
     where
@@ -131,7 +131,7 @@ impl RustGenerator {
         quote! { if #test #cons_block #alt }
     }
 
-    /// Convert a throw statement, mapping NestJS exceptions to AppError variants.
+    /// Convert a throw statement, mapping `NestJS` exceptions to `AppError` variants.
     fn convert_throw(&self, arg: &swc_ecma_ast::Expr) -> TokenStream {
         // Detect: throw new XxxException("msg")
         if let swc_ecma_ast::Expr::New(new_expr) = arg {
@@ -144,8 +144,7 @@ impl RustGenerator {
                         .args
                         .as_ref()
                         .and_then(|args| args.first())
-                        .map(|a| self.convert_expr(&a.expr))
-                        .unwrap_or_else(|| quote! { String::new() });
+                        .map_or_else(|| quote! { String::new() }, |a| self.convert_expr(&a.expr));
                     return quote! {
                         return Err(AppError::#variant_ident(#msg.to_string()));
                     };

--- a/crates/tyrus_codegen/src/convert/stmt/switch.rs
+++ b/crates/tyrus_codegen/src/convert/stmt/switch.rs
@@ -2,7 +2,7 @@
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use swc_ecma_ast::*;
+use swc_ecma_ast::Stmt;
 
 use super::super::interface::RustGenerator;
 

--- a/crates/tyrus_codegen/src/convert/stmt/try_catch.rs
+++ b/crates/tyrus_codegen/src/convert/stmt/try_catch.rs
@@ -12,7 +12,7 @@
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use swc_ecma_ast::*;
+use swc_ecma_ast::{BlockStmt, CatchClause, Expr, IfStmt, Pat, Stmt, TryStmt};
 
 use super::super::interface::RustGenerator;
 
@@ -184,7 +184,7 @@ impl RustGenerator {
         }
     }
 
-    /// Catch clause for nested try-catch: wraps return values in Ok()
+    /// Catch clause for nested try-catch: wraps return values in `Ok()`
     /// so they propagate correctly through the outer try closure.
     fn convert_catch_clause_for_nesting(&self, handler: Option<&CatchClause>) -> TokenStream {
         let Some(handler) = handler else {

--- a/crates/tyrus_codegen/src/convert/stmt/var_decl.rs
+++ b/crates/tyrus_codegen/src/convert/stmt/var_decl.rs
@@ -2,7 +2,7 @@
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use swc_ecma_ast::*;
+use swc_ecma_ast::{ArrayPat, BindingIdent, ObjectPat, Pat, VarDecl, VarDeclKind, VarDeclarator};
 
 use super::super::helpers::to_snake_case;
 use super::super::interface::RustGenerator;
@@ -21,10 +21,18 @@ impl RustGenerator {
                     self.convert_ident_decl(ident, decl, is_const, &mut declarations);
                 }
                 Pat::Object(obj_pat) => {
-                    self.convert_object_destructuring(obj_pat, &init_expr_opt, &mut declarations);
+                    self.convert_object_destructuring(
+                        obj_pat,
+                        init_expr_opt.as_ref(),
+                        &mut declarations,
+                    );
                 }
                 Pat::Array(arr_pat) => {
-                    self.convert_array_destructuring(arr_pat, &init_expr_opt, &mut declarations);
+                    Self::convert_array_destructuring(
+                        arr_pat,
+                        init_expr_opt.as_ref(),
+                        &mut declarations,
+                    );
                 }
                 _ => {
                     declarations.push(quote! { /* unsupported pattern */ });
@@ -94,7 +102,7 @@ impl RustGenerator {
     fn convert_object_destructuring(
         &self,
         obj_pat: &ObjectPat,
-        init_expr_opt: &Option<TokenStream>,
+        init_expr_opt: Option<&TokenStream>,
         declarations: &mut Vec<TokenStream>,
     ) {
         let Some(init_expr) = init_expr_opt else {
@@ -138,9 +146,8 @@ impl RustGenerator {
     }
 
     fn convert_array_destructuring(
-        &self,
         arr_pat: &ArrayPat,
-        init_expr_opt: &Option<TokenStream>,
+        init_expr_opt: Option<&TokenStream>,
         declarations: &mut Vec<TokenStream>,
     ) {
         let Some(init_expr) = init_expr_opt else {

--- a/crates/tyrus_codegen/src/convert/type_decl.rs
+++ b/crates/tyrus_codegen/src/convert/type_decl.rs
@@ -246,6 +246,10 @@ fn emit_numeric_enum(enum_name: &Ident, decl: &TsEnumDecl, is_exporting: bool) -
     }
 }
 
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "TS numeric enum initializers are integral literals in i32 range"
+)]
 fn numeric_enum_variant(m: &TsEnumMember, current_value: &mut i64) -> TokenStream {
     let variant_name_str = member_ident_string(&m.id);
     let variant_ident = format_ident!("{}", variant_name_str);

--- a/crates/tyrus_codegen/src/convert/type_decl.rs
+++ b/crates/tyrus_codegen/src/convert/type_decl.rs
@@ -248,7 +248,7 @@ fn emit_numeric_enum(enum_name: &Ident, decl: &TsEnumDecl, is_exporting: bool) -
 
 #[expect(
     clippy::cast_possible_truncation,
-    reason = "TS numeric enum initializers are integral literals in i32 range"
+    reason = "pre-existing lossy cast: out-of-i32-range enum initializers wrap silently; range guard tracked in #223"
 )]
 fn numeric_enum_variant(m: &TsEnumMember, current_value: &mut i64) -> TokenStream {
     let variant_name_str = member_ident_string(&m.id);

--- a/crates/tyrus_codegen/src/convert/type_mapper.rs
+++ b/crates/tyrus_codegen/src/convert/type_mapper.rs
@@ -21,17 +21,15 @@ fn map_type_ref(type_ref: &swc_ecma_ast::TsTypeRef) -> TokenStream {
     let name = ident.sym.as_str();
     match name {
         "Date" => quote! { String },
-        "Array" => map_array_type(&type_ref.type_params),
-        "Record" | "Map" => map_record_type(&type_ref.type_params),
-        "Set" => map_set_type(&type_ref.type_params),
-        _ => map_user_defined_type(name, &type_ref.type_params),
+        "Array" => map_array_type(type_ref.type_params.as_deref()),
+        "Record" | "Map" => map_record_type(type_ref.type_params.as_deref()),
+        "Set" => map_set_type(type_ref.type_params.as_deref()),
+        _ => map_user_defined_type(name, type_ref.type_params.as_deref()),
     }
 }
 
 /// Extracts the first generic param as `Vec<T>`, defaulting to `Vec<Value>`.
-fn map_array_type(
-    type_params: &Option<Box<swc_ecma_ast::TsTypeParamInstantiation>>,
-) -> TokenStream {
+fn map_array_type(type_params: Option<&swc_ecma_ast::TsTypeParamInstantiation>) -> TokenStream {
     if let Some(params) = type_params {
         if let Some(first) = params.params.first() {
             let inner = map_type_core(first);
@@ -41,22 +39,20 @@ fn map_array_type(
     quote! { Vec<serde_json::Value> }
 }
 
-/// Maps Record<K,V> to HashMap<K,V>, defaulting to HashMap<String, Value>.
-fn map_record_type(
-    type_params: &Option<Box<swc_ecma_ast::TsTypeParamInstantiation>>,
-) -> TokenStream {
+/// Maps Record<K,V> to `HashMap`<K,V>, defaulting to `HashMap`<String, Value>.
+fn map_record_type(type_params: Option<&swc_ecma_ast::TsTypeParamInstantiation>) -> TokenStream {
     if let Some(params) = type_params {
-        if params.params.len() >= 2 {
-            let key = map_type_core(&params.params[0]);
-            let value = map_type_core(&params.params[1]);
+        if let [key, value, ..] = params.params.as_slice() {
+            let key = map_type_core(key);
+            let value = map_type_core(value);
             return quote! { std::collections::HashMap<#key, #value> };
         }
     }
     quote! { std::collections::HashMap<String, serde_json::Value> }
 }
 
-/// Maps Set<T> to HashSet<T>, defaulting to HashSet<serde_json::Value>.
-fn map_set_type(type_params: &Option<Box<swc_ecma_ast::TsTypeParamInstantiation>>) -> TokenStream {
+/// Maps Set<T> to `HashSet`<T>, defaulting to `HashSet`<`serde_json::Value`>.
+fn map_set_type(type_params: Option<&swc_ecma_ast::TsTypeParamInstantiation>) -> TokenStream {
     if let Some(params) = type_params {
         if let Some(first) = params.params.first() {
             let inner = map_type_core(first);
@@ -69,7 +65,7 @@ fn map_set_type(type_params: &Option<Box<swc_ecma_ast::TsTypeParamInstantiation>
 /// Maps a user-defined type reference, preserving generic parameters.
 fn map_user_defined_type(
     name: &str,
-    type_params: &Option<Box<swc_ecma_ast::TsTypeParamInstantiation>>,
+    type_params: Option<&swc_ecma_ast::TsTypeParamInstantiation>,
 ) -> TokenStream {
     let type_ident = proc_macro2::Ident::new(name, proc_macro2::Span::call_site());
     if let Some(params) = type_params {
@@ -212,7 +208,7 @@ pub fn is_void_or_promise_void(type_ann: Option<&TsTypeAnn>) -> bool {
     }
 }
 
-/// Maps a TsType directly to a Rust TokenStream.
+/// Maps a `TsType` directly to a Rust `TokenStream`.
 pub fn map_inner_type(ts_type: &swc_ecma_ast::TsType) -> TokenStream {
     map_type_core(ts_type)
 }

--- a/crates/tyrus_codegen/src/decorators/http_code.rs
+++ b/crates/tyrus_codegen/src/decorators/http_code.rs
@@ -13,8 +13,15 @@ impl HttpCodeHandler {
     /// previous `value as u16` lossy cast — `@HttpCode(70000)` no longer wraps
     /// silently to a different code, and `@HttpCode(404.5)` is rejected.
     fn parse_status_code(value: f64) -> Option<u16> {
-        if value.is_finite() && value >= 0.0 && value <= u16::MAX as f64 && value.fract() == 0.0 {
-            Some(value as u16)
+        if value.is_finite() && value >= 0.0 && value <= f64::from(u16::MAX) && value.fract() == 0.0
+        {
+            #[expect(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "guarded above: finite, integral, within 0..=u16::MAX"
+            )]
+            let code = value as u16;
+            Some(code)
         } else {
             None
         }

--- a/crates/tyrus_codegen/src/decorators/mod.rs
+++ b/crates/tyrus_codegen/src/decorators/mod.rs
@@ -1,7 +1,7 @@
 //! Decorator handler registry.
 //!
 //! This module is the architectural answer to the prior approach where every
-//! NestJS decorator required hardcoded match arms scattered across
+//! `NestJS` decorator required hardcoded match arms scattered across
 //! `class/mod.rs`, `class/method.rs`, `class/routing.rs`, and the analyzer.
 //!
 //! ## Design

--- a/crates/tyrus_codegen/src/decorators/params.rs
+++ b/crates/tyrus_codegen/src/decorators/params.rs
@@ -112,7 +112,11 @@ mod tests {
             span: swc_common::DUMMY_SP,
             decorators: vec![],
             pat: swc_ecma_ast::Pat::Ident(swc_ecma_ast::BindingIdent {
-                id: swc_ecma_ast::Ident::new("x".into(), swc_common::DUMMY_SP, Default::default()),
+                id: swc_ecma_ast::Ident::new(
+                    "x".into(),
+                    swc_common::DUMMY_SP,
+                    swc_common::SyntaxContext::default(),
+                ),
                 type_ann: None,
             }),
         }

--- a/crates/tyrus_codegen/src/lib.rs
+++ b/crates/tyrus_codegen/src/lib.rs
@@ -16,6 +16,7 @@ pub struct ControllerMetadata {
     pub route_path: String,
 }
 
+#[derive(Debug)]
 pub struct GeneratedCode {
     pub code: String,
     pub controllers: Vec<ControllerMetadata>,
@@ -48,7 +49,7 @@ pub fn generate(program: &Program, is_index: bool) -> GeneratedCode {
 ///
 /// Per Power of Ten Rule 7, code emission goes through `quote!` rather
 /// than string concatenation. Statements arrive already converted to
-/// Rust syntax (via `convert_stmt`), so we parse them as a TokenStream
+/// Rust syntax (via `convert_stmt`), so we parse them as a `TokenStream`
 /// and embed under a function header. Parse failure surfaces via
 /// `compile_error!` rather than silent body drop.
 fn wrap_top_level_in_main(body: &str) -> String {

--- a/crates/tyrus_codegen/src/stdlib/array.rs
+++ b/crates/tyrus_codegen/src/stdlib/array.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use swc_ecma_ast::*;
+use swc_ecma_ast::{Expr, ExprOrSpread};
 
 use super::super::convert::interface::RustGenerator;
 
@@ -20,9 +20,9 @@ pub(crate) fn handle(
     args: &[ExprOrSpread],
 ) -> Option<TokenStream> {
     let obj_tokens = gen.convert_expr(obj);
+    // push/map/filter/forEach/some/every/reduce/replace are deferred to
+    // call_array.rs (TS-callback handlers) and fall through to `None` below.
     match method {
-        // Defer to call_array.rs (TS-callback handlers).
-        "push" | "map" | "filter" | "forEach" | "some" | "every" | "reduce" | "replace" => None,
         "find" => handle_find(gen, &obj_tokens, args),
         "join" => handle_join(gen, &obj_tokens, args),
         "includes" => handle_includes(gen, &obj_tokens, args),
@@ -56,8 +56,8 @@ fn handle_find(
     obj_tokens: &TokenStream,
     args: &[ExprOrSpread],
 ) -> Option<TokenStream> {
-    if args.len() == 1 {
-        let predicate = gen.convert_expr_or_spread(&args[0]);
+    if let [arg] = args {
+        let predicate = gen.convert_expr_or_spread(arg);
         Some(quote! { #obj_tokens.iter().find(|item| (#predicate)(**item)).cloned() })
     } else {
         None
@@ -69,8 +69,8 @@ fn handle_join(
     obj_tokens: &TokenStream,
     args: &[ExprOrSpread],
 ) -> Option<TokenStream> {
-    if args.len() == 1 {
-        let separator = gen.convert_expr_or_spread(&args[0]);
+    if let [arg] = args {
+        let separator = gen.convert_expr_or_spread(arg);
         Some(quote! { #obj_tokens.join(&#separator) })
     } else {
         None
@@ -95,8 +95,8 @@ fn handle_index_of(
     obj_tokens: &TokenStream,
     args: &[ExprOrSpread],
 ) -> Option<TokenStream> {
-    if args.len() == 1 {
-        let val = gen.convert_expr_or_spread(&args[0]);
+    if let [arg] = args {
+        let val = gen.convert_expr_or_spread(arg);
         Some(quote! {
             #obj_tokens.iter().position(|x| x == &#val).map(|i| i as f64).unwrap_or(-1.0)
         })
@@ -110,14 +110,14 @@ fn handle_slice(
     obj_tokens: &TokenStream,
     args: &[ExprOrSpread],
 ) -> Option<TokenStream> {
-    match args.len() {
-        1 => {
-            let start = gen.convert_expr_or_spread(&args[0]);
+    match args {
+        [start] => {
+            let start = gen.convert_expr_or_spread(start);
             Some(quote! { #obj_tokens[(#start as usize)..].to_vec() })
         }
-        2 => {
-            let start = gen.convert_expr_or_spread(&args[0]);
-            let end = gen.convert_expr_or_spread(&args[1]);
+        [start, end] => {
+            let start = gen.convert_expr_or_spread(start);
+            let end = gen.convert_expr_or_spread(end);
             Some(quote! { #obj_tokens[(#start as usize)..(#end as usize)].to_vec() })
         }
         _ => None,
@@ -129,8 +129,8 @@ fn handle_concat(
     obj_tokens: &TokenStream,
     args: &[ExprOrSpread],
 ) -> Option<TokenStream> {
-    if args.len() == 1 {
-        let other = gen.convert_expr_or_spread(&args[0]);
+    if let [arg] = args {
+        let other = gen.convert_expr_or_spread(arg);
         Some(quote! {
             #obj_tokens.iter().chain(#other.iter()).cloned().collect::<Vec<_>>()
         })
@@ -180,8 +180,8 @@ fn handle_flat_map(
     obj_tokens: &TokenStream,
     args: &[ExprOrSpread],
 ) -> Option<TokenStream> {
-    if args.len() == 1 {
-        let callback = gen.convert_expr_or_spread(&args[0]);
+    if let [arg] = args {
+        let callback = gen.convert_expr_or_spread(arg);
         Some(quote! {
             #obj_tokens.iter().flat_map(|x| (#callback)(x.clone())).collect::<Vec<_>>()
         })

--- a/crates/tyrus_codegen/src/stdlib/console.rs
+++ b/crates/tyrus_codegen/src/stdlib/console.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use swc_ecma_ast::*;
+use swc_ecma_ast::ExprOrSpread;
 
 use super::super::convert::interface::RustGenerator;
 

--- a/crates/tyrus_codegen/src/stdlib/json.rs
+++ b/crates/tyrus_codegen/src/stdlib/json.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use swc_ecma_ast::*;
+use swc_ecma_ast::ExprOrSpread;
 
 use super::super::convert::interface::RustGenerator;
 

--- a/crates/tyrus_codegen/src/stdlib/map_set.rs
+++ b/crates/tyrus_codegen/src/stdlib/map_set.rs
@@ -1,10 +1,10 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use swc_ecma_ast::*;
+use swc_ecma_ast::{Expr, ExprOrSpread};
 
 use super::super::convert::interface::RustGenerator;
 
-/// Handle Map method calls (HashMap equivalents)
+/// Handle Map method calls (`HashMap` equivalents)
 pub(crate) fn handle_map(
     gen: &RustGenerator,
     obj: &Expr,
@@ -23,7 +23,7 @@ pub(crate) fn handle_map(
     }
 }
 
-/// Handle Set method calls (HashSet equivalents)
+/// Handle Set method calls (`HashSet` equivalents)
 pub(crate) fn handle_set(
     gen: &RustGenerator,
     obj: &Expr,
@@ -48,9 +48,9 @@ fn handle_map_set(
     obj: &TokenStream,
     args: &[ExprOrSpread],
 ) -> Option<TokenStream> {
-    if args.len() >= 2 {
-        let key = gen.convert_expr(&args[0].expr);
-        let value = gen.convert_expr(&args[1].expr);
+    if let [key, value, ..] = args {
+        let key = gen.convert_expr(&key.expr);
+        let value = gen.convert_expr(&value.expr);
         Some(quote! { #obj.insert(#key, #value) })
     } else {
         None

--- a/crates/tyrus_codegen/src/stdlib/math.rs
+++ b/crates/tyrus_codegen/src/stdlib/math.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use swc_ecma_ast::*;
+use swc_ecma_ast::ExprOrSpread;
 
 use super::super::convert::interface::RustGenerator;
 
@@ -34,49 +34,52 @@ fn unary_method(
     args: &[ExprOrSpread],
     emit: impl FnOnce(TokenStream) -> TokenStream,
 ) -> Option<TokenStream> {
-    if args.len() == 1 {
-        Some(emit(gen.convert_expr_or_spread(&args[0])))
+    if let [arg] = args {
+        Some(emit(gen.convert_expr_or_spread(arg)))
     } else {
         None
     }
 }
 
 fn handle_max(gen: &RustGenerator, args: &[ExprOrSpread]) -> Option<TokenStream> {
-    if args.len() == 1 && args[0].spread.is_some() {
-        let arg = gen.convert_expr_or_spread(&args[0]);
-        Some(quote! { #arg.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b)) })
-    } else if args.len() == 2 {
-        if args[0].spread.is_some() {
-            let arr = gen.convert_expr_or_spread(&args[0]);
-            let val = gen.convert_expr_or_spread(&args[1]);
+    match args {
+        [only] if only.spread.is_some() => {
+            let arg = gen.convert_expr_or_spread(only);
+            Some(quote! { #arg.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b)) })
+        }
+        [first, second] if first.spread.is_some() => {
+            let arr = gen.convert_expr_or_spread(first);
+            let val = gen.convert_expr_or_spread(second);
             Some(quote! { #arr.iter().fold(#val, |a, &b| a.max(b)) })
-        } else {
-            let a = gen.convert_expr_or_spread(&args[0]);
-            let b = gen.convert_expr_or_spread(&args[1]);
+        }
+        [first, second] => {
+            let a = gen.convert_expr_or_spread(first);
+            let b = gen.convert_expr_or_spread(second);
             Some(quote! { #a.max(#b) })
         }
-    } else {
-        None
+        _ => None,
     }
 }
 
 fn handle_min(gen: &RustGenerator, args: &[ExprOrSpread]) -> Option<TokenStream> {
-    if args.len() == 1 && args[0].spread.is_some() {
-        let arg = gen.convert_expr_or_spread(&args[0]);
-        Some(quote! { #arg.iter().fold(f64::INFINITY, |a, &b| a.min(b)) })
-    } else if args.len() == 2 {
-        let a = gen.convert_expr_or_spread(&args[0]);
-        let b = gen.convert_expr_or_spread(&args[1]);
-        Some(quote! { #a.min(#b) })
-    } else {
-        None
+    match args {
+        [only] if only.spread.is_some() => {
+            let arg = gen.convert_expr_or_spread(only);
+            Some(quote! { #arg.iter().fold(f64::INFINITY, |a, &b| a.min(b)) })
+        }
+        [first, second] => {
+            let a = gen.convert_expr_or_spread(first);
+            let b = gen.convert_expr_or_spread(second);
+            Some(quote! { #a.min(#b) })
+        }
+        _ => None,
     }
 }
 
 fn handle_pow(gen: &RustGenerator, args: &[ExprOrSpread]) -> Option<TokenStream> {
-    if args.len() == 2 {
-        let base = gen.convert_expr_or_spread(&args[0]);
-        let exp = gen.convert_expr_or_spread(&args[1]);
+    if let [base, exp] = args {
+        let base = gen.convert_expr_or_spread(base);
+        let exp = gen.convert_expr_or_spread(exp);
         Some(quote! { (#base as f64).powf(#exp as f64) })
     } else {
         None
@@ -92,8 +95,8 @@ fn handle_random(args: &[ExprOrSpread]) -> Option<TokenStream> {
 }
 
 fn handle_sign(gen: &RustGenerator, args: &[ExprOrSpread]) -> Option<TokenStream> {
-    if args.len() == 1 {
-        let x = gen.convert_expr_or_spread(&args[0]);
+    if let [arg] = args {
+        let x = gen.convert_expr_or_spread(arg);
         Some(quote! {
             { let __v = #x; if __v == 0.0 { 0.0 } else { __v.signum() } }
         })

--- a/crates/tyrus_codegen/src/stdlib/mod.rs
+++ b/crates/tyrus_codegen/src/stdlib/mod.rs
@@ -63,7 +63,7 @@ pub(crate) fn try_handle_stdlib_call(
     None
 }
 
-/// Try to handle method call on an expression (e.g., str.includes())
+/// Try to handle method call on an expression (e.g., `str.includes()`)
 pub(crate) fn try_handle_method_call(
     gen: &RustGenerator,
     obj: &Expr,

--- a/crates/tyrus_codegen/src/stdlib/object.rs
+++ b/crates/tyrus_codegen/src/stdlib/object.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use swc_ecma_ast::*;
+use swc_ecma_ast::ExprOrSpread;
 
 use super::super::convert::interface::RustGenerator;
 
@@ -12,8 +12,8 @@ pub(crate) fn handle(
 ) -> Option<TokenStream> {
     match method {
         "keys" => {
-            if args.len() == 1 {
-                let obj = gen.convert_expr_or_spread(&args[0]);
+            if let [arg] = args {
+                let obj = gen.convert_expr_or_spread(arg);
                 Some(quote! {
                     #obj.keys().cloned().collect::<Vec<_>>()
                 })
@@ -22,8 +22,8 @@ pub(crate) fn handle(
             }
         }
         "values" => {
-            if args.len() == 1 {
-                let obj = gen.convert_expr_or_spread(&args[0]);
+            if let [arg] = args {
+                let obj = gen.convert_expr_or_spread(arg);
                 Some(quote! {
                     #obj.values().cloned().collect::<Vec<_>>()
                 })
@@ -32,8 +32,8 @@ pub(crate) fn handle(
             }
         }
         "entries" => {
-            if args.len() == 1 {
-                let obj = gen.convert_expr_or_spread(&args[0]);
+            if let [arg] = args {
+                let obj = gen.convert_expr_or_spread(arg);
                 Some(quote! {
                     #obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect::<Vec<_>>()
                 })

--- a/crates/tyrus_codegen/src/stdlib/string.rs
+++ b/crates/tyrus_codegen/src/stdlib/string.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use swc_ecma_ast::*;
+use swc_ecma_ast::{Expr, ExprOrSpread};
 
 use super::super::convert::interface::RustGenerator;
 
@@ -66,9 +66,9 @@ fn handle_replace(
     args: &[ExprOrSpread],
     obj_tokens: &TokenStream,
 ) -> Option<TokenStream> {
-    if args.len() == 2 {
-        let pattern = gen.convert_expr_or_spread(&args[0]);
-        let replacement = gen.convert_expr_or_spread(&args[1]);
+    if let [pattern, replacement] = args {
+        let pattern = gen.convert_expr_or_spread(pattern);
+        let replacement = gen.convert_expr_or_spread(replacement);
         Some(quote! { #obj_tokens.replacen(&#pattern, &#replacement, 1) })
     } else {
         None
@@ -80,14 +80,14 @@ fn handle_substring(
     args: &[ExprOrSpread],
     obj_tokens: &TokenStream,
 ) -> Option<TokenStream> {
-    match args.len() {
-        1 => {
-            let start = gen.convert_expr_or_spread(&args[0]);
+    match args {
+        [start] => {
+            let start = gen.convert_expr_or_spread(start);
             Some(quote! { #obj_tokens[(#start as usize)..].to_string() })
         }
-        2 => {
-            let start = gen.convert_expr_or_spread(&args[0]);
-            let end = gen.convert_expr_or_spread(&args[1]);
+        [start, end] => {
+            let start = gen.convert_expr_or_spread(start);
+            let end = gen.convert_expr_or_spread(end);
             Some(quote! { #obj_tokens[(#start as usize)..(#end as usize)].to_string() })
         }
         _ => None,
@@ -99,8 +99,8 @@ fn handle_char_at(
     args: &[ExprOrSpread],
     obj_tokens: &TokenStream,
 ) -> Option<TokenStream> {
-    if args.len() == 1 {
-        let idx = gen.convert_expr_or_spread(&args[0]);
+    if let [arg] = args {
+        let idx = gen.convert_expr_or_spread(arg);
         Some(quote! {
             #obj_tokens.chars().nth(#idx as usize).map(|c| c.to_string()).unwrap_or_default()
         })
@@ -114,8 +114,8 @@ fn handle_index_of(
     args: &[ExprOrSpread],
     obj_tokens: &TokenStream,
 ) -> Option<TokenStream> {
-    if args.len() == 1 {
-        let substr = gen.convert_expr_or_spread(&args[0]);
+    if let [arg] = args {
+        let substr = gen.convert_expr_or_spread(arg);
         Some(quote! {
             match #obj_tokens.find(&#substr as &str) {
                 Some(i) => i as f64,
@@ -132,8 +132,8 @@ fn handle_repeat(
     args: &[ExprOrSpread],
     obj_tokens: &TokenStream,
 ) -> Option<TokenStream> {
-    if args.len() == 1 {
-        let n = gen.convert_expr_or_spread(&args[0]);
+    if let [arg] = args {
+        let n = gen.convert_expr_or_spread(arg);
         Some(quote! { #obj_tokens.repeat(#n as usize) })
     } else {
         None
@@ -147,31 +147,29 @@ fn pad_tokens(
     gen: &RustGenerator,
     is_start: bool,
 ) -> Option<TokenStream> {
-    if args.is_empty() {
-        return None;
-    }
-    let target_len = gen.convert_expr_or_spread(&args[0]);
-    if args.len() >= 2 {
-        pad_with_fill(obj_tokens, &target_len, gen, args, is_start)
-    } else {
-        pad_with_space(obj_tokens, &target_len, is_start)
+    let (first, rest) = args.split_first()?;
+    let target_len = gen.convert_expr_or_spread(first);
+    match rest.first() {
+        Some(fill_arg) => {
+            let fill = gen.convert_expr_or_spread(fill_arg);
+            Some(pad_with_fill(obj_tokens, &target_len, &fill, is_start))
+        }
+        None => Some(pad_with_space(obj_tokens, &target_len, is_start)),
     }
 }
 
 fn pad_with_fill(
     obj_tokens: &TokenStream,
     target_len: &TokenStream,
-    gen: &RustGenerator,
-    args: &[ExprOrSpread],
+    fill: &TokenStream,
     is_start: bool,
-) -> Option<TokenStream> {
-    let fill = gen.convert_expr_or_spread(&args[1]);
+) -> TokenStream {
     let fmt = if is_start {
         quote! { format!("{}{}", __pad, __s) }
     } else {
         quote! { format!("{}{}", __s, __pad) }
     };
-    Some(quote! {{
+    quote! {{
         let __s = #obj_tokens;
         let __target = #target_len as usize;
         let __fill: String = #fill.to_string();
@@ -183,20 +181,20 @@ fn pad_with_fill(
             let __pad: String = __fill.chars().cycle().take(__pad_len).collect();
             #fmt
         }
-    }})
+    }}
 }
 
 fn pad_with_space(
     obj_tokens: &TokenStream,
     target_len: &TokenStream,
     is_start: bool,
-) -> Option<TokenStream> {
+) -> TokenStream {
     let fmt = if is_start {
         quote! { format!("{:>width$}", __s, width = __target) }
     } else {
         quote! { format!("{:<width$}", __s, width = __target) }
     };
-    Some(quote! {{
+    quote! {{
         let __s = #obj_tokens;
         let __target = #target_len as usize;
         if __s.chars().count() >= __target {
@@ -204,5 +202,5 @@ fn pad_with_space(
         } else {
             #fmt
         }
-    }})
+    }}
 }

--- a/crates/tyrus_common/Cargo.toml
+++ b/crates/tyrus_common/Cargo.toml
@@ -9,3 +9,6 @@ repository.workspace = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+
+[lints]
+workspace = true

--- a/crates/tyrus_decorator_kinds/Cargo.toml
+++ b/crates/tyrus_decorator_kinds/Cargo.toml
@@ -9,3 +9,6 @@ repository.workspace = true
 description = "Single source of truth for NestJS decorator name → kind classification, shared between analyzer and codegen."
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/tyrus_decorator_kinds/src/lib.rs
+++ b/crates/tyrus_decorator_kinds/src/lib.rs
@@ -1,4 +1,4 @@
-//! Single source of truth for NestJS decorator name → kind classification.
+//! Single source of truth for `NestJS` decorator name → kind classification.
 //!
 //! This crate is intentionally lightweight (zero dependencies) so it can be
 //! shared by both `tyrus_analyzer` and `tyrus_codegen` without dragging
@@ -27,7 +27,7 @@ pub enum DecoratorScope {
     Param,
 }
 
-/// Every NestJS decorator the transpiler currently recognizes.
+/// Every `NestJS` decorator the transpiler currently recognizes.
 ///
 /// Adding a new decorator means adding ONE variant here plus mapping its name
 /// in [`DecoratorKind::from_name`]. The handler that emits Rust for it lives

--- a/crates/tyrus_di/Cargo.toml
+++ b/crates/tyrus_di/Cargo.toml
@@ -11,3 +11,6 @@ repository.workspace = true
 petgraph = "0.8"
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
+
+[lints]
+workspace = true

--- a/crates/tyrus_di/src/graph.rs
+++ b/crates/tyrus_di/src/graph.rs
@@ -1,6 +1,6 @@
 use crate::module::Module;
 use petgraph::algo::toposort;
-use petgraph::graph::DiGraph as PetDiGraph;
+use petgraph::graph::{DiGraph as PetDiGraph, NodeIndex};
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -14,10 +14,10 @@ pub enum DiError {
 
 use crate::provider::InjectableDefinition;
 
+#[derive(Debug)]
 pub struct DiGraph {
     pub modules: HashMap<String, Module>,
     pub injectables: HashMap<String, InjectableDefinition>,
-    // graph: PetDiGraph<String, ()>, // Removed unused field for now, it's local to resolve()
 }
 
 impl DiGraph {
@@ -67,30 +67,24 @@ impl DiGraph {
                         return Some(provider.dependencies.clone());
                     } else if let Some(def) = self.injectables.get(token) {
                         return Some(def.dependencies.clone());
-                    } else {
-                        return Some(vec![]);
                     }
+                    return Some(vec![]);
                 }
             }
             for controller in &module.controllers {
                 if controller == token {
                     if let Some(def) = self.injectables.get(token) {
                         return Some(def.dependencies.clone());
-                    } else {
-                        return Some(vec![]);
                     }
+                    return Some(vec![]);
                 }
             }
         }
         None
     }
 
-    pub fn resolve(&self) -> Result<Vec<String>, DiError> {
-        // Build the dependency graph
-        let mut graph = PetDiGraph::<String, ()>::new();
+    fn collect_nodes(&self, graph: &mut PetDiGraph<String, ()>) -> HashMap<String, NodeIndex> {
         let mut node_indices = HashMap::new();
-
-        // 1. Add all providers and controllers as nodes
         for module in self.modules.values() {
             for provider in &module.providers {
                 if !node_indices.contains_key(&provider.token) {
@@ -105,21 +99,25 @@ impl DiGraph {
                 }
             }
         }
+        node_indices
+    }
 
-        // 2. Add edges (dependencies)
+    fn add_dependency_edges(
+        &self,
+        graph: &mut PetDiGraph<String, ()>,
+        node_indices: &HashMap<String, NodeIndex>,
+    ) {
         for module in self.modules.values() {
-            // Process Providers
             for provider in &module.providers {
                 if let Some(parent_idx) = node_indices.get(&provider.token) {
-                    // Try to find dependencies from InjectableDefinition
-                    let deps = if !provider.dependencies.is_empty() {
-                        &provider.dependencies
-                    } else if let Some(def) = self.injectables.get(&provider.token) {
-                        &def.dependencies
+                    // Provider metadata wins; fall back to the @Injectable definition.
+                    let deps = if provider.dependencies.is_empty() {
+                        self.injectables
+                            .get(&provider.token)
+                            .map_or(&provider.dependencies, |def| &def.dependencies)
                     } else {
-                        &provider.dependencies // empty
+                        &provider.dependencies
                     };
-
                     for dep_token in deps {
                         if let Some(dep_idx) = node_indices.get(dep_token) {
                             graph.add_edge(*dep_idx, *parent_idx, ());
@@ -127,23 +125,26 @@ impl DiGraph {
                     }
                 }
             }
-
-            // Process Controllers
             for controller in &module.controllers {
-                if let Some(parent_idx) = node_indices.get(controller) {
-                    // Controllers are Injectables (definitions exist)
-                    if let Some(def) = self.injectables.get(controller) {
-                        for dep_token in &def.dependencies {
-                            if let Some(dep_idx) = node_indices.get(dep_token) {
-                                graph.add_edge(*dep_idx, *parent_idx, ());
-                            }
+                if let (Some(parent_idx), Some(def)) = (
+                    node_indices.get(controller),
+                    self.injectables.get(controller),
+                ) {
+                    for dep_token in &def.dependencies {
+                        if let Some(dep_idx) = node_indices.get(dep_token) {
+                            graph.add_edge(*dep_idx, *parent_idx, ());
                         }
                     }
                 }
             }
         }
+    }
 
-        // 3. Topological Sort
+    pub fn resolve(&self) -> Result<Vec<String>, DiError> {
+        let mut graph = PetDiGraph::<String, ()>::new();
+        let node_indices = self.collect_nodes(&mut graph);
+        self.add_dependency_edges(&mut graph, &node_indices);
+
         match toposort(&graph, None) {
             Ok(sorted_indices) => {
                 let sorted_tokens: Vec<String> = sorted_indices

--- a/crates/tyrus_diagnostics/Cargo.toml
+++ b/crates/tyrus_diagnostics/Cargo.toml
@@ -10,3 +10,6 @@ repository.workspace = true
 [dependencies]
 miette = { version = "7.6.0", features = ["fancy"] }
 thiserror = "2.0"
+
+[lints]
+workspace = true

--- a/crates/tyrus_orchestrator/Cargo.toml
+++ b/crates/tyrus_orchestrator/Cargo.toml
@@ -35,3 +35,6 @@ harness = false
 [[bench]]
 name = "runtime_comparison"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/tyrus_orchestrator/benches/runtime_comparison.rs
+++ b/crates/tyrus_orchestrator/benches/runtime_comparison.rs
@@ -1,4 +1,9 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#![expect(
+    clippy::print_stdout,
+    clippy::print_stderr,
+    reason = "benchmark binary reports its comparison table on the terminal"
+)]
 //! Runtime Comparison Benchmark
 //!
 //! Measures wall-clock execution time of identical algorithms running in:
@@ -39,7 +44,7 @@ struct BenchCase {
 const BENCH_CASES: &[BenchCase] = &[
     BenchCase {
         name: "fibonacci",
-        ts_code: r#"
+        ts_code: r"
 function fibonacci(n: number): number {
     if (n <= 1) {
         return n;
@@ -47,12 +52,12 @@ function fibonacci(n: number): number {
     return fibonacci(n - 1) + fibonacci(n - 2);
 }
 console.log(fibonacci(30));
-"#,
+",
     },
     BenchCase {
         name: "sum_loop",
         //"Sum 1 to 1_000_000 in a while loop",
-        ts_code: r#"
+        ts_code: r"
 function sumTo(n: number): number {
     let total: number = 0;
     let i: number = 1;
@@ -63,7 +68,7 @@ function sumTo(n: number): number {
     return total;
 }
 console.log(sumTo(1000000));
-"#,
+",
     },
     BenchCase {
         name: "string_build",
@@ -84,7 +89,7 @@ console.log(buildString(1000).includes("xxx").toString());
     BenchCase {
         name: "math_intensive",
         //"Math.sqrt + Math.floor in a loop (10000 iterations)",
-        ts_code: r#"
+        ts_code: r"
 function mathLoop(n: number): number {
     let sum: number = 0;
     let i: number = 1;
@@ -95,12 +100,12 @@ function mathLoop(n: number): number {
     return sum;
 }
 console.log(mathLoop(10000));
-"#,
+",
     },
     BenchCase {
         name: "nested_loops",
         //"Nested loop O(n^2) with n=500",
-        ts_code: r#"
+        ts_code: r"
 function nestedSum(n: number): number {
     let total: number = 0;
     let i: number = 0;
@@ -115,7 +120,7 @@ function nestedSum(n: number): number {
     return total;
 }
 console.log(nestedSum(500));
-"#,
+",
     },
 ];
 
@@ -195,10 +200,8 @@ serde_json = "1.0"
 
     fs::write(temp_dir_path.join("Cargo.toml"), cargo_toml).expect("write Cargo.toml");
 
-    let wrapped = format!(
-        "#![allow(dead_code, unused_variables, unused_imports, unused_mut)]\n{}",
-        rust_code
-    );
+    let wrapped =
+        format!("#![allow(dead_code, unused_variables, unused_imports, unused_mut)]\n{rust_code}");
     fs::write(temp_dir_path.join("src/main.rs"), &wrapped).expect("write main.rs");
 
     let build = Command::new("cargo")
@@ -254,6 +257,8 @@ fn normalize_numeric_output(s: &str) -> String {
 // Main: run all benchmarks and print comparison table
 // ---------------------------------------------------------------------------
 
+type CaseResult = (String, Duration, Duration, f64, bool);
+
 fn main() {
     let iterations = std::env::var("BENCH_ITERATIONS")
         .ok()
@@ -271,69 +276,81 @@ fn main() {
     println!("╠══════════════════════════════════════════════════════════════════════════╣");
 
     let mut all_match = true;
-    let mut results: Vec<(String, Duration, Duration, f64, bool)> = Vec::new();
+    let mut results: Vec<CaseResult> = Vec::new();
 
     for case in BENCH_CASES {
-        eprint!("  Running {}... ", case.name);
-
-        // 1. Run in Node.js
-        let (node_output, node_time) = run_node_timed(case.ts_code, iterations);
-
-        // 2. Transpile TS → Rust
-        let rust_code = transpile_ts(case.ts_code);
-
-        // 3. Ensure fn main() exists. Raw quote! output spells it "fn main ()"
-        // (space before parens) — match without the parens to cover both forms.
-        let rust_code = if rust_code.contains("fn main") {
-            rust_code
-        } else {
-            format!("{rust_code}\nfn main() {{}}\n")
-        };
-
-        // 4. Compile Rust (release mode)
-        let bin_path = compile_rust_release(&rust_code, case.name);
-
-        // 5. Run Rust binary
-        let (rust_output, rust_time) = run_rust_timed(&bin_path, iterations);
-
-        // 6. Compare outputs (normalize f64 formatting: "832040" == "832040.0")
-        let outputs_match =
-            normalize_numeric_output(&node_output) == normalize_numeric_output(&rust_output);
-        if !outputs_match {
+        let result = run_case(case, iterations);
+        if !result.4 {
             all_match = false;
         }
-
-        let speedup = if rust_time.as_nanos() > 0 {
-            node_time.as_secs_f64() / rust_time.as_secs_f64()
-        } else {
-            f64::INFINITY
-        };
-
-        let match_str = if outputs_match { "OK" } else { "DIFF" };
-
-        println!(
-            "║ {:20} │ {:>10.2}ms │ {:>10.2}ms │ {:>6.1}x │ {:>6} ║",
-            case.name,
-            node_time.as_secs_f64() * 1000.0,
-            rust_time.as_secs_f64() * 1000.0,
-            speedup,
-            match_str,
-        );
-
-        results.push((
-            case.name.to_string(),
-            node_time,
-            rust_time,
-            speedup,
-            outputs_match,
-        ));
-
-        eprintln!("done");
+        results.push(result);
     }
 
+    print_summary(&results, all_match, iterations);
+}
+
+fn run_case(case: &BenchCase, iterations: u32) -> CaseResult {
+    eprint!("  Running {}... ", case.name);
+
+    // 1. Run in Node.js
+    let (node_output, node_time) = run_node_timed(case.ts_code, iterations);
+
+    // 2. Transpile TS → Rust
+    let rust_code = transpile_ts(case.ts_code);
+
+    // 3. Ensure fn main() exists. Raw quote! output spells it "fn main ()"
+    // (space before parens) — match without the parens to cover both forms.
+    let rust_code = if rust_code.contains("fn main") {
+        rust_code
+    } else {
+        format!("{rust_code}\nfn main() {{}}\n")
+    };
+
+    // 4. Compile Rust (release mode)
+    let bin_path = compile_rust_release(&rust_code, case.name);
+
+    // 5. Run Rust binary
+    let (rust_output, rust_time) = run_rust_timed(&bin_path, iterations);
+
+    // 6. Compare outputs (normalize f64 formatting: "832040" == "832040.0")
+    let outputs_match =
+        normalize_numeric_output(&node_output) == normalize_numeric_output(&rust_output);
+
+    let speedup = if rust_time.as_nanos() > 0 {
+        node_time.as_secs_f64() / rust_time.as_secs_f64()
+    } else {
+        f64::INFINITY
+    };
+
+    let match_str = if outputs_match { "OK" } else { "DIFF" };
+
+    println!(
+        "║ {:20} │ {:>10.2}ms │ {:>10.2}ms │ {:>6.1}x │ {:>6} ║",
+        case.name,
+        node_time.as_secs_f64() * 1000.0,
+        rust_time.as_secs_f64() * 1000.0,
+        speedup,
+        match_str,
+    );
+
+    eprintln!("done");
+
+    (
+        case.name.to_string(),
+        node_time,
+        rust_time,
+        speedup,
+        outputs_match,
+    )
+}
+
+fn print_summary(results: &[CaseResult], all_match: bool, iterations: u32) {
     println!("╠══════════════════════════════════════════════════════════════════════════╣");
 
-    // Summary
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "benchmark case count is far below f64 mantissa range"
+    )]
     let avg_speedup: f64 =
         results.iter().map(|(_, _, _, s, _)| s).sum::<f64>() / results.len() as f64;
 
@@ -358,7 +375,7 @@ fn main() {
     if std::env::var("BENCH_CSV").is_ok() {
         println!("--- CSV OUTPUT ---");
         println!("benchmark,node_ms,rust_ms,speedup,match");
-        for (name, node, rust, speedup, m) in &results {
+        for (name, node, rust, speedup, m) in results {
             println!(
                 "{},{:.3},{:.3},{:.1},{}",
                 name,

--- a/crates/tyrus_orchestrator/benches/transpiler.rs
+++ b/crates/tyrus_orchestrator/benches/transpiler.rs
@@ -26,7 +26,7 @@ fn ts_temp_file(source: &str) -> (NamedTempFile, FilePath) {
 // Tier 1: Basic TypeScript (primitives, functions, control flow)
 // ---------------------------------------------------------------------------
 
-const TIER1_FUNCTIONS: &str = r#"
+const TIER1_FUNCTIONS: &str = r"
 function square(x: number): number {
     return x * x;
 }
@@ -38,7 +38,7 @@ function isPositive(n: number): boolean {
 function formatUser(name: string, age: number): string {
     return `${name} is ${age} years old`;
 }
-"#;
+";
 
 const TIER1_CONTROL_FLOW: &str = r#"
 function max(a: number, b: number): number {
@@ -74,7 +74,7 @@ function classify(x: number): string {
 // Tier 2: Intermediate (interfaces, classes, arrays)
 // ---------------------------------------------------------------------------
 
-const TIER2_INTERFACES: &str = r#"
+const TIER2_INTERFACES: &str = r"
 interface User {
     name: string;
     age: number;
@@ -94,9 +94,9 @@ interface ApiResponse {
     total: number;
     success: boolean;
 }
-"#;
+";
 
-const TIER2_CLASS: &str = r#"
+const TIER2_CLASS: &str = r"
 class Calculator {
     private result: number;
 
@@ -117,9 +117,9 @@ class Calculator {
         this.result = 0;
     }
 }
-"#;
+";
 
-const TIER2_ARRAYS: &str = r#"
+const TIER2_ARRAYS: &str = r"
 function doubleAll(nums: number[]): number[] {
     return nums.map((n: number) => n * 2);
 }
@@ -135,13 +135,13 @@ function sum(nums: number[]): number {
     });
     return total;
 }
-"#;
+";
 
 // ---------------------------------------------------------------------------
 // Tier 3: Advanced (generics, stdlib, methods)
 // ---------------------------------------------------------------------------
 
-const TIER3_STDLIB: &str = r#"
+const TIER3_STDLIB: &str = r"
 function clamp(value: number, min: number, max: number): number {
     return Math.max(min, Math.min(max, value));
 }
@@ -162,7 +162,7 @@ function hasLarge(nums: number[]): boolean {
 function allPositive(nums: number[]): boolean {
     return nums.every((n: number) => n > 0);
 }
-"#;
+";
 
 // ---------------------------------------------------------------------------
 // Tier 4: NestJS / Enterprise (decorators, DI, controllers)
@@ -226,7 +226,7 @@ class UsersController {
 // Combined: all tiers in one file (scalability test)
 // ---------------------------------------------------------------------------
 
-const COMBINED_ALL_TIERS: &str = r#"
+const COMBINED_ALL_TIERS: &str = r"
 function square(x: number): number { return x * x; }
 function isPositive(n: number): boolean { return n > 0; }
 function formatUser(name: string, age: number): string {
@@ -270,7 +270,7 @@ function clamp(value: number, min: number, max: number): number {
 function roundToTwo(n: number): number {
     return Math.round(n * 100) / 100;
 }
-"#;
+";
 
 // ---------------------------------------------------------------------------
 // Benchmark Group 1: Full pipeline by tier (parse → analyze → codegen → format)
@@ -365,12 +365,10 @@ fn bench_scalability(c: &mut Criterion) {
     let sizes: &[usize] = &[1, 5, 10, 20];
 
     for &count in sizes {
-        let mut source = String::new();
-        for i in 0..count {
-            source.push_str(&format!(
-                "function func_{i}(x: number): number {{ return x * {i}; }}\n"
-            ));
-        }
+        let fns: Vec<String> = (0..count)
+            .map(|i| format!("function func_{i}(x: number): number {{ return x * {i}; }}"))
+            .collect();
+        let source = format!("{}\n", fns.join("\n"));
 
         let label = format!("{count}_functions");
         let (_tmp, path) = ts_temp_file(&source);

--- a/crates/tyrus_orchestrator/src/format.rs
+++ b/crates/tyrus_orchestrator/src/format.rs
@@ -6,7 +6,7 @@ pub(crate) fn format_code(code: &str) -> Result<String, TyrusError> {
     Ok(prettyplease::unparse(&syntax_tree))
 }
 
-/// Minimal AppError for non-web async code (no axum dependency).
+/// Minimal `AppError` for non-web async code (no axum dependency).
 pub(crate) fn get_app_error_simple() -> &'static str {
     r#"
 #[derive(Debug)]
@@ -29,7 +29,7 @@ where
 "#
 }
 
-/// Full AppError with named HTTP variants and axum IntoResponse (for web/NestJS code).
+/// Full `AppError` with named HTTP variants and axum `IntoResponse` (for web/NestJS code).
 pub(crate) fn get_app_error_code() -> &'static str {
     r#"
 use axum::{response::{IntoResponse, Response}, http::StatusCode};
@@ -99,7 +99,7 @@ fn main() {
     println!("hello");
 }
 "#,
-            r#"
+            r"
 struct Foo {
     x: i32,
     y: String,
@@ -110,7 +110,7 @@ impl Foo {
         Self { x: 0, y: String::new() }
     }
 }
-"#,
+",
             // Async + Result — the historical bypass class.
             r#"
 async fn handler() -> Result<String, Box<dyn std::error::Error>> {
@@ -118,14 +118,14 @@ async fn handler() -> Result<String, Box<dyn std::error::Error>> {
 }
 "#,
             // Mutex pattern from generated NestJS services.
-            r#"
+            r"
 pub struct Svc { x: std::sync::Arc<std::sync::Mutex<f64>> }
 impl Svc {
     pub fn read(&self) -> f64 {
         { let __g = self.x.lock().unwrap_or_else(|e| e.into_inner()); *__g }
     }
 }
-"#,
+",
         ];
         for src in inputs {
             let once = format_code(src).expect("first format must succeed");

--- a/crates/tyrus_orchestrator/src/lib.rs
+++ b/crates/tyrus_orchestrator/src/lib.rs
@@ -9,6 +9,7 @@ mod format;
 mod pipeline;
 mod scaffold;
 
+#[derive(Debug)]
 pub struct CheckResult {
     pub errors: Vec<TyrusError>,
     pub diagnostics: Vec<tyrus_analyzer::severity::Diagnostic>,

--- a/crates/tyrus_orchestrator/src/pipeline.rs
+++ b/crates/tyrus_orchestrator/src/pipeline.rs
@@ -187,8 +187,7 @@ fn transpile_files(
     parsed: &ParsedProject,
 ) -> Result<Vec<String>, TyrusError> {
     let mut controllers = Vec::new();
-    for (i, program) in parsed.programs.iter().enumerate() {
-        let path = &parsed.file_paths[i];
+    for (program, path) in parsed.programs.iter().zip(&parsed.file_paths) {
         write_transpiled_file(input_dir, output_dir, path, program, &mut controllers)?;
     }
     Ok(controllers)
@@ -276,7 +275,7 @@ fn write_main_rs(output_dir: &Path, ctx: &MainRsCtx<'_>) -> Result<(), TyrusErro
         ctx.controllers,
         ctx.graph,
         ctx.generic_classes,
-    )?;
+    );
 
     let src_dir = output_dir.join("src");
     if !src_dir.exists() {

--- a/crates/tyrus_orchestrator/src/pipeline/analyze.rs
+++ b/crates/tyrus_orchestrator/src/pipeline/analyze.rs
@@ -5,12 +5,16 @@ use tyrus_diagnostics::TyrusError;
 
 use super::ParsedProject;
 
+#[expect(
+    clippy::print_stdout,
+    clippy::print_stderr,
+    reason = "user-facing analyzer warnings; orchestrator has no diagnostics sink yet"
+)]
 pub(super) fn analyze_di_graph(
     parsed: &ParsedProject,
 ) -> Result<(DiGraph, Vec<String>), TyrusError> {
     let mut graph = DiGraph::new();
-    for (i, program) in parsed.programs.iter().enumerate() {
-        let path = &parsed.file_paths[i];
+    for (program, path) in parsed.programs.iter().zip(&parsed.file_paths) {
         let source_code = fs::read_to_string(path).map_err(TyrusError::IoError)?;
         let file_name = path.to_string_lossy().to_string();
 

--- a/crates/tyrus_orchestrator/src/scaffold.rs
+++ b/crates/tyrus_orchestrator/src/scaffold.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, HashSet};
+use std::fmt::Write;
 use std::fs;
 use std::path::Path;
 
@@ -5,11 +7,11 @@ use tyrus_diagnostics::TyrusError;
 
 pub(crate) fn generate_main_rs(
     init_order: &[String],
-    class_module_map: &std::collections::HashMap<String, String>,
+    class_module_map: &HashMap<String, String>,
     controllers: &[String],
     graph: &tyrus_di::graph::DiGraph,
-    generic_classes: &std::collections::HashSet<String>,
-) -> Result<String, TyrusError> {
+    generic_classes: &HashSet<String>,
+) -> String {
     let mut main_content = String::new();
     main_content.push_str("#![allow(unused)]\n\n");
     main_content.push_str("use axum::Router;\n");
@@ -20,8 +22,42 @@ pub(crate) fn generate_main_rs(
     main_content.push_str("#[tokio::main]\n");
     main_content.push_str("async fn main() -> Result<(), Box<dyn std::error::Error>> {\n");
 
-    // Instantiate components in order
-    let mut instantiated_vars = std::collections::HashMap::new();
+    let mut instantiated_vars = emit_di_instantiations(
+        &mut main_content,
+        init_order,
+        class_module_map,
+        graph,
+        generic_classes,
+    );
+
+    // Fallback: if no DI graph but controllers exist, instantiate all classes
+    if instantiated_vars.is_empty() && !controllers.is_empty() {
+        emit_fallback_instantiations(
+            &mut main_content,
+            class_module_map,
+            controllers,
+            &mut instantiated_vars,
+        );
+    }
+
+    emit_router_and_serve(
+        &mut main_content,
+        class_module_map,
+        controllers,
+        &instantiated_vars,
+    );
+    main_content
+}
+
+/// Instantiates components in DI topological order; returns `class -> var` map.
+fn emit_di_instantiations(
+    main_content: &mut String,
+    init_order: &[String],
+    class_module_map: &HashMap<String, String>,
+    graph: &tyrus_di::graph::DiGraph,
+    generic_classes: &HashSet<String>,
+) -> HashMap<String, String> {
+    let mut instantiated_vars = HashMap::new();
 
     for class_name in init_order {
         if generic_classes.contains(class_name) {
@@ -30,86 +66,97 @@ pub(crate) fn generate_main_rs(
         if let Some(module_path) = class_module_map.get(class_name) {
             let var_name = tyrus_common::util::to_snake_case(class_name);
 
-            // Get dependencies
             let deps = graph
                 .get_provider_dependencies(class_name)
                 .unwrap_or_default();
             let mut args = Vec::new();
             for dep in deps {
                 let dep_var = tyrus_common::util::to_snake_case(&dep);
-                args.push(format!("{}.clone()", dep_var));
+                args.push(format!("{dep_var}.clone()"));
             }
 
             // Check if it has new_di
             // For now assume yes if it has dependencies, or just call new_di
-            main_content.push_str(&format!(
-                "    let {} = Arc::new({}::{}::new_di({}));\n",
+            let _ = writeln!(
+                main_content,
+                "    let {} = Arc::new({}::{}::new_di({}));",
                 var_name,
                 module_path,
                 class_name,
                 args.join(", ")
-            ));
+            );
 
             instantiated_vars.insert(class_name.clone(), var_name);
         }
     }
+    instantiated_vars
+}
 
-    // Fallback: if no DI graph but controllers exist, instantiate all classes
-    if instantiated_vars.is_empty() && !controllers.is_empty() {
-        for (class_name, module_path) in class_module_map {
-            let var_name = tyrus_common::util::to_snake_case(class_name);
-            let is_controller = controllers.contains(class_name);
+/// No-DI-graph fallback: services first (no deps), then controllers.
+fn emit_fallback_instantiations(
+    main_content: &mut String,
+    class_module_map: &HashMap<String, String>,
+    controllers: &[String],
+    instantiated_vars: &mut HashMap<String, String>,
+) {
+    for (class_name, module_path) in class_module_map {
+        let var_name = tyrus_common::util::to_snake_case(class_name);
+        let is_controller = controllers.contains(class_name);
 
-            // Instantiate services first (no deps), then controllers
-            if !is_controller {
-                main_content.push_str(&format!(
-                    "    let {} = Arc::new({}::{}::new_di());\n",
-                    var_name, module_path, class_name
-                ));
-                instantiated_vars.insert(class_name.clone(), var_name);
-            }
-        }
-        // Instantiate controllers with their service deps
-        for controller in controllers {
-            if let Some(module_path) = class_module_map.get(controller) {
-                let var_name = tyrus_common::util::to_snake_case(controller);
-                // Find service dependencies (vars already instantiated)
-                let service_args: Vec<String> = instantiated_vars
-                    .values()
-                    .map(|v| format!("{}.clone()", v))
-                    .collect();
-                main_content.push_str(&format!(
-                    "    let {} = Arc::new({}::{}::new_di({}));\n",
-                    var_name,
-                    module_path,
-                    controller,
-                    service_args.join(", ")
-                ));
-                instantiated_vars.insert(controller.clone(), var_name);
-            }
+        if !is_controller {
+            let _ = writeln!(
+                main_content,
+                "    let {var_name} = Arc::new({module_path}::{class_name}::new_di());"
+            );
+            instantiated_vars.insert(class_name.clone(), var_name);
         }
     }
-
-    main_content.push_str("\n    // Build router\n");
-    main_content.push_str("    let app = axum::Router::new()");
-
-    // Register controllers
+    // Instantiate controllers with their service deps
     for controller in controllers {
         if let Some(module_path) = class_module_map.get(controller) {
             let var_name = tyrus_common::util::to_snake_case(controller);
-            main_content.push_str(&format!(
-                "\n        .merge({}::{}::router({}.clone()))",
-                module_path, controller, var_name
-            ));
+            // Find service dependencies (vars already instantiated)
+            let service_args: Vec<String> = instantiated_vars
+                .values()
+                .map(|v| format!("{v}.clone()"))
+                .collect();
+            let _ = writeln!(
+                main_content,
+                "    let {} = Arc::new({}::{}::new_di({}));",
+                var_name,
+                module_path,
+                controller,
+                service_args.join(", ")
+            );
+            instantiated_vars.insert(controller.clone(), var_name);
+        }
+    }
+}
+
+fn emit_router_and_serve(
+    main_content: &mut String,
+    class_module_map: &HashMap<String, String>,
+    controllers: &[String],
+    instantiated_vars: &HashMap<String, String>,
+) {
+    main_content.push_str("\n    // Build router\n");
+    main_content.push_str("    let app = axum::Router::new()");
+
+    for controller in controllers {
+        if let Some(module_path) = class_module_map.get(controller) {
+            let var_name = tyrus_common::util::to_snake_case(controller);
+            let _ = write!(
+                main_content,
+                "\n        .merge({module_path}::{controller}::router({var_name}.clone()))"
+            );
         }
     }
 
-    // Add extensions
     for var_name in instantiated_vars.values() {
-        main_content.push_str(&format!(
-            "\n        .layer(Extension({}.clone()))",
-            var_name
-        ));
+        let _ = write!(
+            main_content,
+            "\n        .layer(Extension({var_name}.clone()))"
+        );
     }
 
     main_content.push_str(";\n\n");
@@ -119,8 +166,6 @@ pub(crate) fn generate_main_rs(
     main_content.push_str("        .await?;\n");
     main_content.push_str("    Ok(())\n");
     main_content.push_str("}\n");
-
-    Ok(main_content)
 }
 
 pub(crate) fn generate_cargo_toml(output_dir: &Path) -> Result<(), TyrusError> {
@@ -179,7 +224,7 @@ pub(crate) fn generate_mod_rs(dir: &Path) -> Result<(), TyrusError> {
             // so we expose it as a module.
             if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
                 let sanitized_name = name.replace(['.', '-'], "_");
-                mod_content.push_str(&format!("pub mod {};\n", sanitized_name));
+                let _ = writeln!(mod_content, "pub mod {sanitized_name};");
                 has_children = true;
             }
         } else if let Some(ext) = path.extension() {
@@ -194,7 +239,7 @@ pub(crate) fn generate_mod_rs(dir: &Path) -> Result<(), TyrusError> {
                     } else {
                         // Sanitize module name just in case, though we sanitized filename on write
                         let sanitized_stem = stem.replace(['.', '-'], "_");
-                        mod_content.push_str(&format!("pub mod {};\n", sanitized_stem));
+                        let _ = writeln!(mod_content, "pub mod {sanitized_stem};");
                         has_children = true;
                     }
                 }

--- a/crates/tyrus_parser/Cargo.toml
+++ b/crates/tyrus_parser/Cargo.toml
@@ -13,3 +13,6 @@ swc_ecma_ast = "23.0.0"
 swc_common = { version = "21.0.1", features = ["tty-emitter"] }
 tyrus_diagnostics = { path = "../tyrus_diagnostics" }
 miette = { version = "7.6.0", features = ["fancy"] }
+
+[lints]
+workspace = true

--- a/crates/tyrus_parser/src/lib.rs
+++ b/crates/tyrus_parser/src/lib.rs
@@ -9,11 +9,11 @@ use swc_common::{
     sync::Lrc,
     SourceMap, Spanned,
 };
-use swc_ecma_ast::Program;
+use swc_ecma_ast::{EsVersion, Program};
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsSyntax};
 
 pub fn parse(path: &Path) -> Result<Program, TyrusError> {
-    let cm: Lrc<SourceMap> = Default::default();
+    let cm: Lrc<SourceMap> = Lrc::default();
     let handler = Handler::with_tty_emitter(ColorConfig::Auto, true, false, Some(cm.clone()));
 
     let fm = cm.load_file(path).map_err(TyrusError::IoError)?;
@@ -24,7 +24,7 @@ pub fn parse(path: &Path) -> Result<Program, TyrusError> {
             decorators: true,
             ..Default::default()
         }),
-        Default::default(),
+        EsVersion::default(),
         StringInput::from(&*fm),
         None,
     );

--- a/crates/tyrus_test_utils/Cargo.toml
+++ b/crates/tyrus_test_utils/Cargo.toml
@@ -10,3 +10,6 @@ repository.workspace = true
 [dependencies]
 tempfile = "3.10"
 # We include dependencies that generated code might use, to ensure they are available in the temp environment
+
+[lints]
+workspace = true

--- a/crates/tyrus_test_utils/src/lib.rs
+++ b/crates/tyrus_test_utils/src/lib.rs
@@ -1,5 +1,11 @@
 #![forbid(unsafe_code)]
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::string_slice
+)]
 use std::fs;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -11,7 +17,7 @@ use tempfile::TempDir;
 static RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Shared target directory for compilation caching.
-/// Dependencies are compiled once and reused across all tests via CARGO_TARGET_DIR.
+/// Dependencies are compiled once and reused across all tests via `CARGO_TARGET_DIR`.
 static SHARED_TARGET_DIR: OnceLock<PathBuf> = OnceLock::new();
 
 fn get_shared_target_dir() -> &'static PathBuf {
@@ -25,7 +31,7 @@ fn get_shared_target_dir() -> &'static PathBuf {
 /// Asserts that the provided Rust code compiles successfully as a **library**.
 ///
 /// Each test gets its own temporary project directory (no race conditions),
-/// but all tests share a common CARGO_TARGET_DIR for dependency caching.
+/// but all tests share a common `CARGO_TARGET_DIR` for dependency caching.
 /// Dependencies are compiled once on first use and reused by subsequent tests.
 ///
 /// # Panics
@@ -62,10 +68,7 @@ rand = "0.8"
     fs::write(project_path.join("Cargo.toml"), cargo_toml).expect("Failed to write Cargo.toml");
 
     // Wrap code with common allows to suppress dead_code warnings
-    let wrapped_code = format!(
-        "#![allow(dead_code, unused_variables, unused_imports)]\n{}",
-        code
-    );
+    let wrapped_code = format!("#![allow(dead_code, unused_variables, unused_imports)]\n{code}");
 
     fs::write(src_dir.join("lib.rs"), &wrapped_code).expect("Failed to write lib.rs");
 
@@ -83,9 +86,8 @@ rand = "0.8"
             "\n╔══════════════════════════════════════════╗\n\
              ║   RUST COMPILATION FAILED                ║\n\
              ╚══════════════════════════════════════════╝\n\n\
-             CODE:\n------\n{}\n------\n\n\
-             STDERR:\n{}\n\nSTDOUT:\n{}",
-            code, stderr, stdout
+             CODE:\n------\n{code}\n------\n\n\
+             STDERR:\n{stderr}\n\nSTDOUT:\n{stdout}"
         );
     }
 }
@@ -98,7 +100,7 @@ rand = "0.8"
 fn prepare_and_build_binary(code: &str) -> PathBuf {
     let run_id = RUN_COUNTER.fetch_add(1, Ordering::SeqCst);
     let pid = std::process::id();
-    let bin_name = format!("tyrus_run_{}_{}", pid, run_id);
+    let bin_name = format!("tyrus_run_{pid}_{run_id}");
 
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let project_path = temp_dir.path();
@@ -126,10 +128,8 @@ serde_json = "1.0"
 
     fs::write(project_path.join("Cargo.toml"), cargo_toml).expect("Failed to write Cargo.toml");
 
-    let wrapped_code = format!(
-        "#![allow(dead_code, unused_variables, unused_imports, unused_mut)]\n{}",
-        code
-    );
+    let wrapped_code =
+        format!("#![allow(dead_code, unused_variables, unused_imports, unused_mut)]\n{code}");
     fs::write(src_dir.join("main.rs"), &wrapped_code).expect("Failed to write main.rs");
 
     let build_output = Command::new("cargo")
@@ -141,10 +141,7 @@ serde_json = "1.0"
 
     if !build_output.status.success() {
         let stderr = String::from_utf8_lossy(&build_output.stderr);
-        panic!(
-            "\n=== RUST BUILD FAILED ===\nCODE:\n{}\n\nSTDERR:\n{}",
-            code, stderr
-        );
+        panic!("\n=== RUST BUILD FAILED ===\nCODE:\n{code}\n\nSTDERR:\n{stderr}");
     }
 
     shared_target.join("debug").join(&bin_name)
@@ -166,10 +163,7 @@ pub fn compile_and_run_rust(code: &str) -> String {
 
     if !run_output.status.success() {
         let stderr = String::from_utf8_lossy(&run_output.stderr);
-        panic!(
-            "\n=== RUST EXECUTION FAILED ===\nCODE:\n{}\n\nSTDERR:\n{}",
-            code, stderr
-        );
+        panic!("\n=== RUST EXECUTION FAILED ===\nCODE:\n{code}\n\nSTDERR:\n{stderr}");
     }
 
     String::from_utf8_lossy(&run_output.stdout).to_string()
@@ -205,9 +199,8 @@ pub fn compile_and_run_rust_with_timeout(code: &str, timeout: Duration) -> Strin
                     let _ = child.wait();
                     panic!(
                         "\n=== RUST BINARY TIMEOUT ===\n\
-                         Did not exit within {:?} (likely deadlock).\n\
-                         CODE:\n{}",
-                        timeout, code
+                         Did not exit within {timeout:?} (likely deadlock).\n\
+                         CODE:\n{code}"
                     );
                 }
                 std::thread::sleep(Duration::from_millis(50));
@@ -226,10 +219,7 @@ pub fn compile_and_run_rust_with_timeout(code: &str, timeout: Duration) -> Strin
 
     if !exit_status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        panic!(
-            "\n=== RUST EXECUTION FAILED ===\nCODE:\n{}\n\nSTDERR:\n{}",
-            code, stderr
-        );
+        panic!("\n=== RUST EXECUTION FAILED ===\nCODE:\n{code}\n\nSTDERR:\n{stderr}");
     }
 
     String::from_utf8_lossy(&output.stdout).to_string()
@@ -262,8 +252,7 @@ pub fn run_node(ts_code: &str) -> String {
         "\n=== NODE EXECUTION FAILED ===\n\
          Node.js 22+ is required for --experimental-strip-types.\n\
          Check your Node version with: node --version\n\n\
-         CODE:\n{}\n\nSTDERR:\n{}",
-        ts_code, stderr
+         CODE:\n{ts_code}\n\nSTDERR:\n{stderr}"
     )
 }
 
@@ -275,7 +264,7 @@ mod tests {
     #[should_panic(expected = "RUST BINARY TIMEOUT")]
     fn timeout_kills_deadlocked_binary() {
         compile_and_run_rust_with_timeout(
-            r#"fn main() { std::thread::park(); }"#,
+            r"fn main() { std::thread::park(); }",
             Duration::from_millis(500),
         );
     }
@@ -284,7 +273,7 @@ mod tests {
     fn no_timeout_for_fast_program() {
         let out = compile_and_run_rust_with_timeout(
             r#"fn main() { println!("ok"); }"#,
-            Duration::from_secs(60),
+            Duration::from_mins(1),
         );
         assert_eq!(out.trim(), "ok");
     }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -21,3 +21,6 @@ serde_json = "1.0"
 trybuild = "1.0"
 
 [dev-dependencies]
+
+[lints]
+workspace = true

--- a/tests/src/equivalence/arrays.rs
+++ b/tests/src/equivalence/arrays.rs
@@ -3,7 +3,7 @@ use crate::helpers::assert_output_equivalent;
 #[test]
 fn test_equivalence_array_for_each() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     const nums: number[] = [10, 20, 30];
     nums.forEach((n: number): void => {
@@ -11,14 +11,14 @@ function main(): void {
     });
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_array_push() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     let items: number[] = [1, 2, 3];
     items.push(4);
@@ -28,21 +28,21 @@ function main(): void {
     });
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_array_includes() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     const nums: number[] = [1, 2, 3, 4, 5];
     console.log(nums.includes(3));
     console.log(nums.includes(9));
 }
 main();
-"#,
+",
     );
 }
 
@@ -65,21 +65,21 @@ main();
 #[test]
 fn test_equivalence_array_index_of() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     const nums: number[] = [10, 20, 30, 40];
     console.log(nums.indexOf(30));
     console.log(nums.indexOf(99));
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_array_reverse() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     let nums: number[] = [1, 2, 3, 4, 5];
     nums.reverse();
@@ -88,14 +88,14 @@ function main(): void {
     });
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_array_slice() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     const nums: number[] = [1, 2, 3, 4, 5];
     const sliced: number[] = nums.slice(1, 4);
@@ -104,28 +104,28 @@ function main(): void {
     });
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_array_reduce_with_initial() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     const nums: number[] = [1, 2, 3, 4, 5];
     const sum: number = nums.reduce((acc: number, n: number): number => acc + n, 0);
     console.log(sum);
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_array_concat() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     const a: number[] = [1, 2];
     const b: number[] = [3, 4];
@@ -135,14 +135,14 @@ function main(): void {
     });
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_array_sort() {
     assert_output_equivalent(
-        r#"
+        r"
 function sortTest(): void {
     let nums: number[] = [3, 1, 4, 1, 5, 9, 2, 6];
     nums.sort();
@@ -154,14 +154,14 @@ function main(): void {
     sortTest();
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_array_shift() {
     assert_output_equivalent(
-        r#"
+        r"
 function shiftTest(): void {
     let items: number[] = [10, 20, 30];
     const first: number = items.shift();
@@ -174,6 +174,6 @@ function main(): void {
     shiftTest();
 }
 main();
-"#,
+",
     );
 }

--- a/tests/src/equivalence/basic.rs
+++ b/tests/src/equivalence/basic.rs
@@ -3,7 +3,7 @@ use crate::helpers::assert_output_equivalent;
 #[test]
 fn test_equivalence_simple_addition() {
     assert_output_equivalent(
-        r#"
+        r"
 function add(a: number, b: number): number {
     return a + b;
 }
@@ -11,14 +11,14 @@ function main(): void {
     console.log(add(2, 3));
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_arithmetic_operations() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     console.log(2 + 3);
     console.log(10 - 4);
@@ -26,14 +26,14 @@ function main(): void {
     console.log(15 / 4);
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_comparison_operators() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     console.log(5 > 3);
     console.log(2 < 1);
@@ -41,7 +41,7 @@ function main(): void {
     console.log(4 <= 5);
 }
 main();
-"#,
+",
     );
 }
 
@@ -84,7 +84,7 @@ main();
 #[test]
 fn test_equivalence_while_loop() {
     assert_output_equivalent(
-        r#"
+        r"
 function sum(n: number): number {
     let total: number = 0;
     let i: number = 1;
@@ -99,14 +99,14 @@ function main(): void {
     console.log(sum(10));
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_const_vs_let() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     const x: number = 10;
     let y: number = 20;
@@ -114,14 +114,14 @@ function main(): void {
     console.log(y);
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_unary_negation() {
     assert_output_equivalent(
-        r#"
+        r"
 function negate(x: number): number {
     return -x;
 }
@@ -130,14 +130,14 @@ function main(): void {
     console.log(negate(-3));
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_logical_not() {
     assert_output_equivalent(
-        r#"
+        r"
 function invert(x: boolean): boolean {
     return !x;
 }
@@ -146,42 +146,42 @@ function main(): void {
     console.log(invert(false));
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_parenthesized_precedence() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     console.log((2 + 3) * 4);
     console.log(2 + 3 * 4);
     console.log((10 - 2) / 4);
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_exponentiation() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     console.log(2 ** 3);
     console.log(3 ** 2);
     console.log(2 ** 10);
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_boolean_logic() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     const a: boolean = true;
     const b: boolean = false;
@@ -192,6 +192,6 @@ function main(): void {
     console.log(a && !b);
 }
 main();
-"#,
+",
     );
 }

--- a/tests/src/equivalence/console.rs
+++ b/tests/src/equivalence/console.rs
@@ -3,12 +3,12 @@ use crate::helpers::assert_output_equivalent;
 #[test]
 fn test_equivalence_console_log_number() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     console.log(42);
 }
 main();
-"#,
+",
     );
 }
 
@@ -27,12 +27,12 @@ main();
 #[test]
 fn test_equivalence_console_log_boolean() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     console.log(true);
     console.log(false);
 }
 main();
-"#,
+",
     );
 }

--- a/tests/src/equivalence/control_flow.rs
+++ b/tests/src/equivalence/control_flow.rs
@@ -3,7 +3,7 @@ use crate::helpers::assert_output_equivalent;
 #[test]
 fn test_equivalence_for_loop() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     let sum: number = 0;
     for (let i: number = 1; i <= 5; i++) {
@@ -12,14 +12,14 @@ function main(): void {
     console.log(sum);
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_for_of_loop() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     const nums: number[] = [10, 20, 30];
     for (const n of nums) {
@@ -27,14 +27,14 @@ function main(): void {
     }
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_do_while_loop() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     let i: number = 0;
     do {
@@ -43,7 +43,7 @@ function main(): void {
     console.log(i);
 }
 main();
-"#,
+",
     );
 }
 

--- a/tests/src/equivalence/getters_setters.rs
+++ b/tests/src/equivalence/getters_setters.rs
@@ -15,7 +15,7 @@ use crate::helpers::assert_output_equivalent;
 #[test]
 fn test_equivalence_getter_setter_basic() {
     assert_output_equivalent(
-        r#"
+        r"
 class Temperature {
     private _celsius: number;
     constructor(celsius: number) {
@@ -41,7 +41,7 @@ function main(): void {
     console.log(temp.fahrenheit);
 }
 main();
-"#,
+",
     );
 }
 
@@ -57,7 +57,7 @@ main();
 #[test]
 fn test_equivalence_getter_only_computed() {
     assert_output_equivalent(
-        r#"
+        r"
 class Circle {
     radius: number;
     constructor(radius: number) {
@@ -73,7 +73,7 @@ function main(): void {
     console.log(c.area);
 }
 main();
-"#,
+",
     );
 }
 
@@ -90,7 +90,7 @@ main();
 #[test]
 fn test_equivalence_setter_with_validation() {
     assert_output_equivalent(
-        r#"
+        r"
 class Percentage {
     private _value: number;
     constructor(value: number) {
@@ -119,6 +119,6 @@ function main(): void {
     console.log(p.value);
 }
 main();
-"#,
+",
     );
 }

--- a/tests/src/equivalence/inheritance.rs
+++ b/tests/src/equivalence/inheritance.rs
@@ -38,7 +38,7 @@ main();
 #[test]
 fn test_equivalence_class_inheritance_method_override() {
     assert_output_equivalent(
-        r#"
+        r"
 class Shape {
     area(): number {
         return 0;
@@ -61,6 +61,6 @@ function main(): void {
     console.log(c.area());
 }
 main();
-"#,
+",
     );
 }

--- a/tests/src/equivalence/math.rs
+++ b/tests/src/equivalence/math.rs
@@ -3,142 +3,142 @@ use crate::helpers::assert_output_equivalent;
 #[test]
 fn test_equivalence_math_pow() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     console.log(Math.pow(2, 10));
     console.log(Math.pow(3, 3));
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_math_sqrt() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     console.log(Math.sqrt(16));
     console.log(Math.sqrt(9));
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_math_pi() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     console.log(Math.PI);
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_math_abs() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     console.log(Math.abs(-5));
     console.log(Math.abs(3));
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_math_floor_ceil_round() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     console.log(Math.floor(4.7));
     console.log(Math.ceil(4.2));
     console.log(Math.round(4.5));
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_math_max_min() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     console.log(Math.max(3, 7));
     console.log(Math.min(3, 7));
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_math_trunc() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     console.log(Math.trunc(4.9));
     console.log(Math.trunc(-4.9));
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_math_sign() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     console.log(Math.sign(5));
     console.log(Math.sign(-3));
     console.log(Math.sign(0));
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_math_log() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     console.log(Math.log(1));
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_math_sin_cos_tan() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     console.log(Math.sin(0));
     console.log(Math.cos(0));
     console.log(Math.tan(0));
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_math_e_constant() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     console.log(Math.E);
 }
 main();
-"#,
+",
     );
 }

--- a/tests/src/equivalence/nestjs_logic.rs
+++ b/tests/src/equivalence/nestjs_logic.rs
@@ -1,6 +1,6 @@
 use crate::helpers::assert_output_equivalent;
 
-/// Verifies that the service logic from the reference NestJS project
+/// Verifies that the service logic from the reference `NestJS` project
 /// produces identical output in both TypeScript and generated Rust.
 /// This is the REAL equivalence test — not just "does it compile".
 

--- a/tests/src/equivalence/spread.rs
+++ b/tests/src/equivalence/spread.rs
@@ -71,7 +71,7 @@ main();
 #[test]
 fn test_equivalence_object_spread_copy() {
     assert_output_equivalent(
-        r#"
+        r"
 interface Point {
     x: number;
     y: number;
@@ -83,6 +83,6 @@ function main(): void {
     console.log(copy.y);
 }
 main();
-"#,
+",
     );
 }

--- a/tests/src/equivalence/sprint1.rs
+++ b/tests/src/equivalence/sprint1.rs
@@ -5,63 +5,63 @@ use crate::helpers::assert_output_equivalent;
 #[test]
 fn test_equivalence_subtract_assign() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     let x: number = 100;
     x -= 37;
     console.log(x);
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_multiply_assign() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     let x: number = 6;
     x *= 7;
     console.log(x);
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_divide_assign() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     let x: number = 100;
     x /= 4;
     console.log(x);
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_modulo_assign() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     let x: number = 17;
     x %= 5;
     console.log(x);
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_all_assign_ops() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     let a: number = 100;
     a += 10;
@@ -71,7 +71,7 @@ function main(): void {
     console.log(Math.floor(a));
 }
 main();
-"#,
+",
     );
 }
 
@@ -80,70 +80,70 @@ main();
 #[test]
 fn test_equivalence_bitwise_and_assign() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     let x: number = 255;
     x &= 15;
     console.log(x);
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_bitwise_or_assign() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     let x: number = 10;
     x |= 5;
     console.log(x);
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_bitwise_xor_assign() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     let x: number = 12;
     x ^= 6;
     console.log(x);
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_left_shift_assign() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     let x: number = 1;
     x <<= 4;
     console.log(x);
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_right_shift_assign() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     let x: number = 32;
     x >>= 2;
     console.log(x);
 }
 main();
-"#,
+",
     );
 }
 
@@ -188,7 +188,7 @@ main();
 #[test]
 fn test_equivalence_this_method_call() {
     assert_output_equivalent(
-        r#"
+        r"
 class Calculator {
     double(n: number): number {
         return n * 2;
@@ -199,7 +199,7 @@ class Calculator {
 }
 const c: Calculator = new Calculator();
 console.log(c.quadruple(5));
-"#,
+",
     );
 }
 
@@ -214,13 +214,13 @@ console.log(c.quadruple(5));
 #[test]
 fn test_equivalence_date_now_type() {
     assert_output_equivalent(
-        r#"
+        r"
 function main(): void {
     const ts: number = Date.now();
     console.log(ts > 0);
 }
 main();
-"#,
+",
     );
 }
 

--- a/tests/src/equivalence/static_members.rs
+++ b/tests/src/equivalence/static_members.rs
@@ -3,7 +3,7 @@ use crate::helpers::assert_output_equivalent;
 #[test]
 fn test_equivalence_static_method() {
     assert_output_equivalent(
-        r#"
+        r"
 class MathUtils {
     static add(a: number, b: number): number {
         return a + b;
@@ -18,14 +18,14 @@ function main(): void {
     console.log(MathUtils.multiply(5, 6));
 }
 main();
-"#,
+",
     );
 }
 
 #[test]
 fn test_equivalence_static_and_instance() {
     assert_output_equivalent(
-        r#"
+        r"
 class Counter {
     count: number;
     constructor() {
@@ -46,6 +46,6 @@ function main(): void {
     console.log(c.increment());
 }
 main();
-"#,
+",
     );
 }

--- a/tests/src/equivalence/top_level.rs
+++ b/tests/src/equivalence/top_level.rs
@@ -17,12 +17,12 @@ console.log(active);
 #[test]
 fn test_equivalence_top_level_let() {
     assert_output_equivalent(
-        r#"
+        r"
 let counter: number = 0;
 counter = counter + 1;
 counter = counter + 1;
 console.log(counter);
-"#,
+",
     );
 }
 
@@ -39,15 +39,15 @@ console.log(message);
     );
 }
 
-/// Regression test for #186 (UAT-C1): ExprStmt at module level was silently
+/// Regression test for #186 (UAT-C1): `ExprStmt` at module level was silently
 /// dropped because `process_module_item` used `stmt.visit_with(self)`
 /// (children-only traversal) instead of `self.visit_stmt(stmt)`.
 #[test]
 fn test_equivalence_top_level_bare_expr_stmt() {
     assert_output_equivalent(
-        r#"
+        r"
 console.log(1 + 1);
-"#,
+",
     );
 }
 
@@ -71,13 +71,13 @@ if (score >= 70) {
 #[test]
 fn test_equivalence_top_level_for_loop() {
     assert_output_equivalent(
-        r#"
+        r"
 let total: number = 0;
 for (const n of [1, 2, 3, 4, 5]) {
     total = total + n;
 }
 console.log(total);
-"#,
+",
     );
 }
 

--- a/tests/src/helpers.rs
+++ b/tests/src/helpers.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 /// Transpile a TypeScript string to Rust code (no compilation).
 /// This is the primary test helper — fast, no I/O beyond a temp file.
-pub fn transpile(ts_code: &str) -> String {
+pub(crate) fn transpile(ts_code: &str) -> String {
     let tmp = tempfile::Builder::new()
         .suffix(".ts")
         .tempfile()
@@ -19,7 +19,7 @@ pub fn transpile(ts_code: &str) -> String {
 /// - Function declarations (transpiled as Rust functions)
 /// - Top-level statements (wrapped in `fn main()` automatically)
 /// - `console.log()` for observable output
-pub fn assert_output_equivalent(ts_code: &str) {
+pub(crate) fn assert_output_equivalent(ts_code: &str) {
     // 1. Run TypeScript with Node.js
     let ts_output = tyrus_test_utils::run_node(ts_code);
 
@@ -30,7 +30,7 @@ pub fn assert_output_equivalent(ts_code: &str) {
     let rust_binary = if rust_code.contains("fn main()") {
         rust_code.clone()
     } else {
-        format!("{}\nfn main() {{}}", rust_code)
+        format!("{rust_code}\nfn main() {{}}")
     };
 
     // 4. Compile + run Rust
@@ -58,14 +58,14 @@ pub fn assert_output_equivalent(ts_code: &str) {
 ///
 /// On timeout, the child process is killed and the test panics with a message
 /// that names the timeout — preventing nextest from hanging indefinitely.
-pub fn assert_output_equivalent_with_timeout(ts_code: &str, timeout: Duration) {
+pub(crate) fn assert_output_equivalent_with_timeout(ts_code: &str, timeout: Duration) {
     let ts_output = tyrus_test_utils::run_node(ts_code);
     let rust_code = transpile(ts_code);
 
     let rust_binary = if rust_code.contains("fn main()") {
         rust_code.clone()
     } else {
-        format!("{}\nfn main() {{}}", rust_code)
+        format!("{rust_code}\nfn main() {{}}")
     };
 
     let rust_output = tyrus_test_utils::compile_and_run_rust_with_timeout(&rust_binary, timeout);
@@ -86,7 +86,7 @@ pub fn assert_output_equivalent_with_timeout(ts_code: &str, timeout: Duration) {
 }
 
 /// Transpile a fixture file by name (e.g., "tier1/variables").
-pub fn transpile_fixture(fixture: &str) -> String {
+pub(crate) fn transpile_fixture(fixture: &str) -> String {
     let fixture_path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("fixtures")
         .join(format!("{fixture}.ts"));

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -3,6 +3,8 @@
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::panic,
+    clippy::indexing_slicing,
+    clippy::string_slice,
     dead_code,
     unused_imports
 )]

--- a/tests/src/unit/expr.rs
+++ b/tests/src/unit/expr.rs
@@ -75,7 +75,7 @@ fn test_division() {
 
 #[test]
 fn test_string_template_literal() {
-    let rust = transpile(r#"function greet(name: string): string { return `Hello, ${name}!`; }"#);
+    let rust = transpile(r"function greet(name: string): string { return `Hello, ${name}!`; }");
     assert!(rust.contains("format!"), "Expected 'format!' in: {rust}");
     assert!(
         rust.contains("Hello, {}!"),

--- a/tests/src/unit/state_mutation.rs
+++ b/tests/src/unit/state_mutation.rs
@@ -54,10 +54,10 @@ fn assert_no_inline_compound_on_lock(rust: &str) {
 #[test]
 fn compound_addassign_emits_read_then_write() {
     let ts = render_service(
-        r#"
+        r"
     bumpCounter(): void {
         this.counter += 7;
-    }"#,
+    }",
     );
     let rust = transpile(&ts);
 
@@ -80,10 +80,10 @@ fn compound_addassign_emits_read_then_write() {
 #[test]
 fn compound_subassign_emits_read_then_write() {
     let ts = render_service(
-        r#"
+        r"
     drain(amount: number): void {
         this.counter -= amount;
-    }"#,
+    }",
     );
     let rust = transpile(&ts);
     assert_no_inline_compound_on_lock(&rust);
@@ -96,10 +96,10 @@ fn compound_subassign_emits_read_then_write() {
 #[test]
 fn update_expr_postincrement_emits_safe_form() {
     let ts = render_service(
-        r#"
+        r"
     next(): void {
         this.counter++;
-    }"#,
+    }",
     );
     let rust = transpile(&ts);
     // The unsafe form would be `*self.counter.lock(...) += 1f64` (single statement,
@@ -133,10 +133,10 @@ fn dual_read_in_struct_literal_uses_guarded_blocks() {
 #[test]
 fn dual_read_in_call_args_uses_guarded_blocks() {
     let ts = render_service(
-        r#"
+        r"
     range(): number {
         return Math.max(this.counter, this.counter);
-    }"#,
+    }",
     );
     let rust = transpile(&ts);
 
@@ -153,12 +153,12 @@ fn dual_read_in_call_args_uses_guarded_blocks() {
 #[test]
 fn state_compound_assign_compiles() {
     let ts = render_service(
-        r#"
+        r"
     bumpCounter(): void {
         this.counter += 1;
         this.counter -= 1;
         this.counter *= 2;
-    }"#,
+    }",
     );
     let rust = transpile(&ts);
     assert_rust_compiles(&rust);
@@ -180,13 +180,13 @@ fn state_dual_read_compiles() {
 #[test]
 fn state_update_expr_compiles() {
     let ts = render_service(
-        r#"
+        r"
     next(): void {
         this.counter++;
     }
     prev(): void {
         this.counter--;
-    }"#,
+    }",
     );
     let rust = transpile(&ts);
     assert_rust_compiles(&rust);

--- a/tests/src/unit/stdlib.rs
+++ b/tests/src/unit/stdlib.rs
@@ -28,5 +28,5 @@ fn test_console_error() {
 fn test_console_log_variable() {
     let rust = transpile("function f(x: number): void { console.log(x); }");
     assert!(rust.contains("println!"), "Expected 'println!' in: {rust}");
-    assert!(rust.contains("x"), "Expected 'x' in: {rust}");
+    assert!(rust.contains('x'), "Expected 'x' in: {rust}");
 }

--- a/tests/src/unit/tier4_nestjs.rs
+++ b/tests/src/unit/tier4_nestjs.rs
@@ -112,7 +112,7 @@ class ItemsController {
     );
 }
 
-/// Empirical proof point for ADR 0007: adding `@Headers` (a NestJS decorator
+/// Empirical proof point for ADR 0007: adding `@Headers` (a `NestJS` decorator
 /// previously unsupported) required edits to exactly 4 files —
 /// `tyrus_decorator_kinds/src/lib.rs` (one variant + maps),
 /// `tyrus_codegen/src/decorators/params.rs` (one handler),

--- a/tests/tests/tier4_tests.rs
+++ b/tests/tests/tier4_tests.rs
@@ -8,15 +8,13 @@
 #[test]
 fn test_tier4_nestjs_extraction() {
     let current_dir = std::env::current_dir().expect("Failed to get CWD");
-    println!("CWD: {:?}", current_dir);
     // CWD is crates/tests (integration_tests), so fixtures are in fixtures/
     let input_path = current_dir.join("fixtures/tier4_nestjs_di/input.ts");
 
     // Ensure file exists before parsing
     assert!(
         input_path.exists(),
-        "Input file does not exist at: {:?}",
-        input_path
+        "Input file does not exist at: {input_path:?}"
     );
 
     let program = tyrus_parser::parse(&input_path).expect("Failed to parse");
@@ -108,8 +106,7 @@ fn test_tier4_full_build() {
 
     assert!(
         has_service,
-        "CatsService instantiation missing or incorrect: {}",
-        main_content
+        "CatsService instantiation missing or incorrect: {main_content}"
     );
 
     // Check for Controller Instantiation with Dependency
@@ -118,8 +115,7 @@ fn test_tier4_full_build() {
 
     assert!(
         has_controller,
-        "CatsController instantiation missing or incorrect: {}",
-        main_content
+        "CatsController instantiation missing or incorrect: {main_content}"
     );
 
     // Check for Router Merge
@@ -305,9 +301,6 @@ fn verify_endpoint(url: &str, expected_contains: &str) {
     let body = String::from_utf8_lossy(&output.stdout);
     assert!(
         body.contains(expected_contains),
-        "GET {} — expected '{}' in response, got: {}",
-        url,
-        expected_contains,
-        body
+        "GET {url} — expected '{expected_contains}' in response, got: {body}"
     );
 }


### PR DESCRIPTION
## Summary
Implements the R6 amendment and lint modernization (ADR 0013, #215):
- `.cargo/config.toml` rustflags → **`[workspace.lints]`** (idiomatic since Rust 1.74), opted into by all 12 members
- `clippy::pedantic = warn` (priority -1) + 4 curated allows; **R6 additions live**: `indexing_slicing`, `string_slice`, `unwrap_in_result` (test crates keep panicking indexing — the panic is the assert); restriction cherry-picks (`dbg_macro`, `print_*`, `exit`, `mem_forget`); rustc `unreachable_pub` + `missing_debug_implementations`
- **150 violations fixed** across 97 files, zero behavior change (306/306 incl. 102 semantic equivalence): production indexing → slice patterns/`.get()`, manual let-else, unused self → associated fns, `ref_option`/`unnecessary_wraps` signature cleanups, `format_push_string` → `fmt::Write`
- 10 targeted `#[expect]` with reasons (adversarial review verified each one; 2 imprecise reasons rewritten, pre-existing lossy enum cast now tracked in #223)
- One observable **improvement**: argless `.filter()` in input TS now falls back to generic translation instead of panicking the transpiler (Rule 6)

Unit U6 of the standardization RFC. Closes #215

## Test plan
- [x] Full gates on the rebased tree: fmt, clippy --locked (0 errors), filesize, unsafe, machete, deny, audit, nextest 306/306, coverage 78.3% ≥ 73%
- [x] Fresh-context adversarial review (F5, effort xhigh): no CRITICAL/HIGH survived; both MEDIUM/LOW findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQnQN7MkJEqWy75YZH7dNJ