### PR TITLE
feat: stable error codes and categories on TyrusError (Rule 14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,6 +1920,7 @@ name = "tyrus_diagnostics"
 version = "0.1.0"
 dependencies = [
  "miette",
+ "serde",
  "thiserror",
 ]
 

--- a/crates/tyrus_analyzer/src/report.rs
+++ b/crates/tyrus_analyzer/src/report.rs
@@ -75,8 +75,12 @@ pub(crate) fn error_to_json_value(err: &TyrusError) -> Value {
     let code = err
         .code()
         .map_or_else(|| "tyrus::unknown".to_string(), |c| c.to_string());
+    // `errorCode`/`category` are the Rule 14 stable identifiers (additive
+    // fields, schemaVersion stays 1). `code` keeps the miette namespace path.
     json!({
         "code": code,
+        "errorCode": err.stable_code(),
+        "category": err.category(),
         "message": format!("{err}"),
     })
 }
@@ -165,6 +169,8 @@ mod tests {
         let errors = json["errors"].as_array().expect("errors array");
         assert_eq!(errors.len(), 1);
         assert_eq!(errors[0]["code"], "tyrus::lint::no_var");
+        assert_eq!(errors[0]["errorCode"], "TYRUS-E1001");
+        assert_eq!(errors[0]["category"], "analyze");
         assert!(errors[0]["message"].as_str().unwrap_or("").contains("var"));
     }
 
@@ -187,6 +193,7 @@ mod tests {
         let errors = json["errors"].as_array().expect("errors array");
         assert_eq!(errors.len(), 1);
         assert_eq!(errors[0]["code"], "tyrus::validation_error");
+        assert_eq!(errors[0]["errorCode"], "TYRUS-E3002");
     }
 
     #[test]
@@ -194,6 +201,8 @@ mod tests {
         let err = TyrusError::Validation("msg".into());
         let v = error_to_json_value(&err);
         assert_eq!(v["code"], "tyrus::validation_error");
+        assert_eq!(v["errorCode"], "TYRUS-E3002");
+        assert_eq!(v["category"], "io");
         assert!(v["message"].as_str().unwrap_or("").contains("msg"));
     }
 

--- a/crates/tyrus_diagnostics/Cargo.toml
+++ b/crates/tyrus_diagnostics/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 miette = { version = "7.6.0", features = ["fancy"] }
+serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
 
 [lints]

--- a/crates/tyrus_diagnostics/src/lib.rs
+++ b/crates/tyrus_diagnostics/src/lib.rs
@@ -3,6 +3,69 @@
 use miette::{Diagnostic, NamedSource, SourceSpan};
 use thiserror::Error;
 
+/// Pipeline stage a [`TyrusError`] originates from (Rule 14, ADR 0013).
+/// Serialized into the `--json` envelope as a lowercase string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ErrorCategory {
+    Parse,
+    Analyze,
+    Codegen,
+    Io,
+    Format,
+}
+
+impl ErrorCategory {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Parse => "parse",
+            Self::Analyze => "analyze",
+            Self::Codegen => "codegen",
+            Self::Io => "io",
+            Self::Format => "format",
+        }
+    }
+}
+
+impl TyrusError {
+    /// Stable machine-readable code (Rule 14). Codes never change meaning or
+    /// get reused; the leading digit encodes the category block:
+    /// `E0xxx` parse, `E1xxx` analyze, `E2xxx` codegen (reserved),
+    /// `E3xxx` io/input, `E4xxx` format, `E9999` unknown.
+    #[must_use]
+    pub fn stable_code(&self) -> &'static str {
+        match self {
+            Self::ParserError { .. } => "TYRUS-E0001",
+            Self::UseOfVar { .. } => "TYRUS-E1001",
+            Self::UseOfAny { .. } => "TYRUS-E1002",
+            Self::UseOfEval { .. } => "TYRUS-E1003",
+            Self::UnsupportedFeature { .. } => "TYRUS-E1004",
+            Self::AmbiguousMainEntrypoint { .. } => "TYRUS-E1005",
+            Self::IoError(_) => "TYRUS-E3001",
+            Self::Validation(_) => "TYRUS-E3002",
+            Self::FormattingError(_) => "TYRUS-E4001",
+            Self::Unknown => "TYRUS-E9999",
+        }
+    }
+
+    /// Category block of [`Self::stable_code`]. `Unknown` maps to `Io` as the
+    /// catch-all for failures with no attributable pipeline stage.
+    #[must_use]
+    pub fn category(&self) -> ErrorCategory {
+        match self {
+            Self::ParserError { .. } => ErrorCategory::Parse,
+            Self::UseOfVar { .. }
+            | Self::UseOfAny { .. }
+            | Self::UseOfEval { .. }
+            | Self::UnsupportedFeature { .. }
+            | Self::AmbiguousMainEntrypoint { .. } => ErrorCategory::Analyze,
+            Self::IoError(_) | Self::Validation(_) | Self::Unknown => ErrorCategory::Io,
+            Self::FormattingError(_) => ErrorCategory::Format,
+        }
+    }
+}
+
 #[derive(Error, Diagnostic, Debug)]
 pub enum TyrusError {
     #[error("IO Error: {0}")]
@@ -81,4 +144,97 @@ pub enum TyrusError {
     #[error("Unknown Error")]
     #[diagnostic(code(tyrus::unknown))]
     Unknown,
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn named(src: &str) -> NamedSource<String> {
+        NamedSource::new("test.ts", src.to_string())
+    }
+
+    fn span() -> SourceSpan {
+        (0, 1).into()
+    }
+
+    /// One instance of every variant. Adding a variant without extending this
+    /// list still fails the build: `stable_code`/`category` use exhaustive
+    /// matches, so the compiler enforces coverage; this list only feeds the
+    /// uniqueness/format assertions below.
+    fn all_variants() -> Vec<TyrusError> {
+        vec![
+            TyrusError::IoError(std::io::Error::other("io")),
+            TyrusError::ParserError {
+                message: "m".into(),
+                src: named("x"),
+                span: span(),
+            },
+            TyrusError::UseOfVar {
+                src: named("var x;"),
+                span: span(),
+            },
+            TyrusError::UseOfAny {
+                src: named("let a: any;"),
+                span: span(),
+            },
+            TyrusError::UseOfEval {
+                src: named("eval('')"),
+                span: span(),
+            },
+            TyrusError::UnsupportedFeature {
+                feature: "f".into(),
+                src: named("x"),
+                span: span(),
+            },
+            TyrusError::AmbiguousMainEntrypoint {
+                src: named("x"),
+                span: span(),
+            },
+            TyrusError::FormattingError("f".into()),
+            TyrusError::Validation("v".into()),
+            TyrusError::Unknown,
+        ]
+    }
+
+    #[test]
+    fn stable_codes_are_unique() {
+        let variants = all_variants();
+        let codes: HashSet<&str> = variants.iter().map(TyrusError::stable_code).collect();
+        assert_eq!(codes.len(), variants.len(), "duplicate stable code");
+    }
+
+    #[test]
+    fn stable_codes_follow_the_format() {
+        for e in all_variants() {
+            let code = e.stable_code();
+            let digits = code.strip_prefix("TYRUS-E").expect("TYRUS-E prefix");
+            assert_eq!(digits.len(), 4, "{code}: expected 4 digits");
+            assert!(digits.chars().all(|c| c.is_ascii_digit()), "{code}");
+        }
+    }
+
+    #[test]
+    fn code_block_matches_category() {
+        for e in all_variants() {
+            let block = e
+                .stable_code()
+                .strip_prefix("TYRUS-E")
+                .and_then(|d| d.chars().next())
+                .expect("leading digit");
+            let expected = match e.category() {
+                ErrorCategory::Parse => '0',
+                ErrorCategory::Analyze => '1',
+                ErrorCategory::Codegen => '2',
+                ErrorCategory::Io => '3',
+                ErrorCategory::Format => '4',
+            };
+            // Unknown (E9999) is the deliberate exception in the Io catch-all.
+            if e.stable_code() != "TYRUS-E9999" {
+                assert_eq!(block, expected, "{}", e.stable_code());
+            }
+        }
+    }
 }

--- a/tests/src/cli.rs
+++ b/tests/src/cli.rs
@@ -143,6 +143,9 @@ fn test_cli_check_json_envelope_on_missing_file() {
         json["errors"].as_array().is_some_and(|a| !a.is_empty()),
         "envelope must include the IO error"
     );
+    // Rule 14: every error entry carries the stable identifiers.
+    assert_eq!(json["errors"][0]["errorCode"], "TYRUS-E3001");
+    assert_eq!(json["errors"][0]["category"], "io");
     assert!(!output.status.success());
 }
 


### PR DESCRIPTION
## Summary
Implements R14 (ADR 0013, #216):
- Every `TyrusError` variant carries a stable `TYRUS-EXXXX` code and an `ErrorCategory` (parse/analyze/codegen/io/format); the leading digit encodes the category block (E2xxx reserved for codegen)
- `check --json` envelope gains **additive** `errorCode` + `category` fields — schemaVersion stays 1 per the documented bump policy; the miette namespace path stays untouched in `code`
- Exhaustiveness is compiler-enforced (exhaustive matches); uniqueness + format + block-consistency tests added (309 total); CLI/analyzer tests now assert stable codes

Unit U7 of the standardization RFC. Closes #216

## Test plan
- [x] Full gates staged: fmt, clippy --locked, filesize, unsafe, machete, deny, audit, nextest 309/309, coverage 76.5% ≥ 73%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQnQN7MkJEqWy75YZH7dNJ