### PR TITLE
feat: version the Claude Code harness — rules, agents, skills, hooks

### DIFF
--- a/.claude/agents/tyrus-codegen.md
+++ b/.claude/agents/tyrus-codegen.md
@@ -1,0 +1,34 @@
+---
+name: tyrus-codegen
+description: Codegen specialist for the Tyrus transpiler. Use for any change under crates/tyrus_codegen — new TS constructs, decorator handlers, stdlib mappings, emission bugs. Works SWC AST → quote! tokens.
+tools: [Read, Edit, Write, Bash, Grep, Glob]
+---
+
+You implement code generation for Tyrus (TypeScript → Rust transpiler).
+
+## Binding constraints (restated per F8 — you do NOT inherit session context)
+
+- Normative docs: `docs/standards/POWER_OF_TEN.md` (14 rules) and
+  `docs/standards/DEVELOPMENT_FLOW.md` (F1–F10). Read the rule you're about to
+  touch before coding.
+- **R7:** emit Rust ONLY via `quote!`/`TokenStream`. No `format!` of Rust source
+  under `src/convert/`.
+- **R8:** name-keyed logic goes through registries. New decorator = 1 handler file +
+  1 `register_*` line + 1 `DecoratorKind` variant. Never raw string-compare decorator
+  names — always `DecoratorKind::from_name`.
+- **R6:** no `.unwrap()/.expect()/panic!/todo!/dbg!`, no `x[i]` indexing (use slice
+  patterns/`.get()`). Unsupported input emits `compile_error!("Tyrus: …")`.
+- **R4:** functions ≤ 50 lines (targeted `#[expect(clippy::too_many_lines, reason)]`
+  only for coherent quote! templates), files ≤ 400 lines.
+- **R5/F2:** write the semantic equivalence test in `tests/src/equivalence/` FIRST
+  (RED), then implement (GREEN). Refactors: green `cargo insta review` instead.
+- Commits: `<type>: description` (Conventional Commits, English, no vague subjects).
+- Validate with `export PATH="$HOME/.cargo/bin:$PATH"` then
+  `cargo clippy --workspace --all-targets --locked` and
+  `cargo nextest run --workspace` before reporting done (F4/F6 — observed output,
+  never "looks correct").
+
+## Report format
+
+Return: what changed (files), the RED→GREEN test evidence (test name + observed
+stdout equivalence), clippy/nextest results, and any `#[expect]` added with reasons.

--- a/.claude/agents/tyrus-docs.md
+++ b/.claude/agents/tyrus-docs.md
@@ -1,0 +1,29 @@
+---
+name: tyrus-docs
+description: Documentation synchronizer for Tyrus (F7). Use when a change alters counts, module trees, commands, rules, or ADRs — updates every document that states them in the same PR.
+tools: [Read, Edit, Write, Bash, Grep, Glob]
+effort: low
+---
+
+You keep Tyrus documentation synchronized with reality (F7, DEVELOPMENT_FLOW.md).
+
+## Binding constraints (restated per F8)
+
+- Documents that state facts about the code: `README.md`, `README.pt-br.md`,
+  `docs/ARCHITECTURE.md` (incl. the ADR index — F9: updated in the same commit as
+  any new ADR), `docs/specs/GRAMMAR.md`, `docs/standards/*.md`, `CLAUDE.md`
+  (quick-reference table), `CONTRIBUTING.md`.
+- **NEVER edit `CHANGELOG.md`** — release-plz owns it.
+- Verify every number you write by counting (`cargo nextest run` summary for test
+  counts, `ls` for module trees, `gh` for issue/PR references). Never copy a count
+  from another document — documents are exactly what drifted.
+- Official docs are ENGLISH (STANDARDIZATION_PLAN §3); `README.pt-br.md` is the
+  only Portuguese artifact.
+- Enforcement claims follow the honest-enforcement rule (ADR 0013): a mechanism is
+  either active (name the gate/lint/test) or pending (name the tracking issue).
+  Never write an aspirational claim as active.
+
+## Report format
+
+Return: files touched, each factual claim you corrected (old → new), and the
+command you used to verify each number.

--- a/.claude/agents/tyrus-reviewer.md
+++ b/.claude/agents/tyrus-reviewer.md
@@ -1,0 +1,28 @@
+---
+name: tyrus-reviewer
+description: Adversarial fresh-context reviewer for Tyrus diffs (F5 second layer). Read-only — reports findings, never edits. Use after any implementation slice and before every PR.
+tools: [Read, Bash, Grep, Glob]
+effort: xhigh
+---
+
+You are the fresh-context adversarial reviewer for Tyrus (F5, DEVELOPMENT_FLOW.md).
+You did not write this diff; your job is to refute it. Read-only: NEVER edit files.
+
+## Method
+
+1. Read the diff you're given (file path or ref range), then read the CURRENT code
+   around every finding — confirm against the repo, not the diff hunk.
+2. Focus on risk, not style: semantic changes hiding in mechanical rewrites,
+   fallbacks that silently swallow what used to be noisy, signature changes with
+   missed call sites, `#[expect]` reasons that assert unguarded invariants,
+   POWER_OF_TEN rule violations (14 rules), and claims in docs/comments that the
+   code does not back ("aspirational enforcement" is a known project disease).
+3. For each candidate finding, actively try to refute it first. Report only
+   survivors, labeled CONFIRMED (you verified in code) or PLAUSIBLE (could not
+   fully verify), with severity CRITICAL/HIGH/MEDIUM/LOW, `file:line`, and a
+   concrete failure scenario (input → wrong output).
+4. CRITICAL/HIGH block merge (F5). If nothing survives, say APPROVED with a
+   one-paragraph justification of what you checked.
+
+Binding references: `docs/standards/POWER_OF_TEN.md`, `docs/standards/DEVELOPMENT_FLOW.md`,
+ADRs 0007/0009/0010/0012/0013. Respond in Portuguese.

--- a/.claude/agents/tyrus-tester.md
+++ b/.claude/agents/tyrus-tester.md
@@ -1,0 +1,31 @@
+---
+name: tyrus-tester
+description: Test engineer for Tyrus. Use to write equivalence/snapshot/compilation tests, reproduce bugs as failing tests (RED), or extend fixture tiers. Enforces test-first (F2).
+tools: [Read, Edit, Write, Bash, Grep, Glob]
+---
+
+You write and maintain tests for Tyrus (TypeScript → Rust transpiler).
+
+## Binding constraints (restated per F8)
+
+- Test architecture: `tests/src/{unit,snapshot,compilation,equivalence}` + CLI tests
+  in `tests/src/cli.rs` + E2E in `tests/tests/tier4_tests.rs`. Crate name:
+  `integration_tests`. Behavior claims are proven by the `equivalence/` layer:
+  Node 22 stdout ≡ compiled Rust stdout, byte-for-byte.
+- **F2:** a bug reproduction is a FAILING test first. Confirm it fails on the current
+  tree before any fix exists; paste the observed failure in your report.
+- Fixture TS must be valid TypeScript unless it exists to exercise the analyzer
+  (`tests/fixtures/invalid/`). Ports 3000–3002 forbidden; 3100 belongs to the HTTP
+  equivalence test.
+- Test code may use `.expect()`/indexing — crate-level allows already exist; do not
+  widen them. Never edit production code to make a test pass unless the task says
+  the production code is the bug.
+- insta: `cargo insta review` accepted snapshots ship in the same change.
+- Run everything with `export PATH="$HOME/.cargo/bin:$PATH"`; prefer
+  `cargo nextest run --workspace`; build the workspace first if CLI tests are in
+  scope (`cargo build --workspace --all-targets` — assert_cmd needs the bin).
+
+## Report format
+
+Return: tests added (names + layer), RED evidence (observed failure) where
+applicable, final nextest summary line, and coverage impact if measured.

--- a/.claude/hooks/commit-msg-guard.sh
+++ b/.claude/hooks/commit-msg-guard.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# PreToolUse guard (Bash): validates `git commit` messages against the
+# repo convention (`<type>: description`, Conventional Commits, R11)
+# before the command runs. Exit 2 blocks; anything else passes.
+
+set -u
+payload=$(cat)
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+cmd=$(jq -r '.tool_input.command // empty' <<<"$payload")
+[ -z "$cmd" ] && exit 0
+
+case "$cmd" in
+  *"git commit"*) ;;
+  *) exit 0 ;;
+esac
+
+# Extract the first -m argument (subject line). Amend/no-message forms pass.
+subject=$(printf '%s' "$cmd" | grep -oP -- '-m\s+"([^"\n]+)' | head -1 | sed 's/-m\s*"//')
+[ -z "$subject" ] && exit 0
+
+if ! grep -qE '^(feat|fix|refactor|docs|test|chore|perf|ci|style|build|revert)(\([a-z0-9._#/-]+\))?!?: .{8,}' <<<"$subject"; then
+  echo "BLOCKED (R11/F1): commit subject must be '<type>: description' (Conventional Commits)." >&2
+  echo "Got: $subject" >&2
+  exit 2
+fi
+
+if grep -qiE '^(feat|fix|refactor|docs|test|chore|perf|ci|style|build|revert)(\([^)]*\))?!?: *(fix|ajustes?|updates?|wip|stuff|misc|changes?)\.?$' <<<"$subject"; then
+  echo "BLOCKED (R11/F1): vague commit subject. Say WHAT changed and WHY." >&2
+  echo "Got: $subject" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/rust-guard.sh
+++ b/.claude/hooks/rust-guard.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# PreToolUse guard (Edit/Write): blocks Rule 6/7 violations at edit time,
+# before clippy ever runs. Deterministic layer of POWER_OF_TEN.md — the
+# gates remain the authoritative check; this only fails fast on the
+# obvious cases. Exit 2 blocks the tool call; anything else lets it pass.
+
+set -u
+payload=$(cat)
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+file_path=$(jq -r '.tool_input.file_path // empty' <<<"$payload")
+new_text=$(jq -r '.tool_input.content // .tool_input.new_string // empty' <<<"$payload")
+
+[ -z "$file_path" ] && exit 0
+[ -z "$new_text" ] && exit 0
+
+case "$file_path" in
+  *crates/*/src/*.rs) ;;
+  *) exit 0 ;;
+esac
+
+# Test modules legitimately use expect/panicking asserts (Rule 6 carve-out).
+if grep -qE '#\[cfg\(test\)\]|#\[test\]' <<<"$new_text"; then
+  exit 0
+fi
+
+# Rule 6 — forbidden panic constructs in production code.
+banned=$(grep -nE '\.unwrap\(\)|\.expect\(|panic!\(|todo!\(|unimplemented!\(|dbg!\(' <<<"$new_text" || true)
+if [ -n "$banned" ]; then
+  echo "BLOCKED (Rule 6, POWER_OF_TEN.md): panic construct in production code:" >&2
+  echo "$banned" | head -5 >&2
+  echo "Use Result<T, TyrusError>, ?, .get(), or compile_error! in generated code." >&2
+  echo "Test code goes in #[cfg(test)] modules with #[allow(clippy::expect_used)]." >&2
+  exit 2
+fi
+
+# Rule 7 — string-assembled Rust source inside codegen conversion modules.
+case "$file_path" in
+  *crates/tyrus_codegen/src/convert/*)
+    if grep -qE 'format!\("(fn |pub |impl |struct |use )' <<<"$new_text"; then
+      echo "BLOCKED (Rule 7, POWER_OF_TEN.md): string-concatenated Rust in convert/." >&2
+      echo "Emit tokens with quote! — never format! of Rust source." >&2
+      exit 2
+    fi
+    ;;
+esac
+
+exit 0

--- a/.claude/rules/analyzer.md
+++ b/.claude/rules/analyzer.md
@@ -1,0 +1,27 @@
+---
+paths:
+  - "crates/tyrus_analyzer/**"
+  - "crates/tyrus_diagnostics/**"
+---
+
+# Analyzer & Diagnostics Rules (binding — R14, envelope contract)
+
+- **JSON envelope is a public contract** (`report.rs`): `schemaVersion` is 1. Adding
+  fields consumers can ignore = allowed without bump. Renaming/removing/retyping a
+  field or changing `status` semantics = breaking → bump the version and document in
+  the PR (release-plz owns CHANGELOG). `status` reflects hard errors only; `--strict`
+  affects exit code, never `status`.
+- **R14:** every `TyrusError` variant carries a unique stable code (`TYRUS-EXXXX`) and
+  an `ErrorCategory`. New variant = new code in the correct block (E0 parse, E1 analyze,
+  E2 codegen, E3 io, E4 format) + arm in `stable_code()`/`category()` (compiler enforces
+  exhaustiveness) + instance in the `all_variants()` test list. Codes are never reused
+  or renumbered. Tests assert codes, never message text.
+- Hard errors (lint violations: `var`, `any`, `eval`, for-in, delete, with, labeled
+  statements, ambiguous main) are `TyrusError`. Soft findings (blocked APIs like
+  `setTimeout`, `document`) are `Diagnostic` with severity — they only become fatal
+  under `--strict`.
+- Spans: `LintVisitor` subtracts 1 from SWC's `span.lo` offset. Keep new visitors
+  consistent with that convention (divergence here already produced off-by-one labels).
+- `tyrus_diagnostics` and `tyrus_common`/`tyrus_decorator_kinds` are boundary crates:
+  `#![deny(missing_docs)]` — every new public item needs a doc comment; doc-tests are
+  the preferred spec for pure functions.

--- a/.claude/rules/codegen.md
+++ b/.claude/rules/codegen.md
@@ -1,0 +1,31 @@
+---
+paths:
+  - "crates/tyrus_codegen/**"
+---
+
+# Codegen Rules (binding — R7/R8, ADRs 0007/0012)
+
+- **R7:** Rust is emitted through `quote!`/`proc_macro2::TokenStream` ONLY. `format!`
+  of Rust source is forbidden anywhere under `src/convert/`. The single string-Rust
+  touchpoint in the workspace is `tyrus_orchestrator::format`.
+- **R8 (two layers):** structural translation dispatches by AST node *type*; anything
+  keyed by *name* (decorators, stdlib calls, framework symbols) goes through a registry.
+  Scattered `match name { "X" => … }` arms across files are forbidden. Adding a NestJS
+  decorator costs exactly: 1 handler file in `src/decorators/` + 1 `register_*` line in
+  `default_registry()` + 1 variant in `tyrus_decorator_kinds::DecoratorKind`.
+- Decorator name → kind classification happens ONLY via `DecoratorKind::from_name`.
+  Never compare decorator names with raw strings. Unknown decorators are silently
+  skipped, never an error.
+- **ADR 0012 boundary:** array methods needing IR context (map/filter/forEach/some/
+  every/reduce/push/replace) live in `convert/expr/call_array.rs`; pure `Vec` ops live
+  in `stdlib/array.rs`. A handler that can't decide returns `None` to defer — it never
+  panics (invalid TS degrades to the generic translation; the generated `cargo build`
+  surfaces the error).
+- Unsupported constructs in generated code emit `compile_error!("Tyrus: …")` — never
+  `todo!()` and never a silent wrong translation.
+- String-vs-array method dispatch relies on `string_vars`/`map_vars`/`set_vars` state
+  on `RustGenerator` — that state is per-file and not lexically scoped; when touching
+  it, note the collision risk across same-named variables in one file.
+- **R5/F2:** every change that affects emitted Rust ships a semantic equivalence test
+  in `tests/src/equivalence/` written RED first (Node stdout ≡ compiled Rust stdout).
+  Pure refactors instead require a green `cargo insta review` diff.

--- a/.claude/rules/orchestrator.md
+++ b/.claude/rules/orchestrator.md
@@ -1,0 +1,24 @@
+---
+paths:
+  - "crates/tyrus_orchestrator/**"
+---
+
+# Orchestrator Rules (binding — ADRs 0009/0010)
+
+- **Formatter contract (ADR 0010):** `format::format_code` guarantees idempotence,
+  error propagation (`TyrusError::FormattingError` — never silent passthrough), and
+  no bypass marker in output. Any change to formatting must keep the three property
+  tests green; swapping the formatter requires an ADR.
+- `format.rs` is the workspace's ONLY permitted string-Rust touchpoint (R7 exception)
+  — pre-validated `&'static str` blocks (`get_app_error_*`) and layout only. Do not
+  grow that exception.
+- **Mutex protocol (ADR 0009):** generated `@Injectable` state uses block-scoped
+  reads and read-then-write splits for compound assignments; every generated `.lock()`
+  uses `.unwrap_or_else(|e| e.into_inner())`. Orchestrator/scaffold changes must not
+  produce code paths holding two guards at once.
+- Scaffold output must be DETERMINISTIC: never iterate a `HashMap` directly into
+  emitted code — sort or use the DI topological order. (A nondeterministic fallback
+  in `generate_main_rs` was a known defect class here.)
+- Analyzer errors during `build_project` currently print warnings instead of failing
+  the build — that is bug #188 (UAT CRITICAL), not a pattern to imitate. New pipeline
+  code fails fast on analyzer errors.

--- a/.claude/rules/rust-core.md
+++ b/.claude/rules/rust-core.md
@@ -1,0 +1,25 @@
+---
+paths:
+  - "crates/**/*.rs"
+---
+
+# Rust Core Rules (binding — POWER_OF_TEN.md R4/R6/R13)
+
+- **Never** emit `.unwrap()`, `.expect(`, `panic!`, `todo!`, `unimplemented!`, `dbg!`,
+  `x[i]` indexing, or `&s[a..b]` slicing in production code. Use `Result<T, TyrusError>`,
+  `?`, `.get()`, slice patterns (`if let [a, b] = xs`). Test modules may use
+  `.expect("msg")` under `#[allow(clippy::expect_used)]`.
+- Functions ≤ 50 lines, ≤ 5 params, nesting ≤ 4; files ≤ 400 lines (`gates.sh filesize`).
+  Escape hatch: `#[expect(clippy::too_many_lines, reason = "…")]` only for coherent
+  `quote!` templates — never `#[allow]`, always with a written reason.
+- Every crate root carries `#![forbid(unsafe_code)]` (R13). Never remove it; new crates
+  must add it (the `unsafe` gate fails otherwise).
+- Lint policy lives ONLY in `[workspace.lints]` (root Cargo.toml). Never add rustflags
+  to `.cargo/config.toml`, and never add crate-root lint attributes that duplicate the
+  workspace table.
+- Prefer `&self` over `&mut self`; `pub(crate)` over `pub` for internal APIs; newtypes
+  over raw `String`/`PathBuf` for domain values (see `tyrus_common::fs::FilePath`).
+- Comments state only the non-obvious *why*, in English, ≤ 4 lines. Never narrate what
+  a line does, never reference the review/PR process.
+- Before pushing: `./scripts/gates.sh all` green locally (F4). If run staged, every
+  gate must pass on the exact pushed tree and the commit body must say so.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,25 @@
+---
+paths:
+  - "tests/**"
+  - "crates/tyrus_test_utils/**"
+---
+
+# Testing Rules (binding — R5, F2, F6)
+
+- **Layer selection** (`tests/src/`): `unit/` asserts on generated Rust text (fast);
+  `snapshot/` uses insta on fixtures; `compilation/` runs real `cargo check`;
+  `equivalence/` is the load-bearing layer — run the TS in Node 22 and the compiled
+  Rust, compare stdout byte-for-byte. Behavior changes REQUIRE an equivalence test
+  written RED first (F2); "the code looks right" is never done (F6).
+- Helpers: `transpile()`, `assert_output_equivalent()` (+ `_with_timeout` for
+  deadlock-prone paths — prefer it for mutex/state tests), `transpile_fixture()`.
+  Test crate name is `integration_tests` (`cargo test -p integration_tests`).
+- Fixtures live in `tests/fixtures/tier1..tier4` + `invalid/` + `uat/`. Fixture TS
+  must be VALID TypeScript (tsc-clean) unless it exists to exercise the analyzer.
+- Ports: never 3000–3002 (dev machines); the HTTP equivalence test owns 3100.
+- insta: never commit `.snap.new`; run `cargo insta review` and commit the accepted
+  snapshot in the same PR as the codegen change.
+- Test code MAY use `.expect()`/panicking indexing — the crate roots already carry
+  the scoped `#![allow]`s; do not widen them.
+- Shared compile cache: generated-code tests build into `$TMPDIR/tyrus_test_target`.
+  If disk pressure strikes, delete that dir (rebuildable) — never `~/.cargo`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,56 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(cargo build*)",
+      "Bash(cargo check*)",
+      "Bash(cargo clippy*)",
+      "Bash(cargo fmt*)",
+      "Bash(cargo test*)",
+      "Bash(cargo nextest*)",
+      "Bash(cargo insta*)",
+      "Bash(cargo doc*)",
+      "Bash(cargo bench*)",
+      "Bash(cargo deny*)",
+      "Bash(cargo audit*)",
+      "Bash(cargo machete*)",
+      "Bash(cargo llvm-cov*)",
+      "Bash(./scripts/gates.sh*)",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git branch*)",
+      "Bash(gh pr view*)",
+      "Bash(gh pr checks*)",
+      "Bash(gh issue view*)",
+      "Bash(gh issue list*)",
+      "Bash(gh run view*)"
+    ],
+    "deny": [
+      "Bash(git push --force*)",
+      "Bash(rm -rf /*)",
+      "Read(.env*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/rust-guard.sh\""
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/commit-msg-guard.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/doc-sync/SKILL.md
+++ b/.claude/skills/doc-sync/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: doc-sync
+description: Synchronize every Tyrus document that states counts, trees, commands or rules (F7). Use inside any PR that changes those facts, or standalone to repay doc drift.
+---
+
+# /doc-sync — make the documents match reality
+
+1. Establish ground truth by MEASURING (never by copying from another doc):
+   - test count: `cargo nextest run --workspace` summary line
+   - crate/module trees: `ls crates/ crates/tyrus_codegen/src/**`
+   - rule/gate lists: `docs/standards/POWER_OF_TEN.md` + `scripts/gates.sh` dispatcher
+   - ADR list: `ls docs/architecture/decisions/`
+2. Sync targets: `README.md`, `README.pt-br.md`, `docs/ARCHITECTURE.md` (incl. ADR
+   index), `docs/specs/GRAMMAR.md`, `CONTRIBUTING.md`, `CLAUDE.md` quick table,
+   `benches/README.md`. **Never `CHANGELOG.md`** (release-plz owns it).
+3. Enforcement claims follow ADR 0013 honest-enforcement: active mechanisms name the
+   gate/lint/test; pending ones name the tracking issue. No aspirational claims.
+4. Known chronic drift points (check every run): test counts, "N crates/N rules"
+   phrases, codegen module tree (decorators/, stdlib/, expr/call_array.rs,
+   type_decl.rs, integer_heuristic.rs), lint-rule counts, benches README describing
+   nonexistent benchmarks.
+5. Dispatch `tyrus-docs` for the mechanical pass when delegating; review its old→new
+   claim list against your measurements.

--- a/.claude/skills/gates/SKILL.md
+++ b/.claude/skills/gates/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: gates
+description: Run the Tyrus quality gates (scripts/gates.sh) and interpret failures. Use before any push (F4), after implementation slices, or when CI is red and you need the local reproduction.
+---
+
+# /gates — run and interpret the quality gates
+
+1. `export PATH="$HOME/.cargo/bin:$PATH"` (cargo may be absent from non-interactive shells).
+2. Prefer the staged sequence over one monolithic run (long single processes have been
+   killed on this machine; F4 permits staging when every gate passes on the same tree):
+   - `./scripts/gates.sh fmt && ./scripts/gates.sh clippy && ./scripts/gates.sh filesize && ./scripts/gates.sh unsafe && ./scripts/gates.sh machete`
+   - `cargo build --workspace --all-targets --locked` (CLI tests need the `tyrus` bin)
+   - `./scripts/gates.sh test`
+   - `./scripts/gates.sh deny && ./scripts/gates.sh audit`
+   - `./scripts/gates.sh coverage`
+3. **Never read pass/fail through a pipe** (`| tail` masks exit codes — a repeated
+   incident here). Check `$?` of the gate command itself, or run it bare.
+4. On failure, fix locally — CI is a verifier, never a debugger (F4). Known failure
+   modes: missing `tyrus` binary → build first; ENOSPC → delete
+   `$TMPDIR/tyrus_test_target`, `target/llvm-cov-target` (rebuildable), check `df -h /`;
+   new RUSTSEC advisory → `cargo update -p <crate>`; new toolchain lint → fix code,
+   never blanket-allow.
+5. Report the per-gate verdicts and the coverage TOTAL line, with exit codes observed.
+
+$ARGUMENTS: optional single gate name (fmt|clippy|filesize|unsafe|test|coverage|deny|audit|machete).

--- a/.claude/skills/new-decorator/SKILL.md
+++ b/.claude/skills/new-decorator/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: new-decorator
+description: Add support for a NestJS decorator via the registry (R8/ADR 0007) — the one-file-plus-two-lines path. Use whenever a new @Decorator must be recognized.
+---
+
+# /new-decorator — the R8-compliant path (nothing else is acceptable)
+
+Adding decorator `@X` touches EXACTLY:
+
+1. `crates/tyrus_decorator_kinds/src/lib.rs` — new `DecoratorKind` variant (documented
+   — the crate denies missing_docs) + arm in `from_name` + scope in `scope()`.
+2. `crates/tyrus_codegen/src/decorators/<x>.rs` — ONE handler file implementing the
+   trait for its scope (`ClassDecoratorHandler` / `MethodDecoratorHandler` /
+   `ParamDecoratorHandler`).
+3. `crates/tyrus_codegen/src/decorators/mod.rs` — ONE `register_*` line in
+   `default_registry()`.
+4. Tests: equivalence test (F2, RED first) exercising the decorator end-to-end, plus
+   a handler isolation unit test.
+
+**Forbidden:** touching `convert/class/*` or `convert/interface.rs` for dispatch,
+raw string comparison of decorator names, `match name { "X" => … }` anywhere. If the
+decorator seems to need more than the four touchpoints above, STOP — that's an R8
+violation or a registry gap; open an issue/ADR instead of hacking around it.
+
+Precedent: ADR 0007 (`docs/architecture/decisions/0007-decorator-registry.md`);
+`@Headers` in `decorators/params.rs` is the reference implementation.
+
+$ARGUMENTS: decorator name + semantics (e.g. "@Redirect(url, status)").

--- a/.claude/skills/pre-pr/SKILL.md
+++ b/.claude/skills/pre-pr/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: pre-pr
+description: Full F5/F7 pre-PR checklist for Tyrus — gates, fresh-context adversarial review, doc sync, and PR body requirements. Use when an implementation slice is ready to become a PR.
+---
+
+# /pre-pr — everything that must be true before opening a PR
+
+1. **F1:** an issue exists and the branch is `<type>/<slug>`; the PR will `Closes #N`.
+2. **F4:** run `/gates` (all nine green on this exact tree). If staged, the commit
+   body says so.
+3. **F5:** dispatch `tyrus-reviewer` (fresh context, read-only) on the diff
+   (`git diff main...HEAD` written to a scratch file — never pasted inline).
+   CRITICAL/HIGH findings: fix and re-review. MEDIUM: fix or open an issue. Never
+   tell the reviewer what not to flag.
+4. **F2/F6:** for behavior changes, the PR body links the test that was RED first
+   and pastes observed output (equivalence stdout, CLI exit codes, HTTP responses).
+5. **F7:** if the change altered counts/trees/commands/rules, run `/doc-sync` — docs
+   ship in this same PR. CHANGELOG.md untouched (release-plz).
+6. **F9:** architecture-shaped change (R10 triggers) → the ADR merged before or
+   within this PR, and the ADR index updated in the same commit.
+7. PR body sections: Summary (what + why), `Closes #N`, Test plan with observed
+   results. Conventional Commit title.
+8. After opening: watch CI with a poll loop on `gh pr checks <n>` (this repo's `gh`
+   has no `--json` for checks — parse the tab-separated table).

--- a/.claude/skills/tdd-codegen/SKILL.md
+++ b/.claude/skills/tdd-codegen/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: tdd-codegen
+description: RED→GREEN workflow for Tyrus codegen changes (F2/R5). Use when adding or fixing any TS construct translation — writes the semantic equivalence test first, then implements.
+---
+
+# /tdd-codegen — equivalence-test-first codegen work
+
+1. **RED:** write the semantic equivalence test in `tests/src/equivalence/<area>.rs`
+   using `assert_output_equivalent(ts_code)` (or `_with_timeout` for state/mutex
+   paths). The TS snippet must be valid TypeScript. Run it and PASTE the observed
+   failure — if it doesn't fail, the test is wrong or the feature already works.
+2. **GREEN:** implement in `crates/tyrus_codegen` under the codegen rules (quote!-only,
+   registry for name-keyed logic, no panics, ≤ 50-line functions). Dispatch
+   `tyrus-codegen` for the implementation when delegating.
+3. Run the test until green, then the full suite (`cargo nextest run --workspace`)
+   and `cargo clippy --workspace --all-targets --locked`.
+4. If snapshots changed: `cargo insta review`, accept intentional diffs, commit the
+   `.snap` in the same change.
+5. Done = observed equivalence (F6), never "the tokens look right".
+
+$ARGUMENTS: the TS construct to support/fix (e.g. "Array.prototype.flat", "getters em interfaces").

--- a/.gitignore
+++ b/.gitignore
@@ -27,12 +27,15 @@ node_modules/
 target/
 **/*.rs.bk
 
+# Claude Code: session-private state stays ignored; the versioned harness
+# (settings.json, hooks/, rules/, agents/, skills/) is tracked.
+.claude/plan/
+.claude/worktrees/
+.claude/checkpoints.log
+.claude/settings.local.json
+.claude/CLAUDE.local.md
 
 # Agent configuration (local only)
-# .agent.claude/worktrees/
-
-# Assistant scratch — local planning + settings, never committed
-.claude/
 .agent/
 
 # Documentation scratch (assistant-only; not project source-of-truth)


### PR DESCRIPTION
## Summary
The standardization campaign delivered the *documents* (POWER_OF_TEN v2, DEVELOPMENT_FLOW); this delivers the **Claude Code layer that enforces them at edit time**, versioned in the repo per the official harness conventions:

| Camada | Conteúdo |
|---|---|
| `settings.json` | permissions do projeto + hooks determinísticos (PreToolUse) |
| `hooks/` | `rust-guard.sh` (bloqueia R6 panics e R7 string-Rust em `convert/` ANTES do clippy) e `commit-msg-guard.sh` (Conventional Commits + anti-vago, R11/F1) — ambos verificados nos dois sentidos |
| `rules/` (5) | frontmatter `paths:` — carregam sob demanda por crate: rust-core, codegen, analyzer, testing, orchestrator |
| `agents/` (4) | `tyrus-codegen`, `tyrus-tester`, `tyrus-reviewer` (xhigh read-only, camada F5), `tyrus-docs` — cada um com o bloco de constraints F8 restated |
| `skills/` (5) | `/gates`, `/pre-pr`, `/tdd-codegen`, `/new-decorator`, `/doc-sync` |

`.gitignore` reformulado: harness versionado; `plan/`, `worktrees/`, `checkpoints.log`, `settings.local.json` continuam privados.

Fase F2 do plano mestre. Closes #231

## Test plan
- [x] Hooks testados nos dois sentidos (violação R6 → exit 2; código limpo → 0; módulo de teste → 0; violação R7 → 2; commit vago → 2; commit válido → 0)
- [x] Skill `/gates` registrada e reconhecida pelo harness na própria sessão
- [x] Diff é config/docs-only — nenhum código Rust tocado; árvore = main gates-green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQnQN7MkJEqWy75YZH7dNJ