### PR TITLE
docs: enforce missing_docs on boundary crates with doc-tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,6 @@ must_use_candidate = "allow"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
 module_name_repetitions = "allow"
+
+[workspace.lints.rustdoc]
+broken_intra_doc_links = "deny"

--- a/crates/tyrus_codegen/src/convert/type_mapper.rs
+++ b/crates/tyrus_codegen/src/convert/type_mapper.rs
@@ -135,7 +135,7 @@ pub fn map_ts_type(type_ann: Option<&Box<TsTypeAnn>>) -> TokenStream {
     }
 }
 
-/// Unwraps Promise<T> to T for async function return types
+/// Unwraps `Promise<T>` to `T` for async function return types
 // Why allowed: same SWC-shaped signature as map_ts_type above; relaxing forces
 // Box-unwrapping at every call site.
 #[allow(clippy::borrowed_box)]

--- a/crates/tyrus_common/src/config.rs
+++ b/crates/tyrus_common/src/config.rs
@@ -1,7 +1,12 @@
+//! Transpilation run configuration.
+
 use serde::{Deserialize, Serialize};
 
+/// Input/output locations for a transpilation run.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
+    /// Path of the TypeScript entry file or source directory.
     pub input_path: String,
+    /// Path where the generated Rust project is written.
     pub output_path: String,
 }

--- a/crates/tyrus_common/src/fs.rs
+++ b/crates/tyrus_common/src/fs.rs
@@ -1,5 +1,17 @@
+//! Filesystem newtypes (C-NEWTYPE): a path with transpiler-input meaning,
+//! not an arbitrary `String`/`PathBuf`.
+
 use std::path::{Path, PathBuf};
 
+/// A path to a transpiler input file.
+///
+/// ```
+/// use tyrus_common::fs::FilePath;
+/// use std::path::Path;
+///
+/// let p = FilePath::from("src/main.ts");
+/// assert_eq!(p.as_ref(), Path::new("src/main.ts"));
+/// ```
 #[derive(Debug, Clone)]
 pub struct FilePath(pub PathBuf);
 

--- a/crates/tyrus_common/src/lib.rs
+++ b/crates/tyrus_common/src/lib.rs
@@ -1,4 +1,10 @@
+//! Shared foundation types for the Tyrus workspace: newtypes ([`fs::FilePath`]),
+//! configuration ([`config::Config`]) and case-conversion utilities
+//! ([`util::to_snake_case`], [`util::to_pascal_case`]) consumed by the
+//! analyzer, codegen and orchestrator crates.
 #![forbid(unsafe_code)]
+#![deny(missing_docs)]
+#![warn(clippy::missing_errors_doc)]
 
 pub mod config;
 pub mod fs;

--- a/crates/tyrus_decorator_kinds/src/lib.rs
+++ b/crates/tyrus_decorator_kinds/src/lib.rs
@@ -14,6 +14,8 @@
 //! ```
 
 #![forbid(unsafe_code)]
+#![deny(missing_docs)]
+#![warn(clippy::missing_errors_doc)]
 #![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::todo)]
 
 /// Where in the AST a decorator can appear.
@@ -34,24 +36,35 @@ pub enum DecoratorScope {
 /// in `tyrus_codegen::decorators`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DecoratorKind {
-    // Class-level
+    /// `@Module({...})` — DI module grouping providers/controllers.
     Module,
+    /// `@Injectable()` — provider registered in the DI graph.
     Injectable,
+    /// `@Controller("/path")` — HTTP controller with a route prefix.
     Controller,
+    /// `@UseGuards(...)` — middleware guard applied to a class or method.
     UseGuards,
 
-    // Method-level
+    /// `@Get("/path")` route handler.
     HttpGet,
+    /// `@Post("/path")` route handler.
     HttpPost,
+    /// `@Put("/path")` route handler.
     HttpPut,
+    /// `@Delete("/path")` route handler.
     HttpDelete,
+    /// `@Patch("/path")` route handler.
     HttpPatch,
+    /// `@HttpCode(n)` — overrides the response status code.
     HttpCode,
 
-    // Param-level
+    /// `@Body()` — deserialized request body parameter.
     Body,
+    /// `@Param("name")` — path parameter.
     Param,
+    /// `@Query("name")` — query-string parameter.
     Query,
+    /// `@Headers()` — request headers map.
     Headers,
 }
 

--- a/crates/tyrus_diagnostics/src/lib.rs
+++ b/crates/tyrus_diagnostics/src/lib.rs
@@ -1,4 +1,9 @@
+//! Central error type ([`TyrusError`]) and stable error taxonomy
+//! ([`ErrorCategory`], `TYRUS-EXXXX` codes — Rule 14) for the whole pipeline,
+//! rendered through `miette` for terminal diagnostics.
 #![forbid(unsafe_code)]
+#![deny(missing_docs)]
+#![warn(clippy::missing_errors_doc)]
 #![allow(unused_assignments)]
 use miette::{Diagnostic, NamedSource, SourceSpan};
 use thiserror::Error;
@@ -8,14 +13,20 @@ use thiserror::Error;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ErrorCategory {
+    /// Lexing/parsing of the TypeScript source (SWC).
     Parse,
+    /// Semantic analysis: lint rules and unsupported-API detection.
     Analyze,
+    /// Rust code generation (reserved — no codegen-stage errors yet).
     Codegen,
+    /// Filesystem/input errors, including CLI input validation.
     Io,
+    /// Formatting of the generated Rust source.
     Format,
 }
 
 impl ErrorCategory {
+    /// Lowercase name used in the `--json` envelope.
     #[must_use]
     pub fn as_str(self) -> &'static str {
         match self {
@@ -66,55 +77,75 @@ impl TyrusError {
     }
 }
 
+/// Every failure the Tyrus pipeline can produce. Each variant carries a
+/// stable code ([`Self::stable_code`]) and category ([`Self::category`]).
 #[derive(Error, Diagnostic, Debug)]
 pub enum TyrusError {
     #[error("IO Error: {0}")]
     #[diagnostic(code(tyrus::io_error))]
+    /// Underlying filesystem/IO failure (`TYRUS-E3001`).
     IoError(#[from] std::io::Error),
 
     #[error("Parsing Error: {message}")]
     #[diagnostic(code(tyrus::parse_error))]
+    /// SWC could not parse the input (`TYRUS-E0001`).
     ParserError {
+        /// Parser-provided description of the syntax problem.
         message: String,
+        /// Source file the diagnostic points into.
         #[source_code]
         src: NamedSource<String>,
+        /// Offending region within `src`.
         #[label("{message}")]
         span: SourceSpan,
     },
 
     #[error("Lint Error: Rust does not support 'var'. Use 'let' or 'const'.")]
     #[diagnostic(code(tyrus::lint::no_var))]
+    /// Lint: `var` declaration (`TYRUS-E1001`).
     UseOfVar {
+        /// Source file the diagnostic points into.
         #[source_code]
         src: NamedSource<String>,
+        /// Offending region within `src`.
         #[label("replace 'var' with 'let' or 'const'")]
         span: SourceSpan,
     },
 
     #[error("Lint Error: Rust requires strict typing. 'any' is not allowed.")]
     #[diagnostic(code(tyrus::lint::no_any))]
+    /// Lint: `any` type (`TYRUS-E1002`).
     UseOfAny {
+        /// Source file the diagnostic points into.
         #[source_code]
         src: NamedSource<String>,
+        /// Offending region within `src`.
         #[label("specify a concrete type")]
         span: SourceSpan,
     },
 
     #[error("Lint Error: Code injection via 'eval' is unsafe and not supported in Rust.")]
     #[diagnostic(code(tyrus::lint::no_eval))]
+    /// Lint: `eval` call (`TYRUS-E1003`).
     UseOfEval {
+        /// Source file the diagnostic points into.
         #[source_code]
         src: NamedSource<String>,
+        /// Offending region within `src`.
         #[label("remove 'eval' usage")]
         span: SourceSpan,
     },
 
     #[error("Unsupported Feature: {feature} is not yet supported in Tyrus.")]
     #[diagnostic(code(tyrus::unsupported))]
+    /// Construct outside the Oxidizable subset (`TYRUS-E1004`).
     UnsupportedFeature {
+        /// Human-readable name of the unsupported construct.
         feature: String,
+        /// Source file the diagnostic points into.
         #[source_code]
         src: NamedSource<String>,
+        /// Offending region within `src`.
         #[label("this feature is pending implementation")]
         span: SourceSpan,
     },
@@ -126,23 +157,29 @@ pub enum TyrusError {
          statements inside `main()`, or remove the user-declared `main` function."
     )]
     #[diagnostic(code(tyrus::lint::ambiguous_main_entrypoint))]
+    /// `function main()` plus top-level statements in one file (`TYRUS-E1005`).
     AmbiguousMainEntrypoint {
+        /// Source file the diagnostic points into.
         #[source_code]
         src: NamedSource<String>,
+        /// Offending region within `src`.
         #[label("first top-level statement here")]
         span: SourceSpan,
     },
 
     #[error("Formatting Error: {0}")]
     #[diagnostic(code(tyrus::fmt_error))]
+    /// `prettyplease`/`syn` rejected the generated source (`TYRUS-E4001`).
     FormattingError(String),
 
     #[error("Validation Error: {0}")]
     #[diagnostic(code(tyrus::validation_error))]
+    /// CLI/input validation failure (`TYRUS-E3002`).
     Validation(String),
 
     #[error("Unknown Error")]
     #[diagnostic(code(tyrus::unknown))]
+    /// Catch-all with no attributable stage (`TYRUS-E9999`).
     Unknown,
 }
 


### PR DESCRIPTION
## Summary
Boundary-crate documentation hardening (R14 follow-through + Rust API Guidelines):
- `tyrus_common`, `tyrus_decorator_kinds`, `tyrus_diagnostics`: `#![deny(missing_docs)]` + `#![warn(clippy::missing_errors_doc)]` — every public item documented
- Doc-tests as executable contracts: `FilePath`, `to_snake_case`/`to_pascal_case`, `DecoratorKind::from_name` (4 passing)
- Workspace-wide `rustdoc::broken_intra_doc_links = deny`; fixed one invalid-HTML-tag (`Promise<T>` unescaped) — `cargo doc --workspace` builds clean

Unit U8 of the standardization RFC.

## Test plan
- [x] Full gates staged: fmt, clippy --locked, nextest 309/309, cargo doc clean, doc-tests 4/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQnQN7MkJEqWy75YZH7dNJ